### PR TITLE
Add logs for Telegram bot initialization failures

### DIFF
--- a/MODELO1/perfil1/bot.js
+++ b/MODELO1/perfil1/bot.js
@@ -75,6 +75,7 @@ let bot;
 try {
   // Não usar polling no OnRender, apenas webhook
   bot = new TelegramBot(TELEGRAM_TOKEN, { polling: false });
+  console.log(`🤖 Bot criado com sucesso para o perfil ${MEU_PERFIL}`);
   
   // Configurar webhook de forma robusta
   if (BASE_URL) {
@@ -98,6 +99,12 @@ try {
 } catch (error) {
   console.error('❌ Erro ao inicializar bot:', error);
   bot = null;
+}
+
+if (!bot) {
+  console.error('⚠️ Bot não inicializado para o perfil', MEU_PERFIL, '- comandos não registrados');
+} else {
+  console.log(`✅ Bot do perfil ${MEU_PERFIL} pronto para registrar comandos`);
 }
 
 // Configurar banco de dados com tratamento de erro

--- a/MODELO1/perfil2/bot.js
+++ b/MODELO1/perfil2/bot.js
@@ -75,6 +75,7 @@ let bot;
 try {
   // Não usar polling no OnRender, apenas webhook
   bot = new TelegramBot(TELEGRAM_TOKEN, { polling: false });
+  console.log(`🤖 Bot criado com sucesso para o perfil ${MEU_PERFIL}`);
   
   // Configurar webhook de forma robusta
 if (BASE_URL) {
@@ -98,6 +99,12 @@ if (BASE_URL) {
 } catch (error) {
   console.error('❌ Erro ao inicializar bot:', error);
   bot = null;
+}
+
+if (!bot) {
+  console.error('⚠️ Bot não inicializado para o perfil', MEU_PERFIL, '- comandos não registrados');
+} else {
+  console.log(`✅ Bot do perfil ${MEU_PERFIL} pronto para registrar comandos`);
 }
 
 // Configurar banco de dados com tratamento de erro

--- a/server.js
+++ b/server.js
@@ -216,6 +216,9 @@ function carregarBots() {
       const botModule = require(botPath);
       bots.push(botModule);
       console.log(`✅ Bot carregado: ${perfil}`);
+      if (!botModule.bot) {
+        console.error(`⚠️ Bot do ${perfil} não inicializado - comandos não registrados`);
+      }
     } catch (error) {
       console.error(`❌ Erro ao carregar bot ${perfil}:`, error.message);
     }


### PR DESCRIPTION
## Summary
- log whether Telegram bots were created successfully
- warn when loading a bot module that didn't initialize

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d2e8e2e68832ab50a67475c63c5b7