### PR TITLE
Remove downsell mutex

### DIFF
--- a/MODELO1/BOT/bot.js
+++ b/MODELO1/BOT/bot.js
@@ -587,17 +587,8 @@ if (bot) {
 
 console.log('✅ Bot configurado e rodando');
 
-// Flag para evitar execuções simultâneas do ciclo de downsells
-let processingDownsells = false;
-
 // Função para enviar downsells automaticamente
 async function enviarDownsells() {
-  if (processingDownsells) {
-    console.log('⏳ Ciclo de downsells já em execução. Pulando...');
-    return;
-  }
-
-  processingDownsells = true;
   try {
     console.log('🟢 Iniciando processo de downsells...');
 
@@ -693,7 +684,7 @@ async function enviarDownsells() {
   } catch (error) {
     console.error('❌ Erro geral na função enviarDownsells:', error.message);
   } finally {
-    processingDownsells = false;
+    // Nenhum controle adicional necessário após a conclusão
   }
 }
 


### PR DESCRIPTION
## Summary
- drop the `processingDownsells` flag
- allow `enviarDownsells()` to run concurrently and keep setInterval scheduling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869034ccbf0832ab67a1865d4364a07