### PR TITLE
Improve server.js error handling and Render config

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,9 +2,10 @@ services:
   - type: web
     name: sitehot
     env: node
-    plan: free
+    plan: starter  # plano pago
     buildCommand: |
       npm install
       npm run build
     startCommand: npm start
     healthCheckPath: /health-basic
+    healthCheckTimeoutSeconds: 120

--- a/server.js
+++ b/server.js
@@ -1,6 +1,14 @@
 // server.js - Arquivo de entrada único para o Render
 require('dotenv').config();
 
+process.on('uncaughtException', (err) => {
+  console.error('❌ Erro não capturado:', err);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('❌ Rejeição de Promise não tratada:', reason);
+});
+
 console.log('🚀 Iniciando servidor SiteHot...');
 
 const fs = require('fs');
@@ -442,15 +450,6 @@ process.on('SIGINT', () => {
     console.log('✅ Servidor fechado');
     process.exit(0);
   });
-});
-
-// Tratamento de erros
-process.on('uncaughtException', (error) => {
-  console.error('❌ Erro não capturado:', error.message);
-});
-
-process.on('unhandledRejection', (reason) => {
-  console.error('❌ Promise rejeitada:', reason);
 });
 
 console.log('✅ Servidor configurado e pronto');


### PR DESCRIPTION
## Summary
- register uncaught exception and unhandled rejection handlers at the start of `server.js`
- remove duplicate error handlers from the end of `server.js`
- configure Render for the paid starter plan and extend health check timeout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686921b761c0832ab54c6c66c85f29bd