### PR TITLE
Fix webhook path

### DIFF
--- a/server.js
+++ b/server.js
@@ -57,7 +57,8 @@ function loadBot(botDir) {
   }
   bots.set(botId, service);
 
-  app.post(`/bot${botToken}`, (req, res) => {
+  const webhookPath = `/webhook/${botId}/${botToken}`;
+  app.post(webhookPath, (req, res) => {
     const bodySnippet = JSON.stringify(req.body).slice(0, 200);
     console.log(`[${botId}] [webhook] Requisição recebida:`, bodySnippet);
     try {
@@ -69,7 +70,7 @@ function loadBot(botDir) {
     }
     res.sendStatus(200);
   });
-  console.log(`[${botId}] Rota /bot${botToken} registrada`);
+  console.log(`[${botId}] Rota ${webhookPath} registrada`);
 
   console.log(`🤖 Bot ${botId} carregado`);
 }

--- a/src/core/telegramBotService.js
+++ b/src/core/telegramBotService.js
@@ -75,7 +75,9 @@ class TelegramBotService {
     }
 
     if (baseUrl) {
-      const webhookUrl = `${baseUrl}/bot${telegramToken}`;
+      const webhookPath = `/webhook/${this.botId}/${telegramToken}`;
+      const webhookUrl = `${baseUrl}${webhookPath}`;
+      console.log(`[${this.botId}] Configurando webhook em ${webhookUrl}`);
       this.bot
         .setWebHook(webhookUrl)
         .then(() => console.log(`[${this.botId}] ✅ Webhook configurado: ${webhookUrl}`))


### PR DESCRIPTION
## Summary
- use unique webhook URL per bot
- register dedicated webhook route per bot in server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d8cd970c8832a8da72394835723ec