### PR TITLE
Fix webhook 404 by calling configuradorWebhooks after bot load

### DIFF
--- a/server.js
+++ b/server.js
@@ -526,6 +526,8 @@ const server = app.listen(PORT, '0.0.0.0', async () => {
   console.log(`🌐 URL: ${BASE_URL}`);
   // Inicializar módulos
   await inicializarModulos();
+  // Garantir que webhooks sejam configurados após os bots estarem prontos
+  configurarWebhooks();
 
   bots.forEach(b => {
     console.log(`🔗 Webhook: ${BASE_URL}/bot${b.TELEGRAM_TOKEN}`);


### PR DESCRIPTION
## Summary
- ensure webhook routes are created once the bots finish loading

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686d35db1d14832ab4546742461b0990