### PR TITLE
Implement periodic messages

### DIFF
--- a/MODELO1/BOT/config.default.js
+++ b/MODELO1/BOT/config.default.js
@@ -296,6 +296,45 @@ const downsells = [
     ]
   }
 ];
+// Mensagens periódicas automáticas
+const mensagensPeriodicas = [
+  {
+    horario: '08:00',
+    texto: `Por apenas 19,90 você vai ter acesso a:
+
+🔥 Mais de 450 fotos e vídeos 
+🔥 Sexo, boquete, anal ménage
+🔥 Vídeo chamada gratuita
+🔥 Live sem roupa toda noite
+🔥 Sorteio pra gravar comigo 
+
+👇🏻ESTOU TE ESPERANDO AQUI👇🏻`,
+    midia: './midia/08.mp4'
+  },
+  {
+    horario: '11:00',
+    texto: `✨ 20 REAIS ✨
+
+É o precinho para entrar no meu grupinho agora e se deliciar com meus vídeos já de manhã, para começar o dia jogando leitinho para fora bem gostoso. Vira macho e aperta o botão agora.`,
+    midia: './midia/11.mp4'
+  },
+  {
+    horario: '18:00',
+    texto: `Decide agora: ou clica e me vê do jeitinho que imaginava,  
+ou volta pro Insta fingindo que não queria me ver... mas vai continuar pensando em mim depois. 😘
+
+👇🏻👇🏻👇🏻`,
+    midia: './midia/18.mp4'
+  },
+  {
+    horario: '20:00',
+    copiarDe: '08:00'
+  },
+  {
+    horario: '23:00',
+    copiarDe: '11:00'
+  }
+];
 
 // Outras configurações
 const canalPrevias = 'https://t.me/+B9dEZHITEM1iYzMx';
@@ -373,5 +412,5 @@ module.exports = {
   formatarValorCentavos,
   mensagemPix,
   obterDownsellPorId,
-  obterPlanoPorId
-};
+  obterPlanoPorId,
+  mensagensPeriodicas};

--- a/MODELO1/BOT/config.js
+++ b/MODELO1/BOT/config.js
@@ -296,6 +296,45 @@ const downsells = [
     ]
   }
 ];
+// Mensagens periódicas automáticas
+const mensagensPeriodicas = [
+  {
+    horario: '08:00',
+    texto: `Por apenas 19,90 você vai ter acesso a:
+
+🔥 Mais de 450 fotos e vídeos 
+🔥 Sexo, boquete, anal ménage
+🔥 Vídeo chamada gratuita
+🔥 Live sem roupa toda noite
+🔥 Sorteio pra gravar comigo 
+
+👇🏻ESTOU TE ESPERANDO AQUI👇🏻`,
+    midia: './midia/08.mp4'
+  },
+  {
+    horario: '11:00',
+    texto: `✨ 20 REAIS ✨
+
+É o precinho para entrar no meu grupinho agora e se deliciar com meus vídeos já de manhã, para começar o dia jogando leitinho para fora bem gostoso. Vira macho e aperta o botão agora.`,
+    midia: './midia/11.mp4'
+  },
+  {
+    horario: '18:00',
+    texto: `Decide agora: ou clica e me vê do jeitinho que imaginava,  
+ou volta pro Insta fingindo que não queria me ver... mas vai continuar pensando em mim depois. 😘
+
+👇🏻👇🏻👇🏻`,
+    midia: './midia/18.mp4'
+  },
+  {
+    horario: '20:00',
+    copiarDe: '08:00'
+  },
+  {
+    horario: '23:00',
+    copiarDe: '11:00'
+  }
+];
 
 // Outras configurações
 const canalPrevias = 'https://t.me/+B9dEZHITEM1iYzMx';
@@ -373,5 +412,5 @@ module.exports = {
   formatarValorCentavos,
   mensagemPix,
   obterDownsellPorId,
-  obterPlanoPorId
-};
+  obterPlanoPorId,
+  mensagensPeriodicas};

--- a/MODELO1/BOT/package.json
+++ b/MODELO1/BOT/package.json
@@ -18,7 +18,9 @@
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
     "node-telegram-bot-api": "^0.66.0",
-    "sharp": "^0.34.2"
+    "sharp": "^0.34.2",
+    "luxon": "^3.4.4",
+    "node-cron": "^3.0.2"
   },
   "devDependencies": {
     "concurrently": "^9.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,8 @@
         "express": "^4.19.2",
         "express-rate-limit": "^5.5.1",
         "helmet": "^5.0.2",
+        "luxon": "^3.4.4",
+        "node-cron": "^3.0.2",
         "node-telegram-bot-api": "^0.61.0",
         "pg": "^8.11.3",
         "uuid": "^9.0.1"
@@ -1939,6 +1941,15 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2083,6 +2094,27 @@
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/node-telegram-bot-api": {
       "version": "0.61.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "helmet": "^5.0.2",
     "node-telegram-bot-api": "^0.61.0",
     "pg": "^8.11.3",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "luxon": "^3.4.4",
+    "node-cron": "^3.0.2"
   },
   "optionalDependencies": {
     "sharp": "^0.32.6"


### PR DESCRIPTION
## Summary
- add luxon and node-cron deps
- support periodic messages configured per bot
- expose new schedules in config files
- schedule automatic messages in TelegramBotService

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ddc974d5c832aa6dce3e33d2c71d5