### PR TITLE
Add support for second telegram bot

### DIFF
--- a/MODELO1/BOT/bot2.js
+++ b/MODELO1/BOT/bot2.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+const TelegramBotService = require('../core/TelegramBotService');
+const config = require('./config2');
+const postgres = require('../database/postgres');
+const sqlite = require('../database/sqlite');
+
+const bot = new TelegramBotService({
+  token: process.env.TELEGRAM_TOKEN_BOT2,
+  baseUrl: process.env.BASE_URL,
+  frontendUrl: process.env.FRONTEND_URL || process.env.BASE_URL,
+  config,
+  postgres,
+  sqlite,
+  bot_id: 'bot2'
+});
+
+function iniciar() {
+  bot.iniciar();
+  return bot;
+}
+
+module.exports = { iniciar, bot };

--- a/MODELO1/BOT/config2.js
+++ b/MODELO1/BOT/config2.js
@@ -1,0 +1,8 @@
+const base = require('./config.default');
+module.exports = {
+  ...base,
+  mensagens: {
+    ...(base.mensagens || {}),
+    boasVindas: '👋 Bem-vindo ao bot2!'
+  }
+};

--- a/core/TelegramBotService.js
+++ b/core/TelegramBotService.js
@@ -41,7 +41,7 @@ class TelegramBotService {
 
     this.bot = new TelegramBot(this.token, { polling: false });
     if (this.baseUrl) {
-      const webhookUrl = `${this.baseUrl}/bot${this.token}`;
+      const webhookUrl = `${this.baseUrl}/${this.botId}/webhook`;
       this.bot.setWebHook(webhookUrl)
         .then(() => console.log(`[${this.botId}] ✅ Webhook configurado: ${webhookUrl}`))
         .catch(err => console.error(`[${this.botId}] ❌ Erro ao configurar webhook:`, err));


### PR DESCRIPTION
## Summary
- add `bot2.js` and `config2.js`
- update `TelegramBotService` to use botId in webhook URL
- configure server to start two bots and expose separate webhook routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686da99b237c832a9a1d3ea869cbe7f8