### PR TITLE
Improve downsell logging and add heartbeat

### DIFF
--- a/MODELO1/BOT/bot.js
+++ b/MODELO1/BOT/bot.js
@@ -719,8 +719,8 @@ async function enviarDownsell(chatId) {
     const idx = progresso.index_downsell;
     const lista = config.downsells;
 
+    // Se o usuário já recebeu todos os downsells, apenas sair
     if (idx >= lista.length) {
-      console.log('✅ Ciclo de downsells concluído');
       return;
     }
 
@@ -762,7 +762,7 @@ async function enviarDownsell(chatId) {
         );
       }, 5 * 60 * 1000);
     } else {
-      console.log('✅ Ciclo de downsells concluído');
+      console.log(`✅ Ciclo de downsells concluído para ${chatId}`);
     }
   } catch (error) {
     console.error('❌ Erro na função enviarDownsell:', error.message);

--- a/server.js
+++ b/server.js
@@ -19,6 +19,12 @@ const helmet = require('helmet');
 const compression = require('compression');
 const rateLimit = require('express-rate-limit');
 
+// Heartbeat para indicar que o bot está ativo
+setInterval(() => {
+  const horario = new Date().toLocaleTimeString('pt-BR', { hour12: false });
+  console.log(`⏱ Uptime OK — ${horario}`);
+}, 15 * 60 * 1000);
+
 
 // Verificar variáveis de ambiente
 const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;


### PR DESCRIPTION
## Summary
- log downsell completion only once per user
- add uptime heartbeat message in server

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68692f9ae544832a86f626fce4ab78be