### PR TITLE
Add extensive logging to troubleshoot Telegram bots

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ const pool = postgres.createPool();
 const bots = new Map();
 
 function loadBot(botDir) {
+  console.log(`[INIT] Carregando bot em ${botDir}`);
   const env = helpers.loadEnv(botDir);
 
   const botId = env.BOT_ID || path.basename(botDir);
@@ -58,11 +59,13 @@ function loadBot(botDir) {
 
   app.post(`/bot${botToken}`, (req, res) => {
     const bodySnippet = JSON.stringify(req.body).slice(0, 200);
-    console.log(`[${botId}] Webhook recebido:`, bodySnippet);
+    console.log(`[${botId}] [webhook] Requisição recebida:`, bodySnippet);
     try {
+      console.log(`[${botId}] [webhook] Chamando processUpdate`);
       service.bot.processUpdate(req.body);
+      console.log(`[${botId}] [webhook] processUpdate executado`);
     } catch (err) {
-      console.error(`[${botId}] Erro no processUpdate:`, err);
+      console.error(`[${botId}] [webhook] Erro no processUpdate:`, err);
     }
     res.sendStatus(200);
   });


### PR DESCRIPTION
## Summary
- log when each bot directory is loaded and when routes are registered
- log webhook requests and processUpdate calls
- add debugging output in TelegramBotService constructor
- wrap sendMessage and media methods to print info
- print details while handling commands, sending periodic messages, and processing webhooks

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d876dbd38832a9d9aa5b8497c9f46