### PR TITLE
Expose env vars to frontend

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -6,20 +6,7 @@
   <title id="dynamic-title">Carregando...</title>
   <meta name="robots" content="noindex, nofollow" />
 
-  <!-- Facebook Pixel -->
-  <script>
-    !function(f,b,e,v,n,t,s){
-      if(f.fbq)return;n=f.fbq=function(){
-        n.callMethod ? n.callMethod.apply(n,arguments) : n.queue.push(arguments)};
-      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-      n.queue=[];t=b.createElement(e);t.async=!0;
-      t.src=v;s=b.getElementsByTagName(e)[0];
-      s.parentNode.insertBefore(t,s)
-    }(window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js');
-
-    fbq('init', '1584917512465705');
-    fbq('track', 'PageView');
-  </script>
+  <script src="env.js"></script>
 
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>
@@ -41,7 +28,10 @@
 
     const cta = document.getElementById("cta");
     cta.innerText = window.config.buttonText;
-    cta.href = window.config.redirectLink;
+    const params = new URLSearchParams(window.location.search);
+    const rKey = params.get('redirect') || 'redirect1';
+    const redirectLink = (window.envVars && window.envVars.redirects && window.envVars.redirects[rKey]) || window.config.redirectLink;
+    cta.href = redirectLink;
 
     // Evento de clique com redirecionamento direto
     cta.addEventListener("click", function () {

--- a/MODELO1/WEB/env.js
+++ b/MODELO1/WEB/env.js
@@ -1,0 +1,29 @@
+(function(){
+  async function loadEnv(){
+    try {
+      const res = await fetch('/api/env');
+      const data = await res.json();
+      window.envVars = data;
+      if(data.pixelId){
+        !function(f,b,e,v,n,t,s){
+          if(f.fbq)return;n=f.fbq=function(){
+            n.callMethod ? n.callMethod.apply(n,arguments) : n.queue.push(arguments);
+          };
+          if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+          n.queue=[];t=b.createElement(e);t.async=!0;
+          t.src=v;s=b.getElementsByTagName(e)[0];
+          s.parentNode.insertBefore(t,s);
+        }(window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js');
+        fbq('init', data.pixelId);
+        fbq('track', 'PageView');
+      }
+    } catch(err){
+      console.error('Erro ao carregar vari\u00e1veis de ambiente', err);
+    }
+  }
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', loadEnv);
+  } else {
+    loadEnv();
+  }
+})();

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -7,20 +7,8 @@
   <title id="dynamic-title">Carregando...</title>
   <meta name="robots" content="noindex, nofollow" />
 
-  <!-- Facebook Pixel -->
-  <script>
-    !function(f,b,e,v,n,t,s){
-      if(f.fbq)return;n=f.fbq=function(){
-        n.callMethod ? n.callMethod.apply(n,arguments) : n.queue.push(arguments)};
-      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-      n.queue=[];t=b.createElement(e);t.async=!0;
-      t.src=v;s=b.getElementsByTagName(e)[0];
-      s.parentNode.insertBefore(t,s)
-    }(window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js');
 
-    fbq('init', '1584917512465705');
-    fbq('track', 'PageView');
-  </script>
+  <script src="env.js"></script>
 
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>
@@ -41,7 +29,10 @@
 
     const cta = document.getElementById("cta");
     cta.innerText = window.config.buttonText;
-    cta.href = window.config.redirectLink;
+    const params = new URLSearchParams(window.location.search);
+    const rKey = params.get('redirect') || 'redirect1';
+    const redirectLink = (window.envVars && window.envVars.redirects && window.envVars.redirects[rKey]) || window.config.redirectLink;
+    cta.href = redirectLink;
 
     // Evento de clique com redirecionamento direto
     cta.addEventListener("click", function () {

--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -93,7 +93,7 @@
       <div class="checkmark">✅</div>
       <p><strong>Acesso liberado com sucesso!</strong></p>
       <p>Você será redirecionado automaticamente para o canal VIP.</p>
-      <a href="https://t.me/+0iLdVzcJsq9kOWQ5" class="botao">Ou clique aqui para entrar agora</a>
+      <a id="redirect-link" href="#" class="botao">Ou clique aqui para entrar agora</a>
       <div id="contador" class="contador"></div>
     </div>
     
@@ -103,23 +103,23 @@
     </div>
   </div>
 
-  <!-- Facebook Pixel -->
-  <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){
-      n.callMethod ? n.callMethod.apply(n,arguments) : n.queue.push(arguments)};
-      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-      n.queue=[];t=b.createElement(e);t.async=!0;
-      t.src=v;s=b.getElementsByTagName(e)[0];
-      s.parentNode.insertBefore(t,s)
-    }(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '1584917512465705');
-    fbq('track', 'PageView');
-  </script>
+  <script src="env.js"></script>
 
   <script>
     console.log('=== PÁGINA OBRIGADO CARREGADA ===');
     console.log('URL:', window.location.href);
-    console.log('Parâmetros:', window.location.search);
+  console.log('Parâmetros:', window.location.search);
+
+    const params = new URLSearchParams(window.location.search);
+    const rKey = params.get('redirect') || 'redirect1';
+    function getRedirectUrl() {
+      if (window.envVars && window.envVars.redirects && window.envVars.redirects[rKey]) {
+        return window.envVars.redirects[rKey];
+      }
+      return '#';
+    }
+    const linkEl = document.getElementById('redirect-link');
+    if (linkEl) linkEl.href = getRedirectUrl();
 
     // Função para mostrar conteúdo de sucesso
     function mostrarSucesso() {
@@ -130,14 +130,14 @@
       let contador = 5;
       const contadorEl = document.getElementById('contador');
       
-      function atualizarContador() {
-        contadorEl.innerHTML = `<strong>Redirecionando em ${contador} segundos...</strong>`;
-        
-        if (contador <= 0) {
-          contadorEl.innerHTML = '<strong>Redirecionando...</strong>';
-          window.location.href = 'https://t.me/+0iLdVzcJsq9kOWQ5';
-          return;
-        }
+        function atualizarContador() {
+          contadorEl.innerHTML = `<strong>Redirecionando em ${contador} segundos...</strong>`;
+
+          if (contador <= 0) {
+            contadorEl.innerHTML = '<strong>Redirecionando...</strong>';
+            window.location.href = getRedirectUrl();
+            return;
+          }
         
         contador--;
         setTimeout(atualizarContador, 1000);

--- a/server.js
+++ b/server.js
@@ -152,6 +152,19 @@ app.get('/api/verificar-token', async (req, res) => {
   }
 });
 
+// Endpoint para expor variáveis de ambiente necessárias no frontend
+app.get('/api/env', (req, res) => {
+  const pixelId = process.env.FB_PIXEL_ID || process.env.PIXEL_ID || null;
+  const redirects = Object.keys(process.env)
+    .filter(key => key.startsWith('REDIRECT'))
+    .reduce((acc, key) => {
+      acc[key.toLowerCase()] = process.env[key];
+      return acc;
+    }, {});
+
+  res.json({ pixelId, redirects });
+});
+
 
 // Servir arquivos estáticos
 const publicPath = path.join(__dirname, 'public');


### PR DESCRIPTION
## Summary
- add API route `/api/env` to server
- load FB Pixel and redirect URLs dynamically via new `env.js`
- update HTML pages to consume env vars

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ce564095c832aa28511227e8d574d