### PR TITLE
Normalize token in PushinPay webhook

### DIFF
--- a/server.js
+++ b/server.js
@@ -343,7 +343,7 @@ async function carregarSistemaTokens() {
 
 app.post('/webhook/pushinpay', async (req, res) => {
   try {
-    const token = req.body?.token || req.body?.id;
+    const token = (req.body?.token || req.body?.id || '').toLowerCase().trim();
     if (!token) {
       return res.status(400).json({ error: 'Token ausente' });
     }


### PR DESCRIPTION
## Summary
- ensure the token from PushinPay webhook is normalized to lowercase before querying Postgres

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dd210c9a8832abde983b78bbcac5f