### PR TITLE
Add root health route and improve downsell logs

### DIFF
--- a/MODELO1/BOT/bot.js
+++ b/MODELO1/BOT/bot.js
@@ -592,19 +592,21 @@ console.log('✅ Bot configurado e rodando');
 // Função para enviar downsells automaticamente
 async function enviarDownsells() {
   try {
-    console.log('🔄 Executando envio de downsells...');
-    
+    console.log('🟢 Iniciando processo de downsells...');
+
     // Buscar todos os usuários que ainda não pagaram no PostgreSQL
     const usuariosRes = await postgres.executeQuery(
       pgPool,
       'SELECT telegram_id, index_downsell FROM downsell_progress WHERE pagou = 0'
     );
     const usuarios = usuariosRes.rows;
-    
+
+    console.log('📂 Conteúdo da tabela downsell_progress:', usuarios);
     console.log(`📊 Encontrados ${usuarios.length} usuários para processar`);
-    
+
     for (const usuario of usuarios) {
       const { telegram_id, index_downsell } = usuario;
+      console.log(`🔎 Verificando usuário ${telegram_id}`);
       
       // Verificar se ainda há downsells para enviar
       if (index_downsell >= config.downsells.length) {
@@ -644,6 +646,7 @@ async function enviarDownsells() {
           parse_mode: 'HTML',
           reply_markup: replyMarkup
         });
+        console.log(`📨 Mensagem enviada para ${telegram_id}`);
         
         // Atualizar índice do downsell no PostgreSQL
         try {
@@ -762,19 +765,19 @@ if (bot) {
   });
 }
 
-// Configurar execução automática dos downsells a cada 10 minutos
+// Configurar execução automática dos downsells a cada 5 minutos (apenas para testes)
 if (bot) {
-  console.log('⏰ Configurando envio automático de downsells (10 minutos)...');
-  
-  // Executar pela primeira vez após 10 minutos da inicialização
+  console.log('⏰ Configurando envio automático de downsells (5 minutos)...');
+
+  // Executar pela primeira vez após 5 minutos da inicialização
   setTimeout(() => {
     enviarDownsells();
-  }, 600000);
-  
-  // Configurar intervalo de 10 minutos (600000 ms)
+  }, 300000);
+
+  // Configurar intervalo de 5 minutos (300000 ms)
   setInterval(() => {
     enviarDownsells();
-  }, 600000);
+  }, 300000);
   
   console.log('✅ Sistema de downsells automático ativado!');
 }
@@ -787,3 +790,4 @@ module.exports = {
   gerenciadorMidia,
   enviarDownsells
 };
+

--- a/server.js
+++ b/server.js
@@ -246,9 +246,15 @@ app.post('/api/gerar-cobranca', async (req, res) => {
 });
 
 // Rotas principais
+// Rota raiz simplificada para health checks
 app.get('/', (req, res) => {
+  res.status(200).send('OK');
+});
+
+// Rota de informações completa (mantida para compatibilidade)
+app.get('/info', (req, res) => {
   const indexPath = path.join(__dirname, 'MODELO1/WEB/index.html');
-  
+
   if (fs.existsSync(indexPath)) {
     res.sendFile(indexPath);
   } else {


### PR DESCRIPTION
## Summary
- simplify `/` route to always respond `OK`
- move previous root info route to `/info`
- add detailed logging for downsell progress
- shorten downsell sending interval to 5 minutes for testing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868ecf1b5a4832aa2d83d224f0bfe9e