### PR TITLE
Fix audio send as waveform

### DIFF
--- a/MODELO1/BOT/bot.js
+++ b/MODELO1/BOT/bot.js
@@ -233,7 +233,15 @@ async function enviarMidiaComFallback(chatId, tipoMidia, caminhoMidia, opcoes = 
         await bot.sendVideo(chatId, stream, opcoes);
         break;
       case 'audio':
-        await bot.sendAudio(chatId, stream, opcoes);
+        await bot.sendAudio(
+          chatId,
+          stream,
+          opcoes,
+          {
+            filename: path.basename(caminhoAbsoluto),
+            contentType: 'audio/mpeg'
+          }
+        );
         break;
       default:
         console.warn(`⚠️ Tipo de mídia não suportado: ${tipoMidia}`);


### PR DESCRIPTION
## Summary
- ensure audio is sent as player not document

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68682ec63be8832a958a704a5252eb1b