### PR TITLE
Adjust token validation on obrigado page

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -224,7 +224,7 @@
           return;
         }
 
-        if (dados.sucesso) {
+        if (dados.status === 'valido') {
           console.log('✅ Token válido, acesso liberado');
           dispararEventoCompra(dados.valor || valor);
           // Aguarda 2 segundos antes de mostrar sucesso

--- a/server.js
+++ b/server.js
@@ -140,6 +140,11 @@ app.get('/api/verificar-token', async (req, res) => {
       return res.json({ status: 'invalido' });
     }
 
+    await databasePool.query(
+      'UPDATE tokens SET usado = TRUE, data_uso = CURRENT_TIMESTAMP WHERE token = $1',
+      [token]
+    );
+
     return res.json({ status: 'valido' });
   } catch (e) {
     console.error('Erro ao verificar token (GET):', e);


### PR DESCRIPTION
## Summary
- update frontend token validation logic to check `dados.status === 'valido'`
- mark token as used in `/api/verificar-token` GET endpoint once validated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686963bb2254832a93f4f8f87cd651c4