### PR TITLE
Fix downsell log trigger and add 5‑min heartbeat

### DIFF
--- a/MODELO1/BOT/bot.js
+++ b/MODELO1/BOT/bot.js
@@ -697,7 +697,6 @@ async function enviarDownsells(targetId = null) {
       }
     }
     
-    console.log('✅ Ciclo de downsells concluído');
 
   } catch (error) {
     console.error('❌ Erro geral na função enviarDownsells:', error.message);

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ const rateLimit = require('express-rate-limit');
 setInterval(() => {
   const horario = new Date().toLocaleTimeString('pt-BR', { hour12: false });
   console.log(`⏱ Uptime OK — ${horario}`);
-}, 15 * 60 * 1000);
+}, 5 * 60 * 1000);
 
 
 // Verificar variáveis de ambiente


### PR DESCRIPTION
## Summary
- avoid announcing downsell cycle prematurely
- ping uptime every 5 minutes

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686930ec2428832ab9c969d2d1803a8c