### PR TITLE
Fix downsell callbacks and reduce log noise

### DIFF
--- a/MODELO1/BOT/bot.js
+++ b/MODELO1/BOT/bot.js
@@ -531,9 +531,30 @@ if (bot) {
         return;
       }
 
-      // Processar compra de plano
-      const plano = config.planos.find(p => p.id === data);
+      // Processar compra de plano principal ou downsell
+      let plano = config.planos.find(p => p.id === data);
+
+      if (!plano) {
+        for (const ds of config.downsells) {
+          const p = ds.planos.find(pl => pl.id === data);
+          if (p) {
+            plano = { ...p };
+            plano.valor = p.valorComDesconto;
+            console.log(`📦 Geração de cobrança para plano ${p.nome} (R$${p.valorComDesconto})`);
+            break;
+          }
+        }
+      }
+
+      if (!plano) {
+        console.log(`⚠️ Plano não encontrado para callback: ${data}`);
+      }
+
       if (plano) {
+        if (!plano.valor && plano.valorComDesconto) {
+          plano.valor = plano.valorComDesconto;
+        }
+
         const resposta = await axios.post(`${BASE_URL}/api/gerar-cobranca`, {
           telegram_id: chatId,
           plano: plano.nome,

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const cors = require('cors');
 const helmet = require('helmet');
 const compression = require('compression');
 const rateLimit = require('express-rate-limit');
+let lastRateLimitLog = 0;
 
 // Heartbeat para indicar que o bot está ativo
 setInterval(() => {
@@ -59,7 +60,13 @@ const limiter = rateLimit({
   max: 100,
   skip: (req) => {
     const ignorar = req.path === '/health' || req.path === '/health-basic';
-    if (ignorar) console.log('⏩ Ignorando rate-limit para', req.path);
+    if (ignorar) {
+      const agora = Date.now();
+      if (agora - lastRateLimitLog > 60 * 60 * 1000) {
+        console.log('⏩ Ignorando rate-limit para', req.path);
+        lastRateLimitLog = agora;
+      }
+    }
     return ignorar;
   }
 });


### PR DESCRIPTION
## Summary
- trigger charge generation for downsell buttons
- log when a downsell plan is not found
- limit rate-limit skip logging to once per hour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686945e3b9fc832a88eec98e0082864d