### PR TITLE
Rotear webhooks de pagamento por bot

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -159,9 +159,9 @@ class TelegramBotService {
       const pix_copia_cola = qr_code;
       if (this.db) {
         this.db.prepare(`
-          INSERT INTO tokens (token, valor, status, telegram_id, utm_source, utm_campaign, utm_medium)
-          VALUES (?, ?, 'pendente', ?, ?, ?, ?)
-        `).run(normalizedId, valorCentavos, telegram_id, utm_source, utm_campaign, utm_medium);
+          INSERT INTO tokens (token, valor, status, telegram_id, utm_source, utm_campaign, utm_medium, bot_id)
+          VALUES (?, ?, 'pendente', ?, ?, ?, ?, ?)
+        `).run(normalizedId, valorCentavos, telegram_id, utm_source, utm_campaign, utm_medium, this.botId);
       }
       return res.json({ qr_code_base64, qr_code, pix_copia_cola: pix_copia_cola || qr_code, transacao_id: normalizedId });
     } catch (err) {
@@ -185,7 +185,11 @@ class TelegramBotService {
         `).run(novoToken, normalizedId);
       }
       if (this.pgPool) {
-        await this.postgres.executeQuery(this.pgPool, 'INSERT INTO tokens (token, valor) VALUES ($1,$2)', [novoToken, (row.valor || 0) / 100]);
+        await this.postgres.executeQuery(
+          this.pgPool,
+          'INSERT INTO tokens (token, valor, bot_id) VALUES ($1,$2,$3)',
+          [novoToken, (row.valor || 0) / 100, this.botId]
+        );
       }
       if (row.telegram_id && this.pgPool) {
         const tgId = this.normalizeTelegramId(row.telegram_id);

--- a/database/postgres.js
+++ b/database/postgres.js
@@ -148,6 +148,7 @@ async function createTables(pool) {
         token VARCHAR(255) UNIQUE NOT NULL,
         usado BOOLEAN DEFAULT FALSE,
         valor DECIMAL(10,2) DEFAULT 0.00,
+        bot_id VARCHAR(50) NULL,
         data_criacao TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         data_uso TIMESTAMP NULL,
         ip_uso INET NULL,
@@ -155,6 +156,11 @@ async function createTables(pool) {
         created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
       )
+    `);
+
+    await client.query(`
+      ALTER TABLE tokens
+      ADD COLUMN IF NOT EXISTS bot_id VARCHAR(50)
     `);
     
     // Criar índices para melhor performance

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -21,6 +21,7 @@ function initialize(path = './pagamentos.db') {
         token TEXT PRIMARY KEY,
         telegram_id TEXT,
         valor INTEGER,
+        bot_id TEXT,
         utm_source TEXT,
         utm_campaign TEXT,
         utm_medium TEXT,
@@ -31,8 +32,12 @@ function initialize(path = './pagamentos.db') {
     `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
     const hasUuid = cols.some(c => c.name === 'token_uuid');
+    const hasBotId = cols.some(c => c.name === 'bot_id');
     if (!hasUuid) {
       database.prepare('ALTER TABLE tokens ADD COLUMN token_uuid TEXT').run();
+    }
+    if (!hasBotId) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN bot_id TEXT').run();
     }
     console.log('✅ SQLite inicializado');
   } catch (err) {


### PR DESCRIPTION
## Summary
- mapear instâncias de bots no servidor
- criar coluna `bot_id` nos bancos SQLite e Postgres
- gravar `bot_id` nos registros gerados pelo TelegramBotService
- rotear /webhook/pushinpay para o bot correto usando o `bots` Map

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dc24ae6a8832a955b52ffe1af5f1d