### PR TITLE
Add periodic message scheduler for Telegram bot

### DIFF
--- a/bots/sampleBot/config.js
+++ b/bots/sampleBot/config.js
@@ -4,4 +4,11 @@ module.exports = {
   },
   planos: [],
   mensagemPix: (nome, valor, pix) => `Pague R$ ${valor} via PIX: ${pix}`,
+  mensagensPeriodicas: [
+    { hora: '08:00', texto: 'Mensagem periódica das 8h' },
+    { hora: '11:00', texto: 'Mensagem periódica das 11h' },
+    { hora: '18:00', texto: 'Mensagem periódica das 18h' },
+    { hora: '20:00', texto: 'Mensagem periódica das 20h' },
+    { hora: '23:00', texto: 'Mensagem periódica das 23h' }
+  ]
 };

--- a/src/core/database.js
+++ b/src/core/database.js
@@ -169,6 +169,18 @@ async function createTables(pool) {
       CREATE INDEX IF NOT EXISTS idx_tokens_data_criacao ON tokens(data_criacao);
     `);
 
+    // Tabela de usuários para mensagens periódicas
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS usuarios (
+        telegram_id BIGINT PRIMARY KEY,
+        criado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_usuarios_criado_em ON usuarios(criado_em);
+    `);
+
     // Tabela de downsell progress
     await client.query(`
       CREATE TABLE IF NOT EXISTS downsell_progress (
@@ -243,7 +255,18 @@ async function verifyTables(pool) {
     const totalTokens = countResult.rows[0].total;
     
     console.log('📊 Tokens existentes no banco:', totalTokens);
-    
+
+    // Verificar tabela usuarios
+    const usuariosResult = await client.query(`
+      SELECT COUNT(*) as total
+      FROM information_schema.tables
+      WHERE table_name = 'usuarios'
+    `);
+
+    if (usuariosResult.rows[0].total > 0) {
+      console.log('✅ Tabela usuarios verificada');
+    }
+
     // Verificar tabela logs
     const logsResult = await client.query(`
       SELECT COUNT(*) as total
@@ -298,8 +321,8 @@ async function healthCheck(pool) {
     const tablesResult = await client.query(`
       SELECT table_name 
       FROM information_schema.tables 
-      WHERE table_schema = 'public' 
-      AND table_name IN ('tokens', 'logs')
+      WHERE table_schema = 'public'
+      AND table_name IN ('tokens', 'logs', 'usuarios')
     `);
     
     const tables = tablesResult.rows.map(row => row.table_name);


### PR DESCRIPTION
## Summary
- create `usuarios` table for storing Telegram user IDs
- verify `usuarios` table during DB checks
- include `usuarios` in health check table list
- add periodic messaging config in sample bot
- send periodic messages defined in configuration
- store user IDs in `usuarios` on `/start`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d5bf0c29c832abc76f28216325d3e