### PR TITLE
Fix bot_id handling in charge API

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -289,7 +289,8 @@ class TelegramBotService {
         valor: plano.valor,
         utm_source: 'telegram',
         utm_campaign: 'bot_principal',
-        utm_medium: 'telegram_bot'
+        utm_medium: 'telegram_bot',
+        bot_id: this.botId
       });
       const { qr_code_base64, pix_copia_cola, transacao_id } = resposta.data;
       let buffer;


### PR DESCRIPTION
## Summary
- register both bot instances in a `Map`
- use bot_id when generating a charge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dd9c18124832a8475e4d55672cdba