### PR TITLE
Fix downsell duplication and interval

### DIFF
--- a/postgres.js
+++ b/postgres.js
@@ -174,6 +174,12 @@ async function createTables(pool) {
       )
     `);
 
+    // Garantir coluna last_sent_at para controle de envio individual
+    await client.query(`
+      ALTER TABLE downsell_progress
+      ADD COLUMN IF NOT EXISTS last_sent_at TIMESTAMP NULL
+    `);
+
     await client.query(`
       CREATE INDEX IF NOT EXISTS idx_downsell_pagou ON downsell_progress(pagou);
       CREATE INDEX IF NOT EXISTS idx_downsell_criado_em ON downsell_progress(criado_em);


### PR DESCRIPTION
## Summary
- ensure `downsell_progress` has a `last_sent_at` column
- block concurrent downsell cycles
- respect a 5 minute delay per user
- log timestamp of each downsell
- reset and insert records with `last_sent_at`

## Testing
- `npm test` *(fails: cannot connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_6868f5aa9828832ab6932fe1e7c45c24