### PR TITLE
Fix Render health check rate limit

### DIFF
--- a/server.js
+++ b/server.js
@@ -58,7 +58,7 @@ const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 100,
   skip: (req) => {
-    const ignorar = req.path === '/health';
+    const ignorar = req.path === '/health' || req.path === '/health-basic';
     if (ignorar) console.log('⏩ Ignorando rate-limit para', req.path);
     return ignorar;
   }


### PR DESCRIPTION
## Summary
- avoid rate limiting on `/health-basic` used by Render

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68693a51a648832a9c8ba9e6d2fe4355