### PR TITLE
Add hourly cleanup for downsell_progress

### DIFF
--- a/MODELO1/BOT/bot.js
+++ b/MODELO1/BOT/bot.js
@@ -10,6 +10,12 @@ const postgres = require('../../postgres.js');
 // Reutilizar o pool global do módulo postgres
 const pgPool = postgres.createPool();
 
+// Iniciar limpeza automática de downsells a cada hora
+if (pgPool) {
+  postgres.limparDownsellsAntigos(pgPool); // executar imediatamente
+  setInterval(() => postgres.limparDownsellsAntigos(pgPool), 60 * 60 * 1000);
+}
+
 
 // Importar gerenciador de mídias
 const GerenciadorMidia = require('./utils/midia');


### PR DESCRIPTION
## Summary
- create downsell_progress table in PostgreSQL setup
- add function `limparDownsellsAntigos` to remove unpaid records older than 72h
- verify downsell_progress table on startup
- schedule automatic cleanup in `bot.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868db9f32c0832a9b9ad69d46e33f86