### PR TITLE
Implement env-based profiles

### DIFF
--- a/MODELO1/BOT/bot.js
+++ b/MODELO1/BOT/bot.js
@@ -29,10 +29,13 @@ try {
   sharp = null;
 }
 
-const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;
+const { getPerfilVar } = require('../../perfil');
+
+const TELEGRAM_TOKEN = getPerfilVar('TELEGRAM_TOKEN');
 const PUSHINPAY_TOKEN = process.env.PUSHINPAY_TOKEN;
 const BASE_URL = process.env.BASE_URL;
 const FRONTEND_URL = process.env.FRONTEND_URL || BASE_URL;
+const REDIRECT_KEY = getPerfilVar('REDIRECT_KEY', 'redirect1');
 
 // Mapa para controle de processamento de downsells
 const processingDownsells = new Map();
@@ -407,7 +410,7 @@ const webhookPushinPay = async (req, res) => {
 
     if (row.telegram_id && bot) {
       const valorReais = (row.valor / 100).toFixed(2);
-      const linkComToken = `${FRONTEND_URL}/obrigado.html?token=${novoToken}&valor=${valorReais}`;
+      const linkComToken = `${FRONTEND_URL}/obrigado.html?token=${novoToken}&valor=${valorReais}&redirect=${REDIRECT_KEY}`;
       
       await bot.sendMessage(row.telegram_id, 
         `🎉 <b>Pagamento aprovado!</b>\n\n💰 Valor: R$ ${valorReais}\n🔗 Acesse seu conteúdo: ${linkComToken}`, 
@@ -538,7 +541,7 @@ if (bot) {
         }
 
         const valorReais = (tokenRow.valor / 100).toFixed(2);
-        const linkComToken = `${FRONTEND_URL}/obrigado.html?token=${tokenRow.token_uuid}&valor=${valorReais}`;
+        const linkComToken = `${FRONTEND_URL}/obrigado.html?token=${tokenRow.token_uuid}&valor=${valorReais}&redirect=${REDIRECT_KEY}`;
         
         await bot.sendMessage(chatId, config.pagamento.aprovado);
         await bot.sendMessage(chatId, `<b>🎉 Pagamento aprovado!</b>\n\n🔗 Acesse: ${linkComToken}`, {

--- a/MODELO1/WEB/tokens.js
+++ b/MODELO1/WEB/tokens.js
@@ -1,3 +1,5 @@
+const { getPerfilVar } = require('../../perfil');
+
 module.exports = (app, databasePool) => {
   const path = require('path');
   const cors = require('cors');
@@ -101,6 +103,8 @@ module.exports = (app, databasePool) => {
 
   // ====== CRIAR ROUTER ======
   const router = express.Router();
+
+  const redirectKey = getPerfilVar('REDIRECT_KEY', 'redirect1');
   
   // Middlewares
   router.use(helmet());
@@ -176,10 +180,10 @@ module.exports = (app, databasePool) => {
         valor
       });
       
-      res.json({ 
-        sucesso: true, 
+      res.json({
+        sucesso: true,
         token: token,
-        url: `${baseUrl}/obrigado.html?token=${token}&valor=${valor}`,
+        url: `${baseUrl}/obrigado.html?token=${token}&valor=${valor}&redirect=${redirectKey}`,
         valor: parseFloat(valor)
       });
       

--- a/perfil.js
+++ b/perfil.js
@@ -1,0 +1,10 @@
+function getPerfil() {
+  return process.env.MEU_PERFIL || '1';
+}
+
+function getPerfilVar(nome, padrao = undefined) {
+  const perfil = getPerfil();
+  return process.env[`${nome}_${perfil}`] || process.env[nome] || padrao;
+}
+
+module.exports = { getPerfil, getPerfilVar };

--- a/server.js
+++ b/server.js
@@ -1,6 +1,11 @@
 // server.js - Arquivo de entrada único para o Render
 require('dotenv').config();
 
+const { getPerfilVar } = require('./perfil');
+
+// Mensagens/configurações (padrão compartilhado)
+const botConfig = require('./MODELO1/BOT/config');
+
 process.on('uncaughtException', (err) => {
   console.error('❌ Erro não capturado:', err);
 });
@@ -19,7 +24,6 @@ const helmet = require('helmet');
 const compression = require('compression');
 const cron = require('node-cron');
 const rateLimit = require('express-rate-limit');
-const botConfig = require('./MODELO1/BOT/config');
 let lastRateLimitLog = 0;
 
 // Heartbeat para indicar que o bot está ativo
@@ -29,8 +33,9 @@ setInterval(() => {
 }, 5 * 60 * 1000);
 
 
-// Verificar variáveis de ambiente
-const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;
+// Verificar variáveis de ambiente por perfil
+const TELEGRAM_TOKEN = getPerfilVar('TELEGRAM_TOKEN');
+const REDIRECT_KEY = getPerfilVar('REDIRECT_KEY', 'redirect1');
 const BASE_URL = process.env.BASE_URL;
 const PORT = process.env.PORT || 3000;
 
@@ -284,7 +289,7 @@ async function carregarSistemaTokens() {
     delete require.cache[require.resolve('./MODELO1/WEB/tokens')];
     
     const tokensModule = require('./MODELO1/WEB/tokens');
-    
+
     if (typeof tokensModule === 'function') {
       const tokenSystem = tokensModule(app, databasePool);
       


### PR DESCRIPTION
## Summary
- add helper for selecting variables by profile
- refactor bot and token modules to read TELEGRAM_TOKEN and REDIRECT_KEY using MEU_PERFIL
- update server to use env-based profile config
- remove unused profile files

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cf533179c832abf5865120bdac35d