### PR TITLE
Enable multi-profile bots

### DIFF
--- a/MODELO1/perfil1/bot.js
+++ b/MODELO1/perfil1/bot.js
@@ -1,0 +1,971 @@
+require('dotenv').config();
+const MEU_PERFIL = '1';
+process.env.MEU_PERFIL = MEU_PERFIL;
+const TelegramBot = require('node-telegram-bot-api');
+const axios = require('axios');
+const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const postgres = require('../../postgres.js');
+
+// Reutilizar o pool global do módulo postgres
+const pgPool = postgres.createPool();
+
+// Iniciar limpeza automática de downsells a cada hora
+if (pgPool) {
+  postgres.limparDownsellsAntigos(pgPool); // executar imediatamente
+  setInterval(() => postgres.limparDownsellsAntigos(pgPool), 60 * 60 * 1000);
+}
+
+
+// Importar gerenciador de mídias
+const GerenciadorMidia = require('./utils/midia');
+
+// Só importar sharp se necessário e tratar erros
+let sharp;
+try {
+  sharp = require('sharp');
+} catch (error) {
+  console.warn('⚠️ Sharp não disponível, usando fallback para imagens');
+  sharp = null;
+}
+
+const { getPerfilVar } = require('../../perfil');
+
+const TELEGRAM_TOKEN = getPerfilVar('TELEGRAM_TOKEN');
+const PUSHINPAY_TOKEN = process.env.PUSHINPAY_TOKEN;
+const BASE_URL = process.env.BASE_URL;
+const FRONTEND_URL = process.env.FRONTEND_URL || BASE_URL;
+const REDIRECT_KEY = getPerfilVar('REDIRECT_KEY', 'redirect1');
+
+// Mapa para controle de processamento de downsells
+const processingDownsells = new Map();
+
+// Utilitário para normalizar telegram_id para bigint
+function normalizeTelegramId(id) {
+  if (id === null || id === undefined) return null;
+  const parsed = parseInt(id.toString(), 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+// Verificar variáveis essenciais
+if (!TELEGRAM_TOKEN) {
+  console.error('❌ TELEGRAM_TOKEN não definido!');
+}
+
+if (!PUSHINPAY_TOKEN) {
+  console.error('❌ PUSHINPAY_TOKEN não definido!');
+}
+
+if (!BASE_URL) {
+  console.error('❌ BASE_URL não definido!');
+}
+
+// Inicializar gerenciador de mídias
+const gerenciadorMidia = new GerenciadorMidia();
+
+// Verificar integridade das mídias na inicialização
+console.log('\n🔍 Verificando integridade das mídias...');
+const integridade = gerenciadorMidia.verificarIntegridade();
+console.log(`✅ Sistema de mídias inicializado (${integridade.porcentagem}% das mídias disponíveis)\n`);
+
+// Inicializar bot com tratamento de erro
+let bot;
+try {
+  // Não usar polling no OnRender, apenas webhook
+  bot = new TelegramBot(TELEGRAM_TOKEN, { polling: false });
+  
+  // Configurar webhook
+  if (BASE_URL) {
+    const webhookUrl = `${BASE_URL}/bot${TELEGRAM_TOKEN}`;
+    bot.setWebHook(webhookUrl).then(() => {
+      console.log('✅ Webhook configurado:', webhookUrl);
+    }).catch(err => {
+      console.error('❌ Erro ao configurar webhook:', err);
+    });
+  }
+} catch (error) {
+  console.error('❌ Erro ao inicializar bot:', error);
+  bot = null;
+}
+
+// Configurar banco de dados com tratamento de erro
+let db;
+try {
+  db = new Database('./pagamentos.db');
+  
+  // Criar tabelas
+  // A tabela downsell_progress agora é mantida apenas no PostgreSQL
+  // db.prepare(`
+  //   CREATE TABLE IF NOT EXISTS downsell_progress (
+  //     telegram_id TEXT PRIMARY KEY,
+  //     index_downsell INTEGER,
+  //     pagou INTEGER DEFAULT 0
+  //   )
+  // `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS tokens (
+      token TEXT PRIMARY KEY,
+      telegram_id TEXT,
+      valor INTEGER,
+      utm_source TEXT,
+      utm_campaign TEXT,
+      utm_medium TEXT,
+      status TEXT DEFAULT 'pendente',
+      token_uuid TEXT,
+      criado_em DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `).run();
+
+  // Verificar e adicionar colunas
+  const colunas = db.prepare("PRAGMA table_info(tokens)").all();
+  const temColunaTokenUuid = colunas.some(col => col.name === 'token_uuid');
+  
+  if (!temColunaTokenUuid) {
+    db.prepare("ALTER TABLE tokens ADD COLUMN token_uuid TEXT").run();
+  }
+
+  // Colunas da tabela downsell_progress são gerenciadas no PostgreSQL
+  // const colunasDownsell = db.prepare("PRAGMA table_info(downsell_progress)").all();
+  // const temColunaPagou = colunasDownsell.some(col => col.name === 'pagou');
+
+  // if (!temColunaPagou) {
+  //   db.prepare("ALTER TABLE downsell_progress ADD COLUMN pagou INTEGER DEFAULT 0").run();
+  // }
+
+  console.log('✅ Banco de dados configurado');
+} catch (error) {
+  console.error('❌ Erro ao configurar banco:', error);
+  db = null;
+}
+
+// Importar config com tratamento de erro
+let config;
+try {
+  config = require('./config');
+} catch (error) {
+  console.error('❌ Erro ao carregar config:', error);
+  // Usar config padrão mínimo
+  config = {
+    formatarValorCentavos: (valor) => Math.round(parseFloat(valor) * 100),
+    inicio: {
+      tipoMidia: 'texto',
+      textoInicial: 'Olá! Bem-vindo ao bot.',
+      menuInicial: {
+        texto: 'Escolha uma opção:',
+        opcoes: [
+          { texto: 'Ver Planos', callback: 'mostrar_planos' },
+          { texto: 'Prévias', callback: 'ver_previas' }
+        ]
+      }
+    },
+    planos: [
+      { id: 'plano1', nome: 'Plano Básico', emoji: '💎', valor: 10.00 }
+    ],
+    downsells: [],
+    canalPrevias: '@seucanal',
+    pagamento: {
+      pendente: '⏳ Pagamento pendente. Verifique novamente.',
+      aprovado: '✅ Pagamento aprovado!'
+    },
+    mensagemPix: (nome, valor, pixCopia) => `
+💎 <b>${nome}</b>
+💰 Valor: R$ ${valor.toFixed(2)}
+
+📋 <b>PIX Copia e Cola:</b>
+<code>${pixCopia}</code>
+
+⏰ <b>Importante:</b> Após o pagamento, clique em "Verificar Status" para liberar o acesso.
+    `
+  };
+}
+
+// Função para processar imagem com fallback
+async function processarImagem(imageBuffer) {
+  if (!sharp) {
+    return imageBuffer;
+  }
+  
+  try {
+    return await sharp(imageBuffer)
+      .extend({ 
+        top: 40, 
+        bottom: 40, 
+        left: 40, 
+        right: 40, 
+        background: { r: 255, g: 255, b: 255, alpha: 1 } 
+      })
+      .png()
+      .toBuffer();
+  } catch (error) {
+    console.warn('⚠️ Erro ao processar imagem, usando original:', error.message);
+    return imageBuffer;
+  }
+}
+
+// Função para enviar mídia com fallback
+async function enviarMidiaComFallback(chatId, tipoMidia, caminhoMidia, opcoes = {}) {
+  if (!caminhoMidia) {
+    console.warn('⚠️ Caminho de mídia não fornecido');
+    return false;
+  }
+
+  try {
+    console.log(`📤 Tentando enviar ${tipoMidia}: ${caminhoMidia}`);
+
+    // Se for URL, enviar diretamente
+    if (caminhoMidia.startsWith('http')) {
+      switch (tipoMidia) {
+        case 'photo':
+          await bot.sendPhoto(chatId, caminhoMidia, opcoes);
+          break;
+        case 'video':
+          await bot.sendVideo(chatId, caminhoMidia, opcoes);
+          break;
+        case 'audio':
+          await bot.sendVoice(chatId, caminhoMidia, opcoes);
+          break;
+        default:
+          console.warn(`⚠️ Tipo de mídia não suportado: ${tipoMidia}`);
+          return false;
+      }
+      return true;
+    }
+
+    // Se for arquivo local, verificar se existe
+    const caminhoAbsoluto = path.resolve(__dirname, caminhoMidia);
+    
+    if (!fs.existsSync(caminhoAbsoluto)) {
+      console.warn(`⚠️ Arquivo de mídia não encontrado: ${caminhoAbsoluto}`);
+      return false;
+    }
+
+    // Criar stream do arquivo
+    const stream = fs.createReadStream(caminhoAbsoluto);
+    
+    switch (tipoMidia) {
+      case 'photo':
+        await bot.sendPhoto(chatId, stream, opcoes);
+        break;
+      case 'video':
+        await bot.sendVideo(chatId, stream, opcoes);
+        break;
+      case 'audio':
+        await bot.sendVoice(chatId, stream, opcoes);
+        break;
+      default:
+        console.warn(`⚠️ Tipo de mídia não suportado: ${tipoMidia}`);
+        return false;
+    }
+
+    console.log(`✅ Mídia ${tipoMidia} enviada com sucesso`);
+    return true;
+
+  } catch (error) {
+    console.error(`❌ Erro ao enviar mídia ${tipoMidia}:`, error.message);
+    return false;
+  }
+}
+
+// Enviar múltiplas mídias na ordem: áudio → vídeo → foto
+async function enviarMidiasHierarquicamente(chatId, midias) {
+  if (!midias) return;
+
+  const ordem = ['audio', 'video', 'photo'];
+
+  for (const tipo of ordem) {
+    let caminho = null;
+    if (tipo === 'photo') {
+      caminho = midias.foto || midias.imagem;
+    } else {
+      caminho = midias[tipo];
+    }
+
+    if (!caminho) continue;
+
+    if (!caminho.startsWith('http')) {
+      const absPath = path.resolve(__dirname, caminho);
+      if (!fs.existsSync(absPath)) {
+        console.warn(`⚠️ Arquivo de mídia não encontrado: ${absPath}`);
+        continue;
+      }
+    }
+
+    await enviarMidiaComFallback(chatId, tipo, caminho);
+  }
+}
+
+// Função para gerar cobrança
+const gerarCobranca = async (req, res) => {
+  const { plano, valor, utm_source, utm_campaign, utm_medium, telegram_id } = req.body;
+    
+  if (!plano || !valor) {
+    return res.status(400).json({ error: 'Parâmetros inválidos: plano e valor são obrigatórios.' });
+  }
+
+  const valorCentavos = config.formatarValorCentavos(valor);
+  if (isNaN(valorCentavos) || valorCentavos < 50) {
+    return res.status(400).json({ error: 'Valor mínimo é R$0,50.' });
+  }
+
+  try {
+    const response = await axios.post(
+      'https://api.pushinpay.com.br/api/pix/cashIn',
+      {
+        value: valorCentavos,
+        webhook_url: `${BASE_URL}/webhook/pushinpay`
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${PUSHINPAY_TOKEN}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        }
+      }
+    );
+    
+    const { qr_code_base64, qr_code, id } = response.data;
+    const normalizedId = id.toLowerCase();
+    const pix_copia_cola = qr_code;
+    
+    console.log(`✅ Token ${normalizedId} salvo no banco com valor ${valorCentavos}`);
+
+    db.prepare(`
+      INSERT INTO tokens (token, valor, status, telegram_id, utm_source, utm_campaign, utm_medium)
+      VALUES (?, ?, 'pendente', ?, ?, ?, ?)
+    `).run(normalizedId, valorCentavos, telegram_id, utm_source, utm_campaign, utm_medium);
+
+    res.json({
+      qr_code_base64,
+      qr_code,
+      pix_copia_cola: pix_copia_cola || qr_code,
+      transacao_id: normalizedId
+    });
+  } catch (error) {
+    console.error("❌ Erro ao gerar cobrança:", error.response?.data || error.message);
+    res.status(500).json({
+      error: 'Erro ao gerar cobrança na API PushinPay.',
+      detalhes: error.response?.data || error.message
+    });
+  }
+};
+
+// Webhook do PushinPay
+const webhookPushinPay = async (req, res) => {
+  try {
+    console.log('📨 Webhook recebido:', req.body);
+
+    const payload = req.body;
+    const { id, status } = payload || {};
+    
+    const normalizedId = id ? id.toLowerCase() : null;
+    
+    if (!normalizedId || status !== 'paid') return res.sendStatus(200);
+
+    const row = db.prepare('SELECT * FROM tokens WHERE token = ?').get(normalizedId);
+
+    if (!row) {
+      console.log('❌ Token não encontrado no banco:', normalizedId);
+      return res.status(400).send('Transação não encontrada');
+    }
+
+    const novoToken = uuidv4();
+    
+    db.prepare(`
+      UPDATE tokens
+      SET token_uuid = ?,
+          status = 'valido', 
+          criado_em = CURRENT_TIMESTAMP
+      WHERE token = ?
+    `).run(novoToken, normalizedId);
+// Salvar token também no PostgreSQL para o sistema web
+        try {
+      await postgres.executeQuery(
+        pgPool,
+        'INSERT INTO tokens (token, valor) VALUES ($1, $2)',
+        [novoToken, (row.valor || 0) / 100]
+      );
+      console.log('✅ Token registrado no PostgreSQL:', novoToken);
+    } catch (pgErr) {
+      console.error('❌ Erro ao registrar token no PostgreSQL:', pgErr.message);
+    }
+
+    if (row.telegram_id) {
+      const tgId = normalizeTelegramId(row.telegram_id);
+      if (tgId !== null) {
+        try {
+          await postgres.executeQuery(
+            pgPool,
+            'UPDATE downsell_progress SET pagou = 1 WHERE telegram_id = $1',
+            [tgId]
+          );
+          console.log(`✅ Usuário ${tgId} marcado como "pagou"`);
+        } catch (pgErr) {
+          console.error('❌ Erro ao atualizar status de pagamento no PostgreSQL:', pgErr.message);
+        }
+      } else {
+        console.warn(`⚠️ telegram_id inválido: ${row.telegram_id}`);
+      }
+    }
+
+    if (row.telegram_id && bot) {
+      const valorReais = (row.valor / 100).toFixed(2);
+      const linkComToken = `${FRONTEND_URL}/obrigado.html?token=${novoToken}&valor=${valorReais}&redirect=${REDIRECT_KEY}`;
+      
+      await bot.sendMessage(row.telegram_id, 
+        `🎉 <b>Pagamento aprovado!</b>\n\n💰 Valor: R$ ${valorReais}\n🔗 Acesse seu conteúdo: ${linkComToken}`, 
+        { parse_mode: 'HTML' }
+      );
+    }
+    
+    res.sendStatus(200);
+  } catch (err) {
+    console.error('❌ Erro no webhook:', err.message);
+    res.sendStatus(500);
+  }
+};
+
+// Comando /start
+if (bot) {
+  bot.onText(/\/start/, async (msg) => {
+    const chatId = msg.chat.id;
+    
+    try {
+      console.log(`📱 Comando /start recebido de ${chatId}`);
+      
+      // Enviar todas as mídias iniciais disponíveis
+      await enviarMidiasHierarquicamente(chatId, config.midias.inicial);
+
+      // Enviar texto inicial
+      await bot.sendMessage(chatId, config.inicio.textoInicial, { parse_mode: 'HTML' });
+
+      // Enviar menu inicial
+      await bot.sendMessage(chatId, config.inicio.menuInicial.texto, {
+        reply_markup: {
+          inline_keyboard: config.inicio.menuInicial.opcoes.map(opcao => [{
+            text: opcao.texto,
+            callback_data: opcao.callback
+          }])
+        }
+      });
+
+      // Registrar usuário no banco de dados PostgreSQL
+      try {
+        const existeRes = await postgres.executeQuery(
+          pgPool,
+          'SELECT telegram_id FROM downsell_progress WHERE telegram_id = $1',
+          [chatId]
+        );
+
+        if (existeRes.rows.length === 0) {
+          await postgres.executeQuery(
+            pgPool,
+            'INSERT INTO downsell_progress (telegram_id, index_downsell, last_sent_at) VALUES ($1, $2, NULL)',
+            [chatId, 0]
+          );
+        }
+      } catch (pgErr) {
+        console.error('❌ Erro ao registrar usuário no PostgreSQL:', pgErr.message);
+      }
+
+
+
+      console.log(`✅ Resposta enviada para ${chatId}`);
+    } catch (error) {
+      console.error('❌ Erro no comando /start:', error);
+      
+      // Enviar mensagem de erro amigável
+      try {
+        await bot.sendMessage(chatId, config.erros?.erroGenerico || '❌ Ocorreu um erro. Tente novamente.');
+      } catch (e) {
+        console.error('❌ Erro ao enviar mensagem de erro:', e);
+      }
+    }
+  });
+
+  // Tratamento dos botões
+  bot.on('callback_query', async (query) => {
+    const chatId = query.message.chat.id;
+    const data = query.data;
+    
+    try {
+      console.log(`🔘 Callback recebido: ${data} de ${chatId}`);
+      
+      if (data === 'mostrar_planos') {
+        const botoesPlanos = config.planos.map(plano => ([{
+          text: `${plano.emoji} ${plano.nome} — por R$${plano.valor.toFixed(2)}`,
+          callback_data: plano.id
+        }]));
+        return bot.sendMessage(chatId, '💖 Escolha seu plano abaixo:', {
+          reply_markup: { inline_keyboard: botoesPlanos }
+        });
+      }
+
+      if (data === 'ver_previas') {
+        return bot.sendMessage(chatId, `🙈 <b>Prévias:</b>\n\n💗 Acesse nosso canal:\n👉 ${config.canalPrevias}`, {
+          parse_mode: 'HTML'
+        });
+      }
+
+      // Verificar pagamento
+      if (data.startsWith('verificar_pagamento_')) {
+        const transacaoId = data.replace('verificar_pagamento_', '');
+
+        const tokenRow = db.prepare(`
+          SELECT token_uuid, status, valor, telegram_id FROM tokens
+          WHERE token = ?
+          LIMIT 1
+        `).get(transacaoId);
+
+        if (!tokenRow) {
+          return bot.sendMessage(chatId, '❌ Pagamento não encontrado.');
+        }
+
+        if (tokenRow.status !== 'valido' || !tokenRow.token_uuid) {
+          return bot.sendMessage(chatId, config.pagamento.pendente);
+        }
+
+        try {
+          const tgId = normalizeTelegramId(chatId);
+          if (tgId !== null) {
+            await postgres.executeQuery(
+              pgPool,
+              'UPDATE downsell_progress SET pagou = 1 WHERE telegram_id = $1',
+              [tgId]
+            );
+          } else {
+            console.warn(`⚠️ telegram_id inválido ao atualizar pagamento: ${chatId}`);
+          }
+        } catch (pgErr) {
+          console.error('❌ Erro ao atualizar pagamento no PostgreSQL:', pgErr.message);
+        }
+
+        const valorReais = (tokenRow.valor / 100).toFixed(2);
+        const linkComToken = `${FRONTEND_URL}/obrigado.html?token=${tokenRow.token_uuid}&valor=${valorReais}&redirect=${REDIRECT_KEY}`;
+        
+        await bot.sendMessage(chatId, config.pagamento.aprovado);
+        await bot.sendMessage(chatId, `<b>🎉 Pagamento aprovado!</b>\n\n🔗 Acesse: ${linkComToken}`, {
+          parse_mode: 'HTML'
+        });
+
+        return;
+      }
+
+      // Processar compra de plano principal ou downsell
+      let plano = config.planos.find(p => p.id === data);
+
+      if (!plano) {
+        for (const ds of config.downsells) {
+          const p = ds.planos.find(pl => pl.id === data);
+          if (p) {
+            plano = { ...p };
+            plano.valor = p.valorComDesconto;
+            console.log(`📦 Geração de cobrança para plano ${p.nome} (R$${p.valorComDesconto})`);
+            break;
+          }
+        }
+      }
+
+      if (!plano) {
+        console.log(`⚠️ Plano não encontrado para callback: ${data}`);
+      }
+
+      if (plano) {
+        if (!plano.valor && plano.valorComDesconto) {
+          plano.valor = plano.valorComDesconto;
+        }
+
+        const resposta = await axios.post(`${BASE_URL}/api/gerar-cobranca`, {
+          telegram_id: chatId,
+          plano: plano.nome,
+          valor: plano.valor,
+          utm_source: 'telegram',
+          utm_campaign: 'bot_principal',
+          utm_medium: 'telegram_bot'
+        });
+
+        const { qr_code_base64, pix_copia_cola, transacao_id } = resposta.data;
+        
+        let buffer;
+        if (qr_code_base64) {
+          const base64Image = qr_code_base64.replace(/^data:image\/png;base64,/, '');
+          const imageBuffer = Buffer.from(base64Image, 'base64');
+          buffer = await processarImagem(imageBuffer);
+        }
+
+        const legenda = config.mensagemPix(plano.nome, plano.valor, pix_copia_cola);
+        
+        if (buffer) {
+          await bot.sendPhoto(chatId, buffer, {
+            caption: legenda,
+            parse_mode: 'HTML',
+            reply_markup: {
+              inline_keyboard: [
+                [{ text: '✅ Verificar Status', callback_data: `verificar_pagamento_${transacao_id}` }]
+              ]
+            }
+          });
+        } else {
+          await bot.sendMessage(chatId, legenda, {
+            parse_mode: 'HTML',
+            reply_markup: {
+              inline_keyboard: [
+                [{ text: '✅ Verificar Status', callback_data: `verificar_pagamento_${transacao_id}` }]
+              ]
+            }
+          });
+        }
+      }
+    } catch (error) {
+      console.error('❌ Erro ao processar callback:', error);
+      
+      try {
+        await bot.sendMessage(chatId, config.erros?.erroGenerico || '❌ Ocorreu um erro. Tente novamente.');
+      } catch (e) {
+        console.error('❌ Erro ao enviar mensagem de erro:', e);
+      }
+    }
+  });
+}
+
+console.log('✅ Bot configurado e rodando');
+
+// Função para enviar downsells automaticamente
+async function enviarDownsells(targetId = null) {
+  const flagKey = targetId || 'GLOBAL';
+  if (processingDownsells.get(flagKey)) {
+    console.log(`⚠️ Processamento de downsells já em andamento para ${flagKey}`);
+    return;
+  }
+  processingDownsells.set(flagKey, true);
+
+  try {
+    console.log('🟢 Iniciando processo de downsells...');
+
+    // Buscar usuários que ainda não pagaram no PostgreSQL
+    let usuariosRes;
+    if (targetId) {
+      usuariosRes = await postgres.executeQuery(
+        pgPool,
+        'SELECT telegram_id, index_downsell, last_sent_at FROM downsell_progress WHERE pagou = 0 AND telegram_id = $1',
+        [targetId]
+      );
+    } else {
+      usuariosRes = await postgres.executeQuery(
+        pgPool,
+        'SELECT telegram_id, index_downsell, last_sent_at FROM downsell_progress WHERE pagou = 0'
+      );
+    }
+    const usuarios = usuariosRes.rows;
+
+    console.log('📂 Conteúdo da tabela downsell_progress:', usuarios);
+    console.log(`📊 Encontrados ${usuarios.length} usuários para processar`);
+
+    for (const usuario of usuarios) {
+      const { telegram_id, index_downsell, last_sent_at } = usuario;
+      console.log(`🔎 Verificando usuário ${telegram_id}`);
+
+      // Verificar se ainda há downsells para enviar
+      if (index_downsell >= config.downsells.length) {
+        console.log(`⏭️ Usuário ${telegram_id} já recebeu todos os downsells`);
+        continue;
+      }
+
+      // Respeitar intervalo de 5 minutos entre cada downsell
+      if (last_sent_at) {
+        const diff = Date.now() - new Date(last_sent_at).getTime();
+        if (diff < 5 * 60 * 1000) {
+          console.log(
+            `⏱️ Usuário ${telegram_id} ainda não completou o intervalo de 5 minutos`
+          );
+          continue;
+        }
+      }
+      
+      const downsell = config.downsells[index_downsell];
+      
+      if (!downsell) {
+        console.log(`⚠️ Downsell não encontrado para índice ${index_downsell}`);
+        continue;
+      }
+      
+      try {
+        const envioTimestamp = new Date().toISOString();
+        console.log(`📤 Enviando downsell ${index_downsell} para usuário ${telegram_id} (\u{1F551} ${envioTimestamp})`);
+        
+        // Enviar mídias do downsell na ordem correta
+        await enviarMidiasHierarquicamente(
+          telegram_id,
+          config.midias.downsells[downsell.id] || {}
+        );
+        
+        // Preparar botões inline se existirem
+        let replyMarkup = null;
+        if (downsell.planos && downsell.planos.length > 0) {
+          const botoes = downsell.planos.map(plano => [{
+            text: `${plano.emoji} ${plano.nome} — R$${plano.valorComDesconto.toFixed(2)}`,
+            callback_data: plano.id
+          }]);
+          
+          replyMarkup = { inline_keyboard: botoes };
+        }
+        
+        // Enviar texto do downsell
+        await bot.sendMessage(telegram_id, downsell.texto, {
+          parse_mode: 'HTML',
+          reply_markup: replyMarkup
+        });
+        console.log(`📨 Mensagem enviada para ${telegram_id}`);
+        
+        // Atualizar índice e timestamp do downsell no PostgreSQL
+        try {
+          await postgres.executeQuery(
+            pgPool,
+            'UPDATE downsell_progress SET index_downsell = $1, last_sent_at = NOW() WHERE telegram_id = $2',
+            [index_downsell + 1, telegram_id]
+          );
+        } catch (pgErr) {
+          console.error(`❌ Erro ao atualizar indice do downsell para ${telegram_id}:`, pgErr.message);
+        }
+        
+        console.log(`✅ Downsell enviado com sucesso para ${telegram_id} em ${envioTimestamp}`);
+        
+        // Pequena pausa entre envios para evitar rate limiting
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        
+      } catch (error) {
+        console.error(`❌ Erro ao enviar downsell para ${telegram_id}:`, error.message);
+      }
+    }
+    
+
+  } catch (error) {
+    console.error('❌ Erro geral na função enviarDownsells:', error.message);
+  } finally {
+    processingDownsells.delete(flagKey);
+  }
+}
+
+// Envio sequencial de downsells para um único usuário
+async function enviarDownsell(chatId) {
+  try {
+    const progressoRes = await postgres.executeQuery(
+      pgPool,
+      'SELECT index_downsell FROM downsell_progress WHERE telegram_id = $1',
+      [chatId]
+    );
+    const progresso = progressoRes.rows[0] || { index_downsell: 0 };
+
+    const idx = progresso.index_downsell;
+    const lista = config.downsells;
+
+    // Se o usuário já recebeu todos os downsells, apenas sair
+    if (idx >= lista.length) {
+      return;
+    }
+
+    const downsell = lista[idx];
+    if (!downsell) {
+      console.warn(`⚠️ Downsell não encontrado para índice ${idx}`);
+      return;
+    }
+
+    await enviarMidiasHierarquicamente(
+      chatId,
+      config.midias.downsells[downsell.id] || {}
+    );
+
+    let replyMarkup = null;
+    if (downsell.planos && downsell.planos.length > 0) {
+      const botoes = downsell.planos.map(p => [{
+        text: `${p.emoji} ${p.nome} — R$${p.valorComDesconto.toFixed(2)}`,
+        callback_data: p.id
+      }]);
+      replyMarkup = { inline_keyboard: botoes };
+    }
+
+    await bot.sendMessage(chatId, downsell.texto, {
+      parse_mode: 'HTML',
+      reply_markup: replyMarkup
+    });
+
+    await postgres.executeQuery(
+      pgPool,
+      'UPDATE downsell_progress SET index_downsell = $1, last_sent_at = NOW() WHERE telegram_id = $2',
+      [idx + 1, chatId]
+    );
+
+    if (idx + 1 < lista.length) {
+      setTimeout(() => {
+        enviarDownsell(chatId).catch(err =>
+          console.error('❌ Erro no próximo downsell:', err.message)
+        );
+      }, 5 * 60 * 1000);
+    } else {
+      console.log(`✅ Ciclo de downsells concluído para ${chatId}`);
+    }
+  } catch (error) {
+    console.error('❌ Erro na função enviarDownsell:', error.message);
+  }
+}
+
+// Enviar mensagens periódicas
+async function enviarMensagemPeriodica(indice = 0) {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] 🚀 Iniciando envio de mensagem periódica`);
+  try {
+    const usuariosRes = await postgres.executeQuery(
+      pgPool,
+      'SELECT telegram_id FROM downsell_progress WHERE pagou = 0'
+    );
+    const usuarios = usuariosRes.rows;
+    console.log(`[${timestamp}] Encontrados ${usuarios.length} usuários`);
+
+    const mensagens = config.mensagensPeriodicas || [];
+    if (mensagens.length === 0) {
+      console.log('⚠️ Nenhuma mensagem periódica configurada');
+      return;
+    }
+    const msg = mensagens[indice % mensagens.length];
+
+    for (const u of usuarios) {
+      const id = u.telegram_id;
+      console.log(`[${new Date().toISOString()}] Enviando para ${id}`);
+      try {
+        if (msg.midia) {
+          let tipo = 'photo';
+          if (msg.midia.endsWith('.mp4')) tipo = 'video';
+          else if (msg.midia.endsWith('.mp3')) tipo = 'audio';
+          await enviarMidiaComFallback(id, tipo, msg.midia);
+          console.log(`[${new Date().toISOString()}] Mídia enviada para ${id}`);
+        }
+
+        const botoes = config.planos.map(p => [{
+          text: `${p.emoji} ${p.nome} — R$${p.valor.toFixed(2)}`,
+          callback_data: p.id
+        }]);
+
+        await bot.sendMessage(id, msg.texto, {
+          parse_mode: 'HTML',
+          reply_markup: { inline_keyboard: botoes }
+        });
+        console.log(`[${new Date().toISOString()}] Texto enviado para ${id}`);
+      } catch (err) {
+        console.error(`[${new Date().toISOString()}] Erro ao enviar para ${id}:`, err.message);
+      }
+
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  } catch (err) {
+    console.error(`[${new Date().toISOString()}] Erro geral no envio periódico:`, err.message);
+  }
+}
+
+// Comando /status
+if (bot) {
+  bot.onText(/\/status/, async (msg) => {
+    const chatId = msg.chat.id;
+    
+    try {
+      const usuarioRes = await postgres.executeQuery(
+        pgPool,
+        'SELECT index_downsell, pagou FROM downsell_progress WHERE telegram_id = $1',
+        [chatId]
+      );
+      const usuario = usuarioRes.rows[0];
+      
+      if (!usuario) {
+        await bot.sendMessage(chatId, '❌ Usuário não encontrado. Use /start primeiro.');
+        return;
+      }
+      
+      const statusPagamento = usuario.pagou === 1 ? 'JÁ PAGOU ✅' : 'NÃO PAGOU ❌';
+      const totalDownsells = config.downsells.length;
+      
+      const mensagem = `
+📊 <b>SEU STATUS:</b>
+
+💰 <b>Pagamento:</b> ${statusPagamento}
+📈 <b>Downsell atual:</b> ${usuario.index_downsell}/${totalDownsells}
+🔄 <b>Próximo downsell:</b> ${usuario.index_downsell >= totalDownsells ? 'Finalizado' : 'Em breve'}
+
+${usuario.pagou === 0 ? '💡 <i>Você receberá ofertas especiais automaticamente!</i>' : '🎉 <i>Obrigado pela sua compra!</i>'}
+      `.trim();
+      
+      await bot.sendMessage(chatId, mensagem, { parse_mode: 'HTML' });
+      
+    } catch (error) {
+      console.error('❌ Erro no comando /status:', error.message);
+      await bot.sendMessage(chatId, '❌ Erro ao verificar status. Tente novamente.');
+    }
+  });
+}
+
+// Comando /resert (reiniciar funil)
+if (bot) {
+  bot.onText(/\/resert/, async (msg) => {
+    const chatId = msg.chat.id;
+    
+    try {
+      // Verificar se o usuário existe no PostgreSQL
+      const usuarioRes = await postgres.executeQuery(
+        pgPool,
+        'SELECT telegram_id FROM downsell_progress WHERE telegram_id = $1',
+        [chatId]
+      );
+      const usuario = usuarioRes.rows[0];
+      
+      if (!usuario) {
+        await bot.sendMessage(chatId, '❌ Usuário não encontrado. Use /start primeiro.');
+        return;
+      }
+      
+      // Resetar o funil no PostgreSQL
+      try {
+        await postgres.executeQuery(
+          pgPool,
+          'UPDATE downsell_progress SET pagou = 0, index_downsell = 0, last_sent_at = NULL WHERE telegram_id = $1',
+          [chatId]
+        );
+      } catch (pgErr) {
+        console.error('❌ Erro ao resetar funil no PostgreSQL:', pgErr.message);
+      }
+      
+      await bot.sendMessage(chatId, `
+🔄 <b>Funil reiniciado com sucesso!</b>
+
+✅ Status de pagamento resetado
+✅ Downsells reiniciados
+📬 Você voltará a receber ofertas automaticamente
+
+💡 <i>Use /status para verificar seu novo status</i>
+      `.trim(), { parse_mode: 'HTML' });
+      
+      console.log(`🔄 Funil reiniciado para usuário ${chatId}`);
+      
+    } catch (error) {
+      console.error('❌ Erro no comando /resert:', error.message);
+      await bot.sendMessage(chatId, '❌ Erro ao reiniciar funil. Tente novamente.');
+    }
+  });
+}
+
+// Configurar execução automática dos downsells a cada 5 minutos (apenas para testes)
+
+
+// Exportar função para uso manual se necessário
+module.exports = {
+  bot,
+  gerarCobranca,
+  webhookPushinPay,
+  gerenciadorMidia,
+  enviarDownsells,
+  enviarDownsell,
+  enviarMensagemPeriodica,
+  TELEGRAM_TOKEN,
+  config,
+  MEU_PERFIL
+};
+

--- a/MODELO1/perfil1/config.js
+++ b/MODELO1/perfil1/config.js
@@ -1,0 +1,412 @@
+const fs = require('fs');
+const path = require('path');
+
+// Configurações das mídias - URLs ou caminhos locais
+const midias = {
+  inicial: {
+    video: '../BOT/midia/inicial.mp4',
+    imagem: '../BOT/midia/inicial.jpg',
+    audio: '../BOT/midia/inicial_audio.mp3'
+  },
+  downsells: {
+    ds1: {
+      video: '../BOT/midia/downsells/ds1.mp4',
+      imagem: '../BOT/midia/downsells/ds1.jpg',
+      audio: '../BOT/midia/downsells/ds1.mp3'
+    },
+    ds2: {
+      video: '../BOT/midia/downsells/ds2.mp4',
+      imagem: '../BOT/midia/downsells/ds2.jpg',
+      audio: '../BOT/midia/downsells/ds2.mp3'
+    },
+    ds3: {
+      video: '../BOT/midia/downsells/ds3.mp4',
+      imagem: '../BOT/midia/downsells/ds3.jpg',
+      audio: '../BOT/midia/downsells/ds3.mp3'
+    },
+    ds4: {
+      video: '../BOT/midia/downsells/ds4.mp4',
+      imagem: '../BOT/midia/downsells/ds4.jpg',
+      audio: '../BOT/midia/downsells/ds4.mp3'
+    },
+    ds5: {
+      video: '../BOT/midia/downsells/ds5.mp4',
+      imagem: '../BOT/midia/downsells/ds5.jpg',
+      audio: '../BOT/midia/downsells/ds5.mp3'
+    },
+    ds6: {
+      video: '../BOT/midia/downsells/ds6.mp4',
+      imagem: '../BOT/midia/downsells/ds6.jpg',
+      audio: '../BOT/midia/downsells/ds6.mp3'
+    },
+    ds7: {
+      video: '../BOT/midia/downsells/ds7.mp4',
+      imagem: '../BOT/midia/downsells/ds7.jpg',
+      audio: '../BOT/midia/downsells/ds7.mp3'
+    },
+    ds8: {
+      video: '../BOT/midia/downsells/ds8.mp4',
+      imagem: '../BOT/midia/downsells/ds8.jpg',
+      audio: '../BOT/midia/downsells/ds8.mp3'
+    },
+    ds9: {
+      video: '../BOT/midia/downsells/ds9.mp4',
+      imagem: '../BOT/midia/downsells/ds9.jpg',
+      audio: '../BOT/midia/downsells/ds9.mp3'
+    },
+    ds10: {
+      video: '../BOT/midia/downsells/ds10.mp4',
+      imagem: '../BOT/midia/downsells/ds10.jpg',
+      audio: '../BOT/midia/downsells/ds10.mp3'
+    },
+    ds11: {
+      video: '../BOT/midia/downsells/ds11.mp4',
+      imagem: '../BOT/midia/downsells/ds11.jpg',
+      audio: '../BOT/midia/downsells/ds11.mp3'
+    },
+    ds12: {
+      video: '../BOT/midia/downsells/ds12.mp4',
+      imagem: '../BOT/midia/downsells/ds12.jpg',
+      audio: '../BOT/midia/downsells/ds12.mp3'
+    }
+  }
+};
+
+// Função para verificar se o arquivo existe
+function verificarMidia(caminhoMidia) {
+  if (!caminhoMidia) return false;
+  
+  // Se for URL, assumir que existe
+  if (caminhoMidia.startsWith('http')) {
+    return true;
+  }
+  
+  // Se for arquivo local, verificar se existe
+  try {
+    return fs.existsSync(caminhoMidia);
+  } catch (error) {
+    console.warn(`⚠️ Erro ao verificar mídia ${caminhoMidia}:`, error.message);
+    return false;
+  }
+}
+
+// Função para obter mídia baseada no tipo
+function obterMidia(tipo, indice = null) {
+  if (tipo === 'inicial') {
+    return midias.inicial;
+  }
+  
+  if (tipo === 'downsell' && indice) {
+    return midias.downsells[indice];
+  }
+  
+  return null;
+}
+
+// Função para obter o melhor tipo de mídia disponível
+function obterMelhorMidia(tipo, indice = null) {
+  const midiasDisponiveis = obterMidia(tipo, indice);
+  
+  if (!midiasDisponiveis) return null;
+  
+  // Prioridade: video > imagem > audio
+  const prioridade = ['video', 'imagem', 'audio'];
+  
+  for (const tipoMidia of prioridade) {
+    const caminhoMidia = midiasDisponiveis[tipoMidia];
+    if (verificarMidia(caminhoMidia)) {
+      return {
+        tipo: tipoMidia,
+        caminho: caminhoMidia
+      };
+    }
+  }
+  
+  return null;
+}
+
+// Configuração do início
+const inicio = {
+  tipoMidia: 'video', // 'video', 'imagem', 'audio' ou null
+  textoInicial: `
+😈 <b>Oi, titio... 👅</b>
+
+Que delícia ter você aqui no meu quartinho…  
+Já tava te esperando, sabia? Tô morrendo de vontade de te mostrar umas coisinhas que só quem entra aqui consegue ver… 😘
+
+🎀 <b>Aqui você vai encontrar meus vídeos mais íntimos — só meus, só pra você.</b>
+
+💌 E se quiser algo mais especial… mais safadinho, é só me chamar. Eu adoro quando o titio pede as coisas do jeitinho dele…
+
+<b>Mas cuidado, viu?</b>  
+Quem entra no meu quartinho nunca mais quer sair. Lá dentro, tudo fica mais quente… mais profundo… mais nosso. 🔥
+
+✨ Talvez esse seja só o primeiro passo...  
+Pra você me conhecer de um jeitinho que ninguém mais conhece.
+
+<b>Vem… a sobrinha aqui tá prontinha pra te mimar, titio.</b> 😏💖
+  `.trim(),
+  menuInicial: {
+    texto: '✨ Escolhe como quer brincar comigo hoje, titio...\nUma espiadinha... ou vem de vez? 😉👇',
+    opcoes: [
+      { texto: 'Acessar Agora', callback: 'mostrar_planos' },
+      { texto: 'Prévias da sobrinha 💗🙈', callback: 'ver_previas' }
+    ]
+  }
+};
+
+// Configuração dos planos
+const planos = [
+  {
+    id: 'plano_semanal',
+    nome: 'Semanal',
+    emoji: '💋',
+    valor: 17.90,
+    descricao: 'Acesso por 7 dias'
+  },
+  {
+    id: 'plano_mensal',
+    nome: 'Mensal',
+    emoji: '🔥',
+    valor: 19.90,
+    descricao: 'Acesso por 30 dias'
+  }
+];
+
+// Configuração dos downsells
+const downsells = [
+  {
+    id: 'ds1',
+    emoji: '💗',
+    texto: 'Oie Titio, percebi que você não finalizou a sua assinatura 😢\n\n💗 Entra pro meu grupinho VIP agora, e vem vê sua sobrinha de um jeito que você nunca viu 🙈',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds1_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 17.90 },
+      { id: 'ds1_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 19.90 }
+    ]
+  },
+  {
+    id: 'ds2',
+    emoji: '💗',
+    texto: 'Oie Titio, percebi que você não finalizou a sua assinatura...\n\n💗 Pra te dar um incentivo, estou te dando 10% de desconto pra entrar agora pro meu grupinho VIP 😈\n\nVem vê sua sobrinha de um jeitinho que você nunca viu... 😏',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds2_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 16.11 },
+      { id: 'ds2_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 17.91 }
+    ]
+  },
+  {
+    id: 'ds3',
+    emoji: '💦',
+    texto: 'Oiee titio, já veio gozar pra sua ninfetinha hoje?\n\n💦 Vi que gerou o PIX mas não pagou, então liberei um desconto exclusivo + PRESENTINHO só pra você (não conta pra ninguém, tá?)\n\nMas corre, o desconto acaba a qualquer momento! ⏬',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds3_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 17.00 },
+      { id: 'ds3_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 18.90 }
+    ]
+  },
+  {
+    id: 'ds4',
+    emoji: '💋',
+    texto: '💋 QUANTO TEMPO VAI ME IGNORAR? 💋\n\nVocê já me espiou antes… Agora é hora de entrar e ver TUDO sem censura! 😈\n\nSe entrar agora, ainda ganha um brinde no privado... Não vou contar o que é 😏',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds4_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 17.00 },
+      { id: 'ds4_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 18.90 }
+    ]
+  },
+  {
+    id: 'ds5',
+    emoji: '💋',
+    texto: 'Titio, você deixou a loirinha aqui esperando...\n\nFiquei molhadinha te imaginando vendo meus vídeos 💋\n\nPra te conquistar: desconto liberado + presentinho do jeitinho que você gosta 😘',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds5_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 16.11 },
+      { id: 'ds5_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 17.91 }
+    ]
+  },
+  {
+    id: 'ds6',
+    emoji: '😈',
+    texto: 'Oie titio, olha só...\n\nLiberei uma promoção secreta só pra você: desconto + bônus extra que ninguém mais vai ganhar 😈\n\nMas não conta pra ninguém... minha calcinha tá te esperando no VIP 💦',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds6_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 15.21 },
+      { id: 'ds6_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 16.91 }
+    ]
+  },
+  {
+    id: 'ds7',
+    emoji: '🥵',
+    texto: 'Já imaginou abrir o grupo e dar de cara comigo peladinha? 😳\n\nAgora imagina isso com um desconto especial + presentinho só seu? 🥵\n\nMas tem que correr, hein? Não vou deixar isso aberto por muito tempo!',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds7_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 15.21 },
+      { id: 'ds7_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 16.91 }
+    ]
+  },
+  {
+    id: 'ds8',
+    emoji: '😈',
+    texto: 'Titio... voltei só pra dizer:\n\nSe pagar agora, além de entrar no meu VIP, vai ganhar um mimo pessoal e um descontinho safado ❤️\n\nSó não demora… ou a oferta some... e eu também 😈',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds8_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 14.32 },
+      { id: 'ds8_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 15.92 }
+    ]
+  },
+  {
+    id: 'ds9',
+    emoji: '😳',
+    texto: 'Tô liberando um código secreto...\n\nPra quem travou no final 😳\n\nDesconto ativado + conteúdo surpresa picante liberado. Só pra você, mas só por hoje, viu?',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds9_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 14.32 },
+      { id: 'ds9_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 15.92 }
+    ]
+  },
+  {
+    id: 'ds10',
+    emoji: '🖤',
+    texto: 'Vi seu nome na lista de quem quase entrou…\n\nMe deixou com vontade de te recompensar 😘\n\nLiberei 25% OFF + vídeo exclusivo surpresa. Mas só até eu cansar de esperar 🖤',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds10_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 13.42 },
+      { id: 'ds10_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 14.92 }
+    ]
+  },
+  {
+    id: 'ds11',
+    emoji: '💦',
+    texto: 'Oieee… sua ninfetinha loira tá aqui te esperando, sabia?\n\nVi que gerou o PIX e sumiu 🙈\n\nEntão toma: descontinho + surpresinha só pra você terminar logo essa sacanagem toda 💦',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds11_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 13.42 },
+      { id: 'ds11_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 14.92 }
+    ]
+  },
+  {
+    id: 'ds12',
+    emoji: '😭',
+    texto: 'Titio, vai me deixar assim?\n\nCom a calcinha molhada e o grupo fechado? 😭\n\nAproveita: desconto + conteúdo extra surpresa liberado AGORA\n\nMas corre… porque eu enjoo rápido.',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds12_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 12.53 },
+      { id: 'ds12_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 13.93 }
+    ]
+  }
+];
+
+// Mensagens periódicas
+const mensagensPeriodicas = [
+  {
+    midia: '../BOT/midia/periodica1.jpg',
+    texto: `Por apenas 19,90 você vai ter acesso a:
+🔥 Mais de 450 fotos e vídeos
+🔥 Sexo, boquete, anal ménage
+🔥 Vídeo chamada gratuita
+🔥 Live sem roupa toda noite
+🔥 Sorteio pra gravar comigo
+👇🏻ESTOU TE ESPERANDO AQUI👇🏻`
+  },
+  {
+    midia: '../BOT/midia/periodica2.mp4',
+    texto: `SÓ 19,90 🎁
+Isso mesmo safadinho, liberei meu VIP (e meu cuzinho) por apenas 19,90 😍
+Corre lá pra ver tudinho e gozar bem gostoso pra sua putinha preferida👇🏻`
+  },
+  {
+    midia: '../BOT/midia/periodica3.jpg',
+    texto: `✨ 20 REAIS ✨
+É o precinho para entrar no meu grupinho agora e se deliciar com meus vídeos já de manhã, para começar o dia jogando leitinho para fora bem gostoso. Vira macho e aperta o botão agora.`
+  }
+];
+
+const horariosEnvioPeriodico = [
+  '0 8 * * *',
+  '0 11 * * *',
+  '0 18 * * *',
+  '0 20 * * *',
+  '0 23 * * *'
+];
+
+// Outras configurações
+const canalPrevias = 'https://t.me/+B9dEZHITEM1iYzMx';
+
+// Configurações de pagamento
+const pagamento = {
+  pendente: '⏳ O pagamento ainda não foi identificado. Aguarde alguns instantes e clique novamente.',
+  aprovado: '✅ Pagamento confirmado com sucesso!\n\n🔓 Aqui está seu acesso ao conteúdo:',
+  link: '👉 https://t.me/+UEmVhhccVMw3ODcx',
+  expirado: '❌ Este QR Code expirou. Por favor, gere uma nova cobrança.',
+  erro: '❌ Erro ao verificar status do pagamento. Tente novamente em alguns instantes.'
+};
+
+// Configurações de erro
+const erros = {
+  erroGenerico: '❌ <b>Ops! Algo deu errado.</b>\n\n🔄 Tente novamente em alguns instantes.',
+  pagamentoNaoEncontrado: '❌ <b>Pagamento não encontrado.</b>\n\n💡 Verifique se o pagamento foi realizado corretamente.',
+  midiaIndisponivel: '❌ <b>Mídia temporariamente indisponível.</b>\n\n🔄 Tente novamente em alguns instantes.'
+};
+
+// Função para formatar valor em centavos
+function formatarValorCentavos(valor) {
+  const numerico = Number(String(valor).replace(',', '.').trim());
+  return Math.round((numerico + Number.EPSILON) * 100);
+}
+
+// Função para gerar mensagem PIX
+function mensagemPix(nome, valor, pixCopiaCola) {
+  return `
+🌟 <b>Você selecionou o seguinte plano:</b>
+
+🎁 <b>Plano:</b> ${nome}
+💰 <b>Valor:</b> R$${valor.toFixed(2)}
+
+💠 <b>Pague via Pix Copia e Cola (ou QR Code em alguns bancos):</b>
+
+<pre>${pixCopiaCola}</pre>
+
+📌 <b>Toque na chave PIX acima para copiá-la</b>
+❗ Após o pagamento, clique no botão abaixo para verificar o status:
+  `.trim();
+}
+
+// Função para obter downsell por ID
+function obterDownsellPorId(id) {
+  return downsells.find(ds => ds.id === id);
+}
+
+// Função para obter plano por ID
+function obterPlanoPorId(id) {
+  // Procura nos planos principais
+  let plano = planos.find(p => p.id === id);
+  if (plano) return plano;
+  
+  // Procura nos planos de downsells
+  for (const downsell of downsells) {
+    plano = downsell.planos.find(p => p.id === id);
+    if (plano) return plano;
+  }
+  
+  return null;
+}
+
+module.exports = {
+  inicio,
+  planos,
+  downsells,
+  canalPrevias,
+  pagamento,
+  erros,
+  midias,
+  verificarMidia,
+  obterMidia,
+  obterMelhorMidia,
+  formatarValorCentavos,
+  mensagemPix,
+  obterDownsellPorId,
+  obterPlanoPorId,
+  mensagensPeriodicas,
+  horariosEnvioPeriodico
+};

--- a/MODELO1/perfil1/utils/midia.js
+++ b/MODELO1/perfil1/utils/midia.js
@@ -1,0 +1,354 @@
+const fs = require('fs');
+const path = require('path');
+const { midias } = require('../config');
+
+/**
+ * Classe para gerenciar mídias do bot
+ */
+class GerenciadorMidia {
+  constructor() {
+    this.baseDir = path.join(__dirname, '..');
+    this.midiaDir = path.join(this.baseDir, '../BOT/midia');
+    this.downsellDir = path.join(this.midiaDir, 'downsells');
+    
+    // Criar diretórios se não existirem
+    this.criarDiretorios();
+  }
+
+  /**
+   * Criar diretórios necessários
+   */
+  criarDiretorios() {
+    try {
+      if (!fs.existsSync(this.midiaDir)) {
+        fs.mkdirSync(this.midiaDir, { recursive: true });
+        console.log('📁 Diretório midia/ criado');
+      }
+      
+      if (!fs.existsSync(this.downsellDir)) {
+        fs.mkdirSync(this.downsellDir, { recursive: true });
+        console.log('📁 Diretório midia/downsells/ criado');
+      }
+    } catch (error) {
+      console.error('❌ Erro ao criar diretórios:', error);
+    }
+  }
+
+  /**
+   * Verificar se uma mídia existe
+   */
+  verificarMidia(caminhoMidia) {
+    if (!caminhoMidia) return false;
+    
+    // Se for URL, assumir que existe
+    if (caminhoMidia.startsWith('http')) {
+      return true;
+    }
+    
+    // Resolver caminho absoluto
+    const caminhoAbsoluto = path.resolve(this.baseDir, caminhoMidia);
+    
+    try {
+      return fs.existsSync(caminhoAbsoluto);
+    } catch (error) {
+      console.warn(`⚠️ Erro ao verificar mídia ${caminhoMidia}:`, error.message);
+      return false;
+    }
+  }
+
+  /**
+   * Obter mídia inicial
+   */
+  obterMidiaInicial() {
+    const midiasIniciais = midias.inicial;
+    
+    // Verificar na ordem de prioridade: video > imagem > audio
+    if (this.verificarMidia(midiasIniciais.video)) {
+      return {
+        tipo: 'video',
+        caminho: midiasIniciais.video
+      };
+    }
+    
+    if (this.verificarMidia(midiasIniciais.imagem)) {
+      return {
+        tipo: 'photo',
+        caminho: midiasIniciais.imagem
+      };
+    }
+    
+    if (this.verificarMidia(midiasIniciais.audio)) {
+      return {
+        tipo: 'audio',
+        caminho: midiasIniciais.audio
+      };
+    }
+    
+    return null;
+  }
+
+  /**
+   * Obter mídia de downsell
+   */
+  obterMidiaDownsell(downsellId) {
+    if (!midias.downsells[downsellId]) {
+      console.warn(`⚠️ Downsell ${downsellId} não encontrado nas configurações`);
+      return null;
+    }
+    
+    const midiasDownsell = midias.downsells[downsellId];
+    
+    // Verificar na ordem de prioridade: video > imagem > audio
+    if (this.verificarMidia(midiasDownsell.video)) {
+      return {
+        tipo: 'video',
+        caminho: midiasDownsell.video
+      };
+    }
+    
+    if (this.verificarMidia(midiasDownsell.imagem)) {
+      return {
+        tipo: 'photo',
+        caminho: midiasDownsell.imagem
+      };
+    }
+    
+    if (this.verificarMidia(midiasDownsell.audio)) {
+      return {
+        tipo: 'audio',
+        caminho: midiasDownsell.audio
+      };
+    }
+    
+    return null;
+  }
+
+  /**
+   * Obter stream da mídia
+   */
+  obterStreamMidia(caminhoMidia) {
+    if (!caminhoMidia) return null;
+    
+    // Se for URL, retornar a URL diretamente
+    if (caminhoMidia.startsWith('http')) {
+      return caminhoMidia;
+    }
+    
+    // Resolver caminho absoluto
+    const caminhoAbsoluto = path.resolve(this.baseDir, caminhoMidia);
+    
+    try {
+      if (fs.existsSync(caminhoAbsoluto)) {
+        return fs.createReadStream(caminhoAbsoluto);
+      }
+    } catch (error) {
+      console.error(`❌ Erro ao criar stream da mídia ${caminhoMidia}:`, error);
+    }
+    
+    return null;
+  }
+
+  /**
+   * Listar mídias disponíveis
+   */
+  listarMidiasDisponiveis() {
+    const relatorio = {
+      inicial: {},
+      downsells: {}
+    };
+
+    console.log('\n📋 RELATÓRIO DE MÍDIAS DISPONÍVEIS:');
+    console.log('================================');
+
+    // Verificar mídias iniciais
+    console.log('\n🎬 MÍDIA INICIAL:');
+    for (const [tipo, caminho] of Object.entries(midias.inicial)) {
+      const existe = this.verificarMidia(caminho);
+      relatorio.inicial[tipo] = existe;
+      console.log(`  ${tipo}: ${existe ? '✅' : '❌'} ${caminho}`);
+    }
+
+    // Verificar mídias de downsells
+    console.log('\n🔄 MÍDIAS DE DOWNSELLS:');
+    for (const [dsId, midiasDs] of Object.entries(midias.downsells)) {
+      console.log(`\n  ${dsId.toUpperCase()}:`);
+      relatorio.downsells[dsId] = {};
+      
+      for (const [tipo, caminho] of Object.entries(midiasDs)) {
+        const existe = this.verificarMidia(caminho);
+        relatorio.downsells[dsId][tipo] = existe;
+        console.log(`    ${tipo}: ${existe ? '✅' : '❌'} ${caminho}`);
+      }
+    }
+
+    console.log('\n================================\n');
+    return relatorio;
+  }
+
+  /**
+   * Verificar integridade de todas as mídias
+   */
+  verificarIntegridade() {
+    const relatorio = this.listarMidiasDisponiveis();
+    let totalMidias = 0;
+    let midiasDisponiveis = 0;
+
+    // Contar mídias iniciais
+    for (const existe of Object.values(relatorio.inicial)) {
+      totalMidias++;
+      if (existe) midiasDisponiveis++;
+    }
+
+    // Contar mídias de downsells
+    for (const downsell of Object.values(relatorio.downsells)) {
+      for (const existe of Object.values(downsell)) {
+        totalMidias++;
+        if (existe) midiasDisponiveis++;
+      }
+    }
+
+    const porcentagem = totalMidias > 0 ? (midiasDisponiveis / totalMidias * 100).toFixed(1) : 0;
+
+    console.log(`📊 RESUMO: ${midiasDisponiveis}/${totalMidias} mídias disponíveis (${porcentagem}%)`);
+
+    return {
+      total: totalMidias,
+      disponivel: midiasDisponiveis,
+      porcentagem: parseFloat(porcentagem),
+      relatorio
+    };
+  }
+
+  /**
+   * Obter informações detalhadas de uma mídia
+   */
+  obterInfoMidia(caminhoMidia) {
+    if (!caminhoMidia) return null;
+
+    // Se for URL
+    if (caminhoMidia.startsWith('http')) {
+      return {
+        tipo: 'url',
+        caminho: caminhoMidia,
+        tamanho: null,
+        existe: true
+      };
+    }
+
+    // Resolver caminho absoluto
+    const caminhoAbsoluto = path.resolve(this.baseDir, caminhoMidia);
+
+    try {
+      if (fs.existsSync(caminhoAbsoluto)) {
+        const stats = fs.statSync(caminhoAbsoluto);
+        return {
+          tipo: 'arquivo',
+          caminho: caminhoMidia,
+          caminhoAbsoluto,
+          tamanho: stats.size,
+          existe: true,
+          modificado: stats.mtime
+        };
+      }
+    } catch (error) {
+      console.error(`❌ Erro ao obter informações da mídia ${caminhoMidia}:`, error);
+    }
+
+    return {
+      tipo: 'arquivo',
+      caminho: caminhoMidia,
+      tamanho: null,
+      existe: false
+    };
+  }
+
+  /**
+   * Obter o melhor tipo de mídia disponível (baseado na função do config.js)
+   */
+  obterMelhorMidia(tipo, indice = null) {
+    let midiasDisponiveis = null;
+    
+    if (tipo === 'inicial') {
+      midiasDisponiveis = midias.inicial;
+    } else if (tipo === 'downsell' && indice) {
+      midiasDisponiveis = midias.downsells[indice];
+    }
+    
+    if (!midiasDisponiveis) return null;
+    
+    // Prioridade: video > imagem > audio
+    const prioridade = ['video', 'imagem', 'audio'];
+    
+    for (const tipoMidia of prioridade) {
+      const caminhoMidia = midiasDisponiveis[tipoMidia];
+      if (this.verificarMidia(caminhoMidia)) {
+        return {
+          tipo: tipoMidia,
+          caminho: caminhoMidia,
+          tipoTelegram: tipoMidia === 'imagem' ? 'photo' : tipoMidia
+        };
+      }
+    }
+    
+    return null;
+  }
+
+  /**
+   * Preparar mídia para envio no Telegram
+   */
+  prepararMidiaParaTelegram(caminhoMidia, tipoMidia) {
+    if (!caminhoMidia) return null;
+
+    // Se for URL, retornar diretamente
+    if (caminhoMidia.startsWith('http')) {
+      return {
+        source: caminhoMidia,
+        tipo: tipoMidia === 'imagem' ? 'photo' : tipoMidia
+      };
+    }
+
+    // Se for arquivo local, criar stream
+    const stream = this.obterStreamMidia(caminhoMidia);
+    if (stream) {
+      return {
+        source: stream,
+        tipo: tipoMidia === 'imagem' ? 'photo' : tipoMidia
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Criar arquivo de mídia de exemplo (para testes)
+   */
+  criarMidiaExemplo(tipo, dsId = null) {
+    const textoExemplo = `Este é um arquivo de exemplo para ${tipo}`;
+    let caminhoArquivo;
+
+    if (dsId) {
+      caminhoArquivo = path.join(this.downsellDir, `${dsId}.txt`);
+    } else {
+      caminhoArquivo = path.join(this.midiaDir, `inicial.txt`);
+    }
+
+    try {
+      fs.writeFileSync(caminhoArquivo, textoExemplo);
+      console.log(`📝 Arquivo de exemplo criado: ${caminhoArquivo}`);
+      return caminhoArquivo;
+    } catch (error) {
+      console.error(`❌ Erro ao criar arquivo de exemplo:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Limpar cache de mídias (se necessário)
+   */
+  limparCache() {
+    // Esta função pode ser expandida no futuro se implementarmos cache
+    console.log('🧹 Cache de mídias limpo');
+  }
+}
+
+module.exports = GerenciadorMidia;

--- a/MODELO1/perfil2/bot.js
+++ b/MODELO1/perfil2/bot.js
@@ -1,0 +1,971 @@
+require('dotenv').config();
+const MEU_PERFIL = '2';
+process.env.MEU_PERFIL = MEU_PERFIL;
+const TelegramBot = require('node-telegram-bot-api');
+const axios = require('axios');
+const Database = require('better-sqlite3');
+const fs = require('fs');
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const postgres = require('../../postgres.js');
+
+// Reutilizar o pool global do módulo postgres
+const pgPool = postgres.createPool();
+
+// Iniciar limpeza automática de downsells a cada hora
+if (pgPool) {
+  postgres.limparDownsellsAntigos(pgPool); // executar imediatamente
+  setInterval(() => postgres.limparDownsellsAntigos(pgPool), 60 * 60 * 1000);
+}
+
+
+// Importar gerenciador de mídias
+const GerenciadorMidia = require('./utils/midia');
+
+// Só importar sharp se necessário e tratar erros
+let sharp;
+try {
+  sharp = require('sharp');
+} catch (error) {
+  console.warn('⚠️ Sharp não disponível, usando fallback para imagens');
+  sharp = null;
+}
+
+const { getPerfilVar } = require('../../perfil');
+
+const TELEGRAM_TOKEN = getPerfilVar('TELEGRAM_TOKEN');
+const PUSHINPAY_TOKEN = process.env.PUSHINPAY_TOKEN;
+const BASE_URL = process.env.BASE_URL;
+const FRONTEND_URL = process.env.FRONTEND_URL || BASE_URL;
+const REDIRECT_KEY = getPerfilVar('REDIRECT_KEY', 'redirect1');
+
+// Mapa para controle de processamento de downsells
+const processingDownsells = new Map();
+
+// Utilitário para normalizar telegram_id para bigint
+function normalizeTelegramId(id) {
+  if (id === null || id === undefined) return null;
+  const parsed = parseInt(id.toString(), 10);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+// Verificar variáveis essenciais
+if (!TELEGRAM_TOKEN) {
+  console.error('❌ TELEGRAM_TOKEN não definido!');
+}
+
+if (!PUSHINPAY_TOKEN) {
+  console.error('❌ PUSHINPAY_TOKEN não definido!');
+}
+
+if (!BASE_URL) {
+  console.error('❌ BASE_URL não definido!');
+}
+
+// Inicializar gerenciador de mídias
+const gerenciadorMidia = new GerenciadorMidia();
+
+// Verificar integridade das mídias na inicialização
+console.log('\n🔍 Verificando integridade das mídias...');
+const integridade = gerenciadorMidia.verificarIntegridade();
+console.log(`✅ Sistema de mídias inicializado (${integridade.porcentagem}% das mídias disponíveis)\n`);
+
+// Inicializar bot com tratamento de erro
+let bot;
+try {
+  // Não usar polling no OnRender, apenas webhook
+  bot = new TelegramBot(TELEGRAM_TOKEN, { polling: false });
+  
+  // Configurar webhook
+  if (BASE_URL) {
+    const webhookUrl = `${BASE_URL}/bot${TELEGRAM_TOKEN}`;
+    bot.setWebHook(webhookUrl).then(() => {
+      console.log('✅ Webhook configurado:', webhookUrl);
+    }).catch(err => {
+      console.error('❌ Erro ao configurar webhook:', err);
+    });
+  }
+} catch (error) {
+  console.error('❌ Erro ao inicializar bot:', error);
+  bot = null;
+}
+
+// Configurar banco de dados com tratamento de erro
+let db;
+try {
+  db = new Database('./pagamentos.db');
+  
+  // Criar tabelas
+  // A tabela downsell_progress agora é mantida apenas no PostgreSQL
+  // db.prepare(`
+  //   CREATE TABLE IF NOT EXISTS downsell_progress (
+  //     telegram_id TEXT PRIMARY KEY,
+  //     index_downsell INTEGER,
+  //     pagou INTEGER DEFAULT 0
+  //   )
+  // `).run();
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS tokens (
+      token TEXT PRIMARY KEY,
+      telegram_id TEXT,
+      valor INTEGER,
+      utm_source TEXT,
+      utm_campaign TEXT,
+      utm_medium TEXT,
+      status TEXT DEFAULT 'pendente',
+      token_uuid TEXT,
+      criado_em DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `).run();
+
+  // Verificar e adicionar colunas
+  const colunas = db.prepare("PRAGMA table_info(tokens)").all();
+  const temColunaTokenUuid = colunas.some(col => col.name === 'token_uuid');
+  
+  if (!temColunaTokenUuid) {
+    db.prepare("ALTER TABLE tokens ADD COLUMN token_uuid TEXT").run();
+  }
+
+  // Colunas da tabela downsell_progress são gerenciadas no PostgreSQL
+  // const colunasDownsell = db.prepare("PRAGMA table_info(downsell_progress)").all();
+  // const temColunaPagou = colunasDownsell.some(col => col.name === 'pagou');
+
+  // if (!temColunaPagou) {
+  //   db.prepare("ALTER TABLE downsell_progress ADD COLUMN pagou INTEGER DEFAULT 0").run();
+  // }
+
+  console.log('✅ Banco de dados configurado');
+} catch (error) {
+  console.error('❌ Erro ao configurar banco:', error);
+  db = null;
+}
+
+// Importar config com tratamento de erro
+let config;
+try {
+  config = require('./config');
+} catch (error) {
+  console.error('❌ Erro ao carregar config:', error);
+  // Usar config padrão mínimo
+  config = {
+    formatarValorCentavos: (valor) => Math.round(parseFloat(valor) * 100),
+    inicio: {
+      tipoMidia: 'texto',
+      textoInicial: 'Olá! Bem-vindo ao bot.',
+      menuInicial: {
+        texto: 'Escolha uma opção:',
+        opcoes: [
+          { texto: 'Ver Planos', callback: 'mostrar_planos' },
+          { texto: 'Prévias', callback: 'ver_previas' }
+        ]
+      }
+    },
+    planos: [
+      { id: 'plano1', nome: 'Plano Básico', emoji: '💎', valor: 10.00 }
+    ],
+    downsells: [],
+    canalPrevias: '@seucanal',
+    pagamento: {
+      pendente: '⏳ Pagamento pendente. Verifique novamente.',
+      aprovado: '✅ Pagamento aprovado!'
+    },
+    mensagemPix: (nome, valor, pixCopia) => `
+💎 <b>${nome}</b>
+💰 Valor: R$ ${valor.toFixed(2)}
+
+📋 <b>PIX Copia e Cola:</b>
+<code>${pixCopia}</code>
+
+⏰ <b>Importante:</b> Após o pagamento, clique em "Verificar Status" para liberar o acesso.
+    `
+  };
+}
+
+// Função para processar imagem com fallback
+async function processarImagem(imageBuffer) {
+  if (!sharp) {
+    return imageBuffer;
+  }
+  
+  try {
+    return await sharp(imageBuffer)
+      .extend({ 
+        top: 40, 
+        bottom: 40, 
+        left: 40, 
+        right: 40, 
+        background: { r: 255, g: 255, b: 255, alpha: 1 } 
+      })
+      .png()
+      .toBuffer();
+  } catch (error) {
+    console.warn('⚠️ Erro ao processar imagem, usando original:', error.message);
+    return imageBuffer;
+  }
+}
+
+// Função para enviar mídia com fallback
+async function enviarMidiaComFallback(chatId, tipoMidia, caminhoMidia, opcoes = {}) {
+  if (!caminhoMidia) {
+    console.warn('⚠️ Caminho de mídia não fornecido');
+    return false;
+  }
+
+  try {
+    console.log(`📤 Tentando enviar ${tipoMidia}: ${caminhoMidia}`);
+
+    // Se for URL, enviar diretamente
+    if (caminhoMidia.startsWith('http')) {
+      switch (tipoMidia) {
+        case 'photo':
+          await bot.sendPhoto(chatId, caminhoMidia, opcoes);
+          break;
+        case 'video':
+          await bot.sendVideo(chatId, caminhoMidia, opcoes);
+          break;
+        case 'audio':
+          await bot.sendVoice(chatId, caminhoMidia, opcoes);
+          break;
+        default:
+          console.warn(`⚠️ Tipo de mídia não suportado: ${tipoMidia}`);
+          return false;
+      }
+      return true;
+    }
+
+    // Se for arquivo local, verificar se existe
+    const caminhoAbsoluto = path.resolve(__dirname, caminhoMidia);
+    
+    if (!fs.existsSync(caminhoAbsoluto)) {
+      console.warn(`⚠️ Arquivo de mídia não encontrado: ${caminhoAbsoluto}`);
+      return false;
+    }
+
+    // Criar stream do arquivo
+    const stream = fs.createReadStream(caminhoAbsoluto);
+    
+    switch (tipoMidia) {
+      case 'photo':
+        await bot.sendPhoto(chatId, stream, opcoes);
+        break;
+      case 'video':
+        await bot.sendVideo(chatId, stream, opcoes);
+        break;
+      case 'audio':
+        await bot.sendVoice(chatId, stream, opcoes);
+        break;
+      default:
+        console.warn(`⚠️ Tipo de mídia não suportado: ${tipoMidia}`);
+        return false;
+    }
+
+    console.log(`✅ Mídia ${tipoMidia} enviada com sucesso`);
+    return true;
+
+  } catch (error) {
+    console.error(`❌ Erro ao enviar mídia ${tipoMidia}:`, error.message);
+    return false;
+  }
+}
+
+// Enviar múltiplas mídias na ordem: áudio → vídeo → foto
+async function enviarMidiasHierarquicamente(chatId, midias) {
+  if (!midias) return;
+
+  const ordem = ['audio', 'video', 'photo'];
+
+  for (const tipo of ordem) {
+    let caminho = null;
+    if (tipo === 'photo') {
+      caminho = midias.foto || midias.imagem;
+    } else {
+      caminho = midias[tipo];
+    }
+
+    if (!caminho) continue;
+
+    if (!caminho.startsWith('http')) {
+      const absPath = path.resolve(__dirname, caminho);
+      if (!fs.existsSync(absPath)) {
+        console.warn(`⚠️ Arquivo de mídia não encontrado: ${absPath}`);
+        continue;
+      }
+    }
+
+    await enviarMidiaComFallback(chatId, tipo, caminho);
+  }
+}
+
+// Função para gerar cobrança
+const gerarCobranca = async (req, res) => {
+  const { plano, valor, utm_source, utm_campaign, utm_medium, telegram_id } = req.body;
+    
+  if (!plano || !valor) {
+    return res.status(400).json({ error: 'Parâmetros inválidos: plano e valor são obrigatórios.' });
+  }
+
+  const valorCentavos = config.formatarValorCentavos(valor);
+  if (isNaN(valorCentavos) || valorCentavos < 50) {
+    return res.status(400).json({ error: 'Valor mínimo é R$0,50.' });
+  }
+
+  try {
+    const response = await axios.post(
+      'https://api.pushinpay.com.br/api/pix/cashIn',
+      {
+        value: valorCentavos,
+        webhook_url: `${BASE_URL}/webhook/pushinpay`
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${PUSHINPAY_TOKEN}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json'
+        }
+      }
+    );
+    
+    const { qr_code_base64, qr_code, id } = response.data;
+    const normalizedId = id.toLowerCase();
+    const pix_copia_cola = qr_code;
+    
+    console.log(`✅ Token ${normalizedId} salvo no banco com valor ${valorCentavos}`);
+
+    db.prepare(`
+      INSERT INTO tokens (token, valor, status, telegram_id, utm_source, utm_campaign, utm_medium)
+      VALUES (?, ?, 'pendente', ?, ?, ?, ?)
+    `).run(normalizedId, valorCentavos, telegram_id, utm_source, utm_campaign, utm_medium);
+
+    res.json({
+      qr_code_base64,
+      qr_code,
+      pix_copia_cola: pix_copia_cola || qr_code,
+      transacao_id: normalizedId
+    });
+  } catch (error) {
+    console.error("❌ Erro ao gerar cobrança:", error.response?.data || error.message);
+    res.status(500).json({
+      error: 'Erro ao gerar cobrança na API PushinPay.',
+      detalhes: error.response?.data || error.message
+    });
+  }
+};
+
+// Webhook do PushinPay
+const webhookPushinPay = async (req, res) => {
+  try {
+    console.log('📨 Webhook recebido:', req.body);
+
+    const payload = req.body;
+    const { id, status } = payload || {};
+    
+    const normalizedId = id ? id.toLowerCase() : null;
+    
+    if (!normalizedId || status !== 'paid') return res.sendStatus(200);
+
+    const row = db.prepare('SELECT * FROM tokens WHERE token = ?').get(normalizedId);
+
+    if (!row) {
+      console.log('❌ Token não encontrado no banco:', normalizedId);
+      return res.status(400).send('Transação não encontrada');
+    }
+
+    const novoToken = uuidv4();
+    
+    db.prepare(`
+      UPDATE tokens
+      SET token_uuid = ?,
+          status = 'valido', 
+          criado_em = CURRENT_TIMESTAMP
+      WHERE token = ?
+    `).run(novoToken, normalizedId);
+// Salvar token também no PostgreSQL para o sistema web
+        try {
+      await postgres.executeQuery(
+        pgPool,
+        'INSERT INTO tokens (token, valor) VALUES ($1, $2)',
+        [novoToken, (row.valor || 0) / 100]
+      );
+      console.log('✅ Token registrado no PostgreSQL:', novoToken);
+    } catch (pgErr) {
+      console.error('❌ Erro ao registrar token no PostgreSQL:', pgErr.message);
+    }
+
+    if (row.telegram_id) {
+      const tgId = normalizeTelegramId(row.telegram_id);
+      if (tgId !== null) {
+        try {
+          await postgres.executeQuery(
+            pgPool,
+            'UPDATE downsell_progress SET pagou = 1 WHERE telegram_id = $1',
+            [tgId]
+          );
+          console.log(`✅ Usuário ${tgId} marcado como "pagou"`);
+        } catch (pgErr) {
+          console.error('❌ Erro ao atualizar status de pagamento no PostgreSQL:', pgErr.message);
+        }
+      } else {
+        console.warn(`⚠️ telegram_id inválido: ${row.telegram_id}`);
+      }
+    }
+
+    if (row.telegram_id && bot) {
+      const valorReais = (row.valor / 100).toFixed(2);
+      const linkComToken = `${FRONTEND_URL}/obrigado.html?token=${novoToken}&valor=${valorReais}&redirect=${REDIRECT_KEY}`;
+      
+      await bot.sendMessage(row.telegram_id, 
+        `🎉 <b>Pagamento aprovado!</b>\n\n💰 Valor: R$ ${valorReais}\n🔗 Acesse seu conteúdo: ${linkComToken}`, 
+        { parse_mode: 'HTML' }
+      );
+    }
+    
+    res.sendStatus(200);
+  } catch (err) {
+    console.error('❌ Erro no webhook:', err.message);
+    res.sendStatus(500);
+  }
+};
+
+// Comando /start
+if (bot) {
+  bot.onText(/\/start/, async (msg) => {
+    const chatId = msg.chat.id;
+    
+    try {
+      console.log(`📱 Comando /start recebido de ${chatId}`);
+      
+      // Enviar todas as mídias iniciais disponíveis
+      await enviarMidiasHierarquicamente(chatId, config.midias.inicial);
+
+      // Enviar texto inicial
+      await bot.sendMessage(chatId, config.inicio.textoInicial, { parse_mode: 'HTML' });
+
+      // Enviar menu inicial
+      await bot.sendMessage(chatId, config.inicio.menuInicial.texto, {
+        reply_markup: {
+          inline_keyboard: config.inicio.menuInicial.opcoes.map(opcao => [{
+            text: opcao.texto,
+            callback_data: opcao.callback
+          }])
+        }
+      });
+
+      // Registrar usuário no banco de dados PostgreSQL
+      try {
+        const existeRes = await postgres.executeQuery(
+          pgPool,
+          'SELECT telegram_id FROM downsell_progress WHERE telegram_id = $1',
+          [chatId]
+        );
+
+        if (existeRes.rows.length === 0) {
+          await postgres.executeQuery(
+            pgPool,
+            'INSERT INTO downsell_progress (telegram_id, index_downsell, last_sent_at) VALUES ($1, $2, NULL)',
+            [chatId, 0]
+          );
+        }
+      } catch (pgErr) {
+        console.error('❌ Erro ao registrar usuário no PostgreSQL:', pgErr.message);
+      }
+
+
+
+      console.log(`✅ Resposta enviada para ${chatId}`);
+    } catch (error) {
+      console.error('❌ Erro no comando /start:', error);
+      
+      // Enviar mensagem de erro amigável
+      try {
+        await bot.sendMessage(chatId, config.erros?.erroGenerico || '❌ Ocorreu um erro. Tente novamente.');
+      } catch (e) {
+        console.error('❌ Erro ao enviar mensagem de erro:', e);
+      }
+    }
+  });
+
+  // Tratamento dos botões
+  bot.on('callback_query', async (query) => {
+    const chatId = query.message.chat.id;
+    const data = query.data;
+    
+    try {
+      console.log(`🔘 Callback recebido: ${data} de ${chatId}`);
+      
+      if (data === 'mostrar_planos') {
+        const botoesPlanos = config.planos.map(plano => ([{
+          text: `${plano.emoji} ${plano.nome} — por R$${plano.valor.toFixed(2)}`,
+          callback_data: plano.id
+        }]));
+        return bot.sendMessage(chatId, '💖 Escolha seu plano abaixo:', {
+          reply_markup: { inline_keyboard: botoesPlanos }
+        });
+      }
+
+      if (data === 'ver_previas') {
+        return bot.sendMessage(chatId, `🙈 <b>Prévias:</b>\n\n💗 Acesse nosso canal:\n👉 ${config.canalPrevias}`, {
+          parse_mode: 'HTML'
+        });
+      }
+
+      // Verificar pagamento
+      if (data.startsWith('verificar_pagamento_')) {
+        const transacaoId = data.replace('verificar_pagamento_', '');
+
+        const tokenRow = db.prepare(`
+          SELECT token_uuid, status, valor, telegram_id FROM tokens
+          WHERE token = ?
+          LIMIT 1
+        `).get(transacaoId);
+
+        if (!tokenRow) {
+          return bot.sendMessage(chatId, '❌ Pagamento não encontrado.');
+        }
+
+        if (tokenRow.status !== 'valido' || !tokenRow.token_uuid) {
+          return bot.sendMessage(chatId, config.pagamento.pendente);
+        }
+
+        try {
+          const tgId = normalizeTelegramId(chatId);
+          if (tgId !== null) {
+            await postgres.executeQuery(
+              pgPool,
+              'UPDATE downsell_progress SET pagou = 1 WHERE telegram_id = $1',
+              [tgId]
+            );
+          } else {
+            console.warn(`⚠️ telegram_id inválido ao atualizar pagamento: ${chatId}`);
+          }
+        } catch (pgErr) {
+          console.error('❌ Erro ao atualizar pagamento no PostgreSQL:', pgErr.message);
+        }
+
+        const valorReais = (tokenRow.valor / 100).toFixed(2);
+        const linkComToken = `${FRONTEND_URL}/obrigado.html?token=${tokenRow.token_uuid}&valor=${valorReais}&redirect=${REDIRECT_KEY}`;
+        
+        await bot.sendMessage(chatId, config.pagamento.aprovado);
+        await bot.sendMessage(chatId, `<b>🎉 Pagamento aprovado!</b>\n\n🔗 Acesse: ${linkComToken}`, {
+          parse_mode: 'HTML'
+        });
+
+        return;
+      }
+
+      // Processar compra de plano principal ou downsell
+      let plano = config.planos.find(p => p.id === data);
+
+      if (!plano) {
+        for (const ds of config.downsells) {
+          const p = ds.planos.find(pl => pl.id === data);
+          if (p) {
+            plano = { ...p };
+            plano.valor = p.valorComDesconto;
+            console.log(`📦 Geração de cobrança para plano ${p.nome} (R$${p.valorComDesconto})`);
+            break;
+          }
+        }
+      }
+
+      if (!plano) {
+        console.log(`⚠️ Plano não encontrado para callback: ${data}`);
+      }
+
+      if (plano) {
+        if (!plano.valor && plano.valorComDesconto) {
+          plano.valor = plano.valorComDesconto;
+        }
+
+        const resposta = await axios.post(`${BASE_URL}/api/gerar-cobranca`, {
+          telegram_id: chatId,
+          plano: plano.nome,
+          valor: plano.valor,
+          utm_source: 'telegram',
+          utm_campaign: 'bot_principal',
+          utm_medium: 'telegram_bot'
+        });
+
+        const { qr_code_base64, pix_copia_cola, transacao_id } = resposta.data;
+        
+        let buffer;
+        if (qr_code_base64) {
+          const base64Image = qr_code_base64.replace(/^data:image\/png;base64,/, '');
+          const imageBuffer = Buffer.from(base64Image, 'base64');
+          buffer = await processarImagem(imageBuffer);
+        }
+
+        const legenda = config.mensagemPix(plano.nome, plano.valor, pix_copia_cola);
+        
+        if (buffer) {
+          await bot.sendPhoto(chatId, buffer, {
+            caption: legenda,
+            parse_mode: 'HTML',
+            reply_markup: {
+              inline_keyboard: [
+                [{ text: '✅ Verificar Status', callback_data: `verificar_pagamento_${transacao_id}` }]
+              ]
+            }
+          });
+        } else {
+          await bot.sendMessage(chatId, legenda, {
+            parse_mode: 'HTML',
+            reply_markup: {
+              inline_keyboard: [
+                [{ text: '✅ Verificar Status', callback_data: `verificar_pagamento_${transacao_id}` }]
+              ]
+            }
+          });
+        }
+      }
+    } catch (error) {
+      console.error('❌ Erro ao processar callback:', error);
+      
+      try {
+        await bot.sendMessage(chatId, config.erros?.erroGenerico || '❌ Ocorreu um erro. Tente novamente.');
+      } catch (e) {
+        console.error('❌ Erro ao enviar mensagem de erro:', e);
+      }
+    }
+  });
+}
+
+console.log('✅ Bot configurado e rodando');
+
+// Função para enviar downsells automaticamente
+async function enviarDownsells(targetId = null) {
+  const flagKey = targetId || 'GLOBAL';
+  if (processingDownsells.get(flagKey)) {
+    console.log(`⚠️ Processamento de downsells já em andamento para ${flagKey}`);
+    return;
+  }
+  processingDownsells.set(flagKey, true);
+
+  try {
+    console.log('🟢 Iniciando processo de downsells...');
+
+    // Buscar usuários que ainda não pagaram no PostgreSQL
+    let usuariosRes;
+    if (targetId) {
+      usuariosRes = await postgres.executeQuery(
+        pgPool,
+        'SELECT telegram_id, index_downsell, last_sent_at FROM downsell_progress WHERE pagou = 0 AND telegram_id = $1',
+        [targetId]
+      );
+    } else {
+      usuariosRes = await postgres.executeQuery(
+        pgPool,
+        'SELECT telegram_id, index_downsell, last_sent_at FROM downsell_progress WHERE pagou = 0'
+      );
+    }
+    const usuarios = usuariosRes.rows;
+
+    console.log('📂 Conteúdo da tabela downsell_progress:', usuarios);
+    console.log(`📊 Encontrados ${usuarios.length} usuários para processar`);
+
+    for (const usuario of usuarios) {
+      const { telegram_id, index_downsell, last_sent_at } = usuario;
+      console.log(`🔎 Verificando usuário ${telegram_id}`);
+
+      // Verificar se ainda há downsells para enviar
+      if (index_downsell >= config.downsells.length) {
+        console.log(`⏭️ Usuário ${telegram_id} já recebeu todos os downsells`);
+        continue;
+      }
+
+      // Respeitar intervalo de 5 minutos entre cada downsell
+      if (last_sent_at) {
+        const diff = Date.now() - new Date(last_sent_at).getTime();
+        if (diff < 5 * 60 * 1000) {
+          console.log(
+            `⏱️ Usuário ${telegram_id} ainda não completou o intervalo de 5 minutos`
+          );
+          continue;
+        }
+      }
+      
+      const downsell = config.downsells[index_downsell];
+      
+      if (!downsell) {
+        console.log(`⚠️ Downsell não encontrado para índice ${index_downsell}`);
+        continue;
+      }
+      
+      try {
+        const envioTimestamp = new Date().toISOString();
+        console.log(`📤 Enviando downsell ${index_downsell} para usuário ${telegram_id} (\u{1F551} ${envioTimestamp})`);
+        
+        // Enviar mídias do downsell na ordem correta
+        await enviarMidiasHierarquicamente(
+          telegram_id,
+          config.midias.downsells[downsell.id] || {}
+        );
+        
+        // Preparar botões inline se existirem
+        let replyMarkup = null;
+        if (downsell.planos && downsell.planos.length > 0) {
+          const botoes = downsell.planos.map(plano => [{
+            text: `${plano.emoji} ${plano.nome} — R$${plano.valorComDesconto.toFixed(2)}`,
+            callback_data: plano.id
+          }]);
+          
+          replyMarkup = { inline_keyboard: botoes };
+        }
+        
+        // Enviar texto do downsell
+        await bot.sendMessage(telegram_id, downsell.texto, {
+          parse_mode: 'HTML',
+          reply_markup: replyMarkup
+        });
+        console.log(`📨 Mensagem enviada para ${telegram_id}`);
+        
+        // Atualizar índice e timestamp do downsell no PostgreSQL
+        try {
+          await postgres.executeQuery(
+            pgPool,
+            'UPDATE downsell_progress SET index_downsell = $1, last_sent_at = NOW() WHERE telegram_id = $2',
+            [index_downsell + 1, telegram_id]
+          );
+        } catch (pgErr) {
+          console.error(`❌ Erro ao atualizar indice do downsell para ${telegram_id}:`, pgErr.message);
+        }
+        
+        console.log(`✅ Downsell enviado com sucesso para ${telegram_id} em ${envioTimestamp}`);
+        
+        // Pequena pausa entre envios para evitar rate limiting
+        await new Promise(resolve => setTimeout(resolve, 5000));
+        
+      } catch (error) {
+        console.error(`❌ Erro ao enviar downsell para ${telegram_id}:`, error.message);
+      }
+    }
+    
+
+  } catch (error) {
+    console.error('❌ Erro geral na função enviarDownsells:', error.message);
+  } finally {
+    processingDownsells.delete(flagKey);
+  }
+}
+
+// Envio sequencial de downsells para um único usuário
+async function enviarDownsell(chatId) {
+  try {
+    const progressoRes = await postgres.executeQuery(
+      pgPool,
+      'SELECT index_downsell FROM downsell_progress WHERE telegram_id = $1',
+      [chatId]
+    );
+    const progresso = progressoRes.rows[0] || { index_downsell: 0 };
+
+    const idx = progresso.index_downsell;
+    const lista = config.downsells;
+
+    // Se o usuário já recebeu todos os downsells, apenas sair
+    if (idx >= lista.length) {
+      return;
+    }
+
+    const downsell = lista[idx];
+    if (!downsell) {
+      console.warn(`⚠️ Downsell não encontrado para índice ${idx}`);
+      return;
+    }
+
+    await enviarMidiasHierarquicamente(
+      chatId,
+      config.midias.downsells[downsell.id] || {}
+    );
+
+    let replyMarkup = null;
+    if (downsell.planos && downsell.planos.length > 0) {
+      const botoes = downsell.planos.map(p => [{
+        text: `${p.emoji} ${p.nome} — R$${p.valorComDesconto.toFixed(2)}`,
+        callback_data: p.id
+      }]);
+      replyMarkup = { inline_keyboard: botoes };
+    }
+
+    await bot.sendMessage(chatId, downsell.texto, {
+      parse_mode: 'HTML',
+      reply_markup: replyMarkup
+    });
+
+    await postgres.executeQuery(
+      pgPool,
+      'UPDATE downsell_progress SET index_downsell = $1, last_sent_at = NOW() WHERE telegram_id = $2',
+      [idx + 1, chatId]
+    );
+
+    if (idx + 1 < lista.length) {
+      setTimeout(() => {
+        enviarDownsell(chatId).catch(err =>
+          console.error('❌ Erro no próximo downsell:', err.message)
+        );
+      }, 5 * 60 * 1000);
+    } else {
+      console.log(`✅ Ciclo de downsells concluído para ${chatId}`);
+    }
+  } catch (error) {
+    console.error('❌ Erro na função enviarDownsell:', error.message);
+  }
+}
+
+// Enviar mensagens periódicas
+async function enviarMensagemPeriodica(indice = 0) {
+  const timestamp = new Date().toISOString();
+  console.log(`[${timestamp}] 🚀 Iniciando envio de mensagem periódica`);
+  try {
+    const usuariosRes = await postgres.executeQuery(
+      pgPool,
+      'SELECT telegram_id FROM downsell_progress WHERE pagou = 0'
+    );
+    const usuarios = usuariosRes.rows;
+    console.log(`[${timestamp}] Encontrados ${usuarios.length} usuários`);
+
+    const mensagens = config.mensagensPeriodicas || [];
+    if (mensagens.length === 0) {
+      console.log('⚠️ Nenhuma mensagem periódica configurada');
+      return;
+    }
+    const msg = mensagens[indice % mensagens.length];
+
+    for (const u of usuarios) {
+      const id = u.telegram_id;
+      console.log(`[${new Date().toISOString()}] Enviando para ${id}`);
+      try {
+        if (msg.midia) {
+          let tipo = 'photo';
+          if (msg.midia.endsWith('.mp4')) tipo = 'video';
+          else if (msg.midia.endsWith('.mp3')) tipo = 'audio';
+          await enviarMidiaComFallback(id, tipo, msg.midia);
+          console.log(`[${new Date().toISOString()}] Mídia enviada para ${id}`);
+        }
+
+        const botoes = config.planos.map(p => [{
+          text: `${p.emoji} ${p.nome} — R$${p.valor.toFixed(2)}`,
+          callback_data: p.id
+        }]);
+
+        await bot.sendMessage(id, msg.texto, {
+          parse_mode: 'HTML',
+          reply_markup: { inline_keyboard: botoes }
+        });
+        console.log(`[${new Date().toISOString()}] Texto enviado para ${id}`);
+      } catch (err) {
+        console.error(`[${new Date().toISOString()}] Erro ao enviar para ${id}:`, err.message);
+      }
+
+      await new Promise(r => setTimeout(r, 1000));
+    }
+  } catch (err) {
+    console.error(`[${new Date().toISOString()}] Erro geral no envio periódico:`, err.message);
+  }
+}
+
+// Comando /status
+if (bot) {
+  bot.onText(/\/status/, async (msg) => {
+    const chatId = msg.chat.id;
+    
+    try {
+      const usuarioRes = await postgres.executeQuery(
+        pgPool,
+        'SELECT index_downsell, pagou FROM downsell_progress WHERE telegram_id = $1',
+        [chatId]
+      );
+      const usuario = usuarioRes.rows[0];
+      
+      if (!usuario) {
+        await bot.sendMessage(chatId, '❌ Usuário não encontrado. Use /start primeiro.');
+        return;
+      }
+      
+      const statusPagamento = usuario.pagou === 1 ? 'JÁ PAGOU ✅' : 'NÃO PAGOU ❌';
+      const totalDownsells = config.downsells.length;
+      
+      const mensagem = `
+📊 <b>SEU STATUS:</b>
+
+💰 <b>Pagamento:</b> ${statusPagamento}
+📈 <b>Downsell atual:</b> ${usuario.index_downsell}/${totalDownsells}
+🔄 <b>Próximo downsell:</b> ${usuario.index_downsell >= totalDownsells ? 'Finalizado' : 'Em breve'}
+
+${usuario.pagou === 0 ? '💡 <i>Você receberá ofertas especiais automaticamente!</i>' : '🎉 <i>Obrigado pela sua compra!</i>'}
+      `.trim();
+      
+      await bot.sendMessage(chatId, mensagem, { parse_mode: 'HTML' });
+      
+    } catch (error) {
+      console.error('❌ Erro no comando /status:', error.message);
+      await bot.sendMessage(chatId, '❌ Erro ao verificar status. Tente novamente.');
+    }
+  });
+}
+
+// Comando /resert (reiniciar funil)
+if (bot) {
+  bot.onText(/\/resert/, async (msg) => {
+    const chatId = msg.chat.id;
+    
+    try {
+      // Verificar se o usuário existe no PostgreSQL
+      const usuarioRes = await postgres.executeQuery(
+        pgPool,
+        'SELECT telegram_id FROM downsell_progress WHERE telegram_id = $1',
+        [chatId]
+      );
+      const usuario = usuarioRes.rows[0];
+      
+      if (!usuario) {
+        await bot.sendMessage(chatId, '❌ Usuário não encontrado. Use /start primeiro.');
+        return;
+      }
+      
+      // Resetar o funil no PostgreSQL
+      try {
+        await postgres.executeQuery(
+          pgPool,
+          'UPDATE downsell_progress SET pagou = 0, index_downsell = 0, last_sent_at = NULL WHERE telegram_id = $1',
+          [chatId]
+        );
+      } catch (pgErr) {
+        console.error('❌ Erro ao resetar funil no PostgreSQL:', pgErr.message);
+      }
+      
+      await bot.sendMessage(chatId, `
+🔄 <b>Funil reiniciado com sucesso!</b>
+
+✅ Status de pagamento resetado
+✅ Downsells reiniciados
+📬 Você voltará a receber ofertas automaticamente
+
+💡 <i>Use /status para verificar seu novo status</i>
+      `.trim(), { parse_mode: 'HTML' });
+      
+      console.log(`🔄 Funil reiniciado para usuário ${chatId}`);
+      
+    } catch (error) {
+      console.error('❌ Erro no comando /resert:', error.message);
+      await bot.sendMessage(chatId, '❌ Erro ao reiniciar funil. Tente novamente.');
+    }
+  });
+}
+
+// Configurar execução automática dos downsells a cada 5 minutos (apenas para testes)
+
+
+// Exportar função para uso manual se necessário
+module.exports = {
+  bot,
+  gerarCobranca,
+  webhookPushinPay,
+  gerenciadorMidia,
+  enviarDownsells,
+  enviarDownsell,
+  enviarMensagemPeriodica,
+  TELEGRAM_TOKEN,
+  config,
+  MEU_PERFIL
+};
+

--- a/MODELO1/perfil2/config.js
+++ b/MODELO1/perfil2/config.js
@@ -1,0 +1,412 @@
+const fs = require('fs');
+const path = require('path');
+
+// Configurações das mídias - URLs ou caminhos locais
+const midias = {
+  inicial: {
+    video: '../BOT/midia/inicial.mp4',
+    imagem: '../BOT/midia/inicial.jpg',
+    audio: '../BOT/midia/inicial_audio.mp3'
+  },
+  downsells: {
+    ds1: {
+      video: '../BOT/midia/downsells/ds1.mp4',
+      imagem: '../BOT/midia/downsells/ds1.jpg',
+      audio: '../BOT/midia/downsells/ds1.mp3'
+    },
+    ds2: {
+      video: '../BOT/midia/downsells/ds2.mp4',
+      imagem: '../BOT/midia/downsells/ds2.jpg',
+      audio: '../BOT/midia/downsells/ds2.mp3'
+    },
+    ds3: {
+      video: '../BOT/midia/downsells/ds3.mp4',
+      imagem: '../BOT/midia/downsells/ds3.jpg',
+      audio: '../BOT/midia/downsells/ds3.mp3'
+    },
+    ds4: {
+      video: '../BOT/midia/downsells/ds4.mp4',
+      imagem: '../BOT/midia/downsells/ds4.jpg',
+      audio: '../BOT/midia/downsells/ds4.mp3'
+    },
+    ds5: {
+      video: '../BOT/midia/downsells/ds5.mp4',
+      imagem: '../BOT/midia/downsells/ds5.jpg',
+      audio: '../BOT/midia/downsells/ds5.mp3'
+    },
+    ds6: {
+      video: '../BOT/midia/downsells/ds6.mp4',
+      imagem: '../BOT/midia/downsells/ds6.jpg',
+      audio: '../BOT/midia/downsells/ds6.mp3'
+    },
+    ds7: {
+      video: '../BOT/midia/downsells/ds7.mp4',
+      imagem: '../BOT/midia/downsells/ds7.jpg',
+      audio: '../BOT/midia/downsells/ds7.mp3'
+    },
+    ds8: {
+      video: '../BOT/midia/downsells/ds8.mp4',
+      imagem: '../BOT/midia/downsells/ds8.jpg',
+      audio: '../BOT/midia/downsells/ds8.mp3'
+    },
+    ds9: {
+      video: '../BOT/midia/downsells/ds9.mp4',
+      imagem: '../BOT/midia/downsells/ds9.jpg',
+      audio: '../BOT/midia/downsells/ds9.mp3'
+    },
+    ds10: {
+      video: '../BOT/midia/downsells/ds10.mp4',
+      imagem: '../BOT/midia/downsells/ds10.jpg',
+      audio: '../BOT/midia/downsells/ds10.mp3'
+    },
+    ds11: {
+      video: '../BOT/midia/downsells/ds11.mp4',
+      imagem: '../BOT/midia/downsells/ds11.jpg',
+      audio: '../BOT/midia/downsells/ds11.mp3'
+    },
+    ds12: {
+      video: '../BOT/midia/downsells/ds12.mp4',
+      imagem: '../BOT/midia/downsells/ds12.jpg',
+      audio: '../BOT/midia/downsells/ds12.mp3'
+    }
+  }
+};
+
+// Função para verificar se o arquivo existe
+function verificarMidia(caminhoMidia) {
+  if (!caminhoMidia) return false;
+  
+  // Se for URL, assumir que existe
+  if (caminhoMidia.startsWith('http')) {
+    return true;
+  }
+  
+  // Se for arquivo local, verificar se existe
+  try {
+    return fs.existsSync(caminhoMidia);
+  } catch (error) {
+    console.warn(`⚠️ Erro ao verificar mídia ${caminhoMidia}:`, error.message);
+    return false;
+  }
+}
+
+// Função para obter mídia baseada no tipo
+function obterMidia(tipo, indice = null) {
+  if (tipo === 'inicial') {
+    return midias.inicial;
+  }
+  
+  if (tipo === 'downsell' && indice) {
+    return midias.downsells[indice];
+  }
+  
+  return null;
+}
+
+// Função para obter o melhor tipo de mídia disponível
+function obterMelhorMidia(tipo, indice = null) {
+  const midiasDisponiveis = obterMidia(tipo, indice);
+  
+  if (!midiasDisponiveis) return null;
+  
+  // Prioridade: video > imagem > audio
+  const prioridade = ['video', 'imagem', 'audio'];
+  
+  for (const tipoMidia of prioridade) {
+    const caminhoMidia = midiasDisponiveis[tipoMidia];
+    if (verificarMidia(caminhoMidia)) {
+      return {
+        tipo: tipoMidia,
+        caminho: caminhoMidia
+      };
+    }
+  }
+  
+  return null;
+}
+
+// Configuração do início
+const inicio = {
+  tipoMidia: 'video', // 'video', 'imagem', 'audio' ou null
+  textoInicial: `
+😈 <b>Olá, titio! Aqui é o perfil 2 👅</b>
+
+Que delícia ter você aqui no meu quartinho…  
+Já tava te esperando, sabia? Tô morrendo de vontade de te mostrar umas coisinhas que só quem entra aqui consegue ver… 😘
+
+🎀 <b>Aqui você vai encontrar meus vídeos mais íntimos — só meus, só pra você.</b>
+
+💌 E se quiser algo mais especial… mais safadinho, é só me chamar. Eu adoro quando o titio pede as coisas do jeitinho dele…
+
+<b>Mas cuidado, viu?</b>  
+Quem entra no meu quartinho nunca mais quer sair. Lá dentro, tudo fica mais quente… mais profundo… mais nosso. 🔥
+
+✨ Talvez esse seja só o primeiro passo...  
+Pra você me conhecer de um jeitinho que ninguém mais conhece.
+
+<b>Vem… a sobrinha aqui tá prontinha pra te mimar, titio.</b> 😏💖
+  `.trim(),
+  menuInicial: {
+    texto: '✨ Escolhe como quer brincar comigo hoje, titio...\nUma espiadinha... ou vem de vez? 😉👇',
+    opcoes: [
+      { texto: 'Acessar Agora', callback: 'mostrar_planos' },
+      { texto: 'Prévias da sobrinha 💗🙈', callback: 'ver_previas' }
+    ]
+  }
+};
+
+// Configuração dos planos
+const planos = [
+  {
+    id: 'plano_semanal',
+    nome: 'Semanal',
+    emoji: '💋',
+    valor: 17.90,
+    descricao: 'Acesso por 7 dias'
+  },
+  {
+    id: 'plano_mensal',
+    nome: 'Mensal',
+    emoji: '🔥',
+    valor: 19.90,
+    descricao: 'Acesso por 30 dias'
+  }
+];
+
+// Configuração dos downsells
+const downsells = [
+  {
+    id: 'ds1',
+    emoji: '💗',
+    texto: 'Oie Titio, percebi que você não finalizou a sua assinatura 😢\n\n💗 Entra pro meu grupinho VIP agora, e vem vê sua sobrinha de um jeito que você nunca viu 🙈',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds1_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 17.90 },
+      { id: 'ds1_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 19.90 }
+    ]
+  },
+  {
+    id: 'ds2',
+    emoji: '💗',
+    texto: 'Oie Titio, percebi que você não finalizou a sua assinatura...\n\n💗 Pra te dar um incentivo, estou te dando 10% de desconto pra entrar agora pro meu grupinho VIP 😈\n\nVem vê sua sobrinha de um jeitinho que você nunca viu... 😏',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds2_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 16.11 },
+      { id: 'ds2_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 17.91 }
+    ]
+  },
+  {
+    id: 'ds3',
+    emoji: '💦',
+    texto: 'Oiee titio, já veio gozar pra sua ninfetinha hoje?\n\n💦 Vi que gerou o PIX mas não pagou, então liberei um desconto exclusivo + PRESENTINHO só pra você (não conta pra ninguém, tá?)\n\nMas corre, o desconto acaba a qualquer momento! ⏬',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds3_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 17.00 },
+      { id: 'ds3_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 18.90 }
+    ]
+  },
+  {
+    id: 'ds4',
+    emoji: '💋',
+    texto: '💋 QUANTO TEMPO VAI ME IGNORAR? 💋\n\nVocê já me espiou antes… Agora é hora de entrar e ver TUDO sem censura! 😈\n\nSe entrar agora, ainda ganha um brinde no privado... Não vou contar o que é 😏',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds4_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 17.00 },
+      { id: 'ds4_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 18.90 }
+    ]
+  },
+  {
+    id: 'ds5',
+    emoji: '💋',
+    texto: 'Titio, você deixou a loirinha aqui esperando...\n\nFiquei molhadinha te imaginando vendo meus vídeos 💋\n\nPra te conquistar: desconto liberado + presentinho do jeitinho que você gosta 😘',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds5_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 16.11 },
+      { id: 'ds5_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 17.91 }
+    ]
+  },
+  {
+    id: 'ds6',
+    emoji: '😈',
+    texto: 'Oie titio, olha só...\n\nLiberei uma promoção secreta só pra você: desconto + bônus extra que ninguém mais vai ganhar 😈\n\nMas não conta pra ninguém... minha calcinha tá te esperando no VIP 💦',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds6_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 15.21 },
+      { id: 'ds6_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 16.91 }
+    ]
+  },
+  {
+    id: 'ds7',
+    emoji: '🥵',
+    texto: 'Já imaginou abrir o grupo e dar de cara comigo peladinha? 😳\n\nAgora imagina isso com um desconto especial + presentinho só seu? 🥵\n\nMas tem que correr, hein? Não vou deixar isso aberto por muito tempo!',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds7_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 15.21 },
+      { id: 'ds7_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 16.91 }
+    ]
+  },
+  {
+    id: 'ds8',
+    emoji: '😈',
+    texto: 'Titio... voltei só pra dizer:\n\nSe pagar agora, além de entrar no meu VIP, vai ganhar um mimo pessoal e um descontinho safado ❤️\n\nSó não demora… ou a oferta some... e eu também 😈',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds8_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 14.32 },
+      { id: 'ds8_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 15.92 }
+    ]
+  },
+  {
+    id: 'ds9',
+    emoji: '😳',
+    texto: 'Tô liberando um código secreto...\n\nPra quem travou no final 😳\n\nDesconto ativado + conteúdo surpresa picante liberado. Só pra você, mas só por hoje, viu?',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds9_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 14.32 },
+      { id: 'ds9_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 15.92 }
+    ]
+  },
+  {
+    id: 'ds10',
+    emoji: '🖤',
+    texto: 'Vi seu nome na lista de quem quase entrou…\n\nMe deixou com vontade de te recompensar 😘\n\nLiberei 25% OFF + vídeo exclusivo surpresa. Mas só até eu cansar de esperar 🖤',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds10_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 13.42 },
+      { id: 'ds10_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 14.92 }
+    ]
+  },
+  {
+    id: 'ds11',
+    emoji: '💦',
+    texto: 'Oieee… sua ninfetinha loira tá aqui te esperando, sabia?\n\nVi que gerou o PIX e sumiu 🙈\n\nEntão toma: descontinho + surpresinha só pra você terminar logo essa sacanagem toda 💦',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds11_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 13.42 },
+      { id: 'ds11_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 14.92 }
+    ]
+  },
+  {
+    id: 'ds12',
+    emoji: '😭',
+    texto: 'Titio, vai me deixar assim?\n\nCom a calcinha molhada e o grupo fechado? 😭\n\nAproveita: desconto + conteúdo extra surpresa liberado AGORA\n\nMas corre… porque eu enjoo rápido.',
+    tipoMidia: 'video',
+    planos: [
+      { id: 'ds12_semanal', nome: 'Semanal', emoji: '💋', valorOriginal: 17.90, valorComDesconto: 12.53 },
+      { id: 'ds12_mensal', nome: 'Mensal', emoji: '🔥', valorOriginal: 19.90, valorComDesconto: 13.93 }
+    ]
+  }
+];
+
+// Mensagens periódicas
+const mensagensPeriodicas = [
+  {
+    midia: '../BOT/midia/periodica1.jpg',
+    texto: `Por apenas 19,90 você vai ter acesso a:
+🔥 Mais de 450 fotos e vídeos
+🔥 Sexo, boquete, anal ménage
+🔥 Vídeo chamada gratuita
+🔥 Live sem roupa toda noite
+🔥 Sorteio pra gravar comigo
+👇🏻ESTOU TE ESPERANDO AQUI👇🏻`
+  },
+  {
+    midia: '../BOT/midia/periodica2.mp4',
+    texto: `SÓ 19,90 🎁
+Isso mesmo safadinho, liberei meu VIP (e meu cuzinho) por apenas 19,90 😍
+Corre lá pra ver tudinho e gozar bem gostoso pra sua putinha preferida👇🏻`
+  },
+  {
+    midia: '../BOT/midia/periodica3.jpg',
+    texto: `✨ 20 REAIS ✨
+É o precinho para entrar no meu grupinho agora e se deliciar com meus vídeos já de manhã, para começar o dia jogando leitinho para fora bem gostoso. Vira macho e aperta o botão agora.`
+  }
+];
+
+const horariosEnvioPeriodico = [
+  '0 8 * * *',
+  '0 11 * * *',
+  '0 18 * * *',
+  '0 20 * * *',
+  '0 23 * * *'
+];
+
+// Outras configurações
+const canalPrevias = 'https://t.me/+B9dEZHITEM1iYzMx';
+
+// Configurações de pagamento
+const pagamento = {
+  pendente: '⏳ O pagamento ainda não foi identificado. Aguarde alguns instantes e clique novamente.',
+  aprovado: '✅ Pagamento confirmado com sucesso!\n\n🔓 Aqui está seu acesso ao conteúdo:',
+  link: '👉 https://t.me/+UEmVhhccVMw3ODcx',
+  expirado: '❌ Este QR Code expirou. Por favor, gere uma nova cobrança.',
+  erro: '❌ Erro ao verificar status do pagamento. Tente novamente em alguns instantes.'
+};
+
+// Configurações de erro
+const erros = {
+  erroGenerico: '❌ <b>Ops! Algo deu errado.</b>\n\n🔄 Tente novamente em alguns instantes.',
+  pagamentoNaoEncontrado: '❌ <b>Pagamento não encontrado.</b>\n\n💡 Verifique se o pagamento foi realizado corretamente.',
+  midiaIndisponivel: '❌ <b>Mídia temporariamente indisponível.</b>\n\n🔄 Tente novamente em alguns instantes.'
+};
+
+// Função para formatar valor em centavos
+function formatarValorCentavos(valor) {
+  const numerico = Number(String(valor).replace(',', '.').trim());
+  return Math.round((numerico + Number.EPSILON) * 100);
+}
+
+// Função para gerar mensagem PIX
+function mensagemPix(nome, valor, pixCopiaCola) {
+  return `
+🌟 <b>Você selecionou o seguinte plano:</b>
+
+🎁 <b>Plano:</b> ${nome}
+💰 <b>Valor:</b> R$${valor.toFixed(2)}
+
+💠 <b>Pague via Pix Copia e Cola (ou QR Code em alguns bancos):</b>
+
+<pre>${pixCopiaCola}</pre>
+
+📌 <b>Toque na chave PIX acima para copiá-la</b>
+❗ Após o pagamento, clique no botão abaixo para verificar o status:
+  `.trim();
+}
+
+// Função para obter downsell por ID
+function obterDownsellPorId(id) {
+  return downsells.find(ds => ds.id === id);
+}
+
+// Função para obter plano por ID
+function obterPlanoPorId(id) {
+  // Procura nos planos principais
+  let plano = planos.find(p => p.id === id);
+  if (plano) return plano;
+  
+  // Procura nos planos de downsells
+  for (const downsell of downsells) {
+    plano = downsell.planos.find(p => p.id === id);
+    if (plano) return plano;
+  }
+  
+  return null;
+}
+
+module.exports = {
+  inicio,
+  planos,
+  downsells,
+  canalPrevias,
+  pagamento,
+  erros,
+  midias,
+  verificarMidia,
+  obterMidia,
+  obterMelhorMidia,
+  formatarValorCentavos,
+  mensagemPix,
+  obterDownsellPorId,
+  obterPlanoPorId,
+  mensagensPeriodicas,
+  horariosEnvioPeriodico
+};

--- a/MODELO1/perfil2/utils/midia.js
+++ b/MODELO1/perfil2/utils/midia.js
@@ -1,0 +1,354 @@
+const fs = require('fs');
+const path = require('path');
+const { midias } = require('../config');
+
+/**
+ * Classe para gerenciar mídias do bot
+ */
+class GerenciadorMidia {
+  constructor() {
+    this.baseDir = path.join(__dirname, '..');
+    this.midiaDir = path.join(this.baseDir, '../BOT/midia');
+    this.downsellDir = path.join(this.midiaDir, 'downsells');
+    
+    // Criar diretórios se não existirem
+    this.criarDiretorios();
+  }
+
+  /**
+   * Criar diretórios necessários
+   */
+  criarDiretorios() {
+    try {
+      if (!fs.existsSync(this.midiaDir)) {
+        fs.mkdirSync(this.midiaDir, { recursive: true });
+        console.log('📁 Diretório midia/ criado');
+      }
+      
+      if (!fs.existsSync(this.downsellDir)) {
+        fs.mkdirSync(this.downsellDir, { recursive: true });
+        console.log('📁 Diretório midia/downsells/ criado');
+      }
+    } catch (error) {
+      console.error('❌ Erro ao criar diretórios:', error);
+    }
+  }
+
+  /**
+   * Verificar se uma mídia existe
+   */
+  verificarMidia(caminhoMidia) {
+    if (!caminhoMidia) return false;
+    
+    // Se for URL, assumir que existe
+    if (caminhoMidia.startsWith('http')) {
+      return true;
+    }
+    
+    // Resolver caminho absoluto
+    const caminhoAbsoluto = path.resolve(this.baseDir, caminhoMidia);
+    
+    try {
+      return fs.existsSync(caminhoAbsoluto);
+    } catch (error) {
+      console.warn(`⚠️ Erro ao verificar mídia ${caminhoMidia}:`, error.message);
+      return false;
+    }
+  }
+
+  /**
+   * Obter mídia inicial
+   */
+  obterMidiaInicial() {
+    const midiasIniciais = midias.inicial;
+    
+    // Verificar na ordem de prioridade: video > imagem > audio
+    if (this.verificarMidia(midiasIniciais.video)) {
+      return {
+        tipo: 'video',
+        caminho: midiasIniciais.video
+      };
+    }
+    
+    if (this.verificarMidia(midiasIniciais.imagem)) {
+      return {
+        tipo: 'photo',
+        caminho: midiasIniciais.imagem
+      };
+    }
+    
+    if (this.verificarMidia(midiasIniciais.audio)) {
+      return {
+        tipo: 'audio',
+        caminho: midiasIniciais.audio
+      };
+    }
+    
+    return null;
+  }
+
+  /**
+   * Obter mídia de downsell
+   */
+  obterMidiaDownsell(downsellId) {
+    if (!midias.downsells[downsellId]) {
+      console.warn(`⚠️ Downsell ${downsellId} não encontrado nas configurações`);
+      return null;
+    }
+    
+    const midiasDownsell = midias.downsells[downsellId];
+    
+    // Verificar na ordem de prioridade: video > imagem > audio
+    if (this.verificarMidia(midiasDownsell.video)) {
+      return {
+        tipo: 'video',
+        caminho: midiasDownsell.video
+      };
+    }
+    
+    if (this.verificarMidia(midiasDownsell.imagem)) {
+      return {
+        tipo: 'photo',
+        caminho: midiasDownsell.imagem
+      };
+    }
+    
+    if (this.verificarMidia(midiasDownsell.audio)) {
+      return {
+        tipo: 'audio',
+        caminho: midiasDownsell.audio
+      };
+    }
+    
+    return null;
+  }
+
+  /**
+   * Obter stream da mídia
+   */
+  obterStreamMidia(caminhoMidia) {
+    if (!caminhoMidia) return null;
+    
+    // Se for URL, retornar a URL diretamente
+    if (caminhoMidia.startsWith('http')) {
+      return caminhoMidia;
+    }
+    
+    // Resolver caminho absoluto
+    const caminhoAbsoluto = path.resolve(this.baseDir, caminhoMidia);
+    
+    try {
+      if (fs.existsSync(caminhoAbsoluto)) {
+        return fs.createReadStream(caminhoAbsoluto);
+      }
+    } catch (error) {
+      console.error(`❌ Erro ao criar stream da mídia ${caminhoMidia}:`, error);
+    }
+    
+    return null;
+  }
+
+  /**
+   * Listar mídias disponíveis
+   */
+  listarMidiasDisponiveis() {
+    const relatorio = {
+      inicial: {},
+      downsells: {}
+    };
+
+    console.log('\n📋 RELATÓRIO DE MÍDIAS DISPONÍVEIS:');
+    console.log('================================');
+
+    // Verificar mídias iniciais
+    console.log('\n🎬 MÍDIA INICIAL:');
+    for (const [tipo, caminho] of Object.entries(midias.inicial)) {
+      const existe = this.verificarMidia(caminho);
+      relatorio.inicial[tipo] = existe;
+      console.log(`  ${tipo}: ${existe ? '✅' : '❌'} ${caminho}`);
+    }
+
+    // Verificar mídias de downsells
+    console.log('\n🔄 MÍDIAS DE DOWNSELLS:');
+    for (const [dsId, midiasDs] of Object.entries(midias.downsells)) {
+      console.log(`\n  ${dsId.toUpperCase()}:`);
+      relatorio.downsells[dsId] = {};
+      
+      for (const [tipo, caminho] of Object.entries(midiasDs)) {
+        const existe = this.verificarMidia(caminho);
+        relatorio.downsells[dsId][tipo] = existe;
+        console.log(`    ${tipo}: ${existe ? '✅' : '❌'} ${caminho}`);
+      }
+    }
+
+    console.log('\n================================\n');
+    return relatorio;
+  }
+
+  /**
+   * Verificar integridade de todas as mídias
+   */
+  verificarIntegridade() {
+    const relatorio = this.listarMidiasDisponiveis();
+    let totalMidias = 0;
+    let midiasDisponiveis = 0;
+
+    // Contar mídias iniciais
+    for (const existe of Object.values(relatorio.inicial)) {
+      totalMidias++;
+      if (existe) midiasDisponiveis++;
+    }
+
+    // Contar mídias de downsells
+    for (const downsell of Object.values(relatorio.downsells)) {
+      for (const existe of Object.values(downsell)) {
+        totalMidias++;
+        if (existe) midiasDisponiveis++;
+      }
+    }
+
+    const porcentagem = totalMidias > 0 ? (midiasDisponiveis / totalMidias * 100).toFixed(1) : 0;
+
+    console.log(`📊 RESUMO: ${midiasDisponiveis}/${totalMidias} mídias disponíveis (${porcentagem}%)`);
+
+    return {
+      total: totalMidias,
+      disponivel: midiasDisponiveis,
+      porcentagem: parseFloat(porcentagem),
+      relatorio
+    };
+  }
+
+  /**
+   * Obter informações detalhadas de uma mídia
+   */
+  obterInfoMidia(caminhoMidia) {
+    if (!caminhoMidia) return null;
+
+    // Se for URL
+    if (caminhoMidia.startsWith('http')) {
+      return {
+        tipo: 'url',
+        caminho: caminhoMidia,
+        tamanho: null,
+        existe: true
+      };
+    }
+
+    // Resolver caminho absoluto
+    const caminhoAbsoluto = path.resolve(this.baseDir, caminhoMidia);
+
+    try {
+      if (fs.existsSync(caminhoAbsoluto)) {
+        const stats = fs.statSync(caminhoAbsoluto);
+        return {
+          tipo: 'arquivo',
+          caminho: caminhoMidia,
+          caminhoAbsoluto,
+          tamanho: stats.size,
+          existe: true,
+          modificado: stats.mtime
+        };
+      }
+    } catch (error) {
+      console.error(`❌ Erro ao obter informações da mídia ${caminhoMidia}:`, error);
+    }
+
+    return {
+      tipo: 'arquivo',
+      caminho: caminhoMidia,
+      tamanho: null,
+      existe: false
+    };
+  }
+
+  /**
+   * Obter o melhor tipo de mídia disponível (baseado na função do config.js)
+   */
+  obterMelhorMidia(tipo, indice = null) {
+    let midiasDisponiveis = null;
+    
+    if (tipo === 'inicial') {
+      midiasDisponiveis = midias.inicial;
+    } else if (tipo === 'downsell' && indice) {
+      midiasDisponiveis = midias.downsells[indice];
+    }
+    
+    if (!midiasDisponiveis) return null;
+    
+    // Prioridade: video > imagem > audio
+    const prioridade = ['video', 'imagem', 'audio'];
+    
+    for (const tipoMidia of prioridade) {
+      const caminhoMidia = midiasDisponiveis[tipoMidia];
+      if (this.verificarMidia(caminhoMidia)) {
+        return {
+          tipo: tipoMidia,
+          caminho: caminhoMidia,
+          tipoTelegram: tipoMidia === 'imagem' ? 'photo' : tipoMidia
+        };
+      }
+    }
+    
+    return null;
+  }
+
+  /**
+   * Preparar mídia para envio no Telegram
+   */
+  prepararMidiaParaTelegram(caminhoMidia, tipoMidia) {
+    if (!caminhoMidia) return null;
+
+    // Se for URL, retornar diretamente
+    if (caminhoMidia.startsWith('http')) {
+      return {
+        source: caminhoMidia,
+        tipo: tipoMidia === 'imagem' ? 'photo' : tipoMidia
+      };
+    }
+
+    // Se for arquivo local, criar stream
+    const stream = this.obterStreamMidia(caminhoMidia);
+    if (stream) {
+      return {
+        source: stream,
+        tipo: tipoMidia === 'imagem' ? 'photo' : tipoMidia
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * Criar arquivo de mídia de exemplo (para testes)
+   */
+  criarMidiaExemplo(tipo, dsId = null) {
+    const textoExemplo = `Este é um arquivo de exemplo para ${tipo}`;
+    let caminhoArquivo;
+
+    if (dsId) {
+      caminhoArquivo = path.join(this.downsellDir, `${dsId}.txt`);
+    } else {
+      caminhoArquivo = path.join(this.midiaDir, `inicial.txt`);
+    }
+
+    try {
+      fs.writeFileSync(caminhoArquivo, textoExemplo);
+      console.log(`📝 Arquivo de exemplo criado: ${caminhoArquivo}`);
+      return caminhoArquivo;
+    } catch (error) {
+      console.error(`❌ Erro ao criar arquivo de exemplo:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Limpar cache de mídias (se necessário)
+   */
+  limparCache() {
+    // Esta função pode ser expandida no futuro se implementarmos cache
+    console.log('🧹 Cache de mídias limpo');
+  }
+}
+
+module.exports = GerenciadorMidia;


### PR DESCRIPTION
## Summary
- add `perfil1` and `perfil2` bot folders
- expose `MEU_PERFIL` and config through each bot module
- adjust media utility paths for shared media directory
- update server to load bots from both profiles and register webhooks
- schedule periodic messages and downsell loops for all profiles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cfe484d44832a9e01302642f6b414