### PR TITLE
Add webhook success logging

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -196,11 +196,16 @@ class TelegramBotService {
         `).run(novoToken, normalizedId);
       }
       if (this.pgPool) {
-        await this.postgres.executeQuery(
-          this.pgPool,
-          'INSERT INTO tokens (token, valor, bot_id) VALUES ($1,$2,$3)',
-          [novoToken, (row.valor || 0) / 100, this.botId]
-        );
+        try {
+          await this.postgres.executeQuery(
+            this.pgPool,
+            'INSERT INTO tokens (token, valor, bot_id) VALUES ($1,$2,$3)',
+            [novoToken, (row.valor || 0) / 100, this.botId]
+          );
+          console.log(`✅ Token ${novoToken} salvo com sucesso no PostgreSQL com bot_id ${this.botId}`);
+        } catch (pgErr) {
+          console.error(`❌ Falha ao salvar token ${novoToken} no PostgreSQL com bot_id ${this.botId}:`, pgErr.message);
+        }
       }
       if (row.telegram_id && this.pgPool) {
         const tgId = this.normalizeTelegramId(row.telegram_id);


### PR DESCRIPTION
## Summary
- log success when saving the new token in webhook
- capture and log failures when saving token

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dc9e7c06c832a95dc8ba13ecca9d4