### PR TITLE
Update 1-week plan price to 9.90

### DIFF
--- a/MODELO1/BOT/config.default.js
+++ b/MODELO1/BOT/config.default.js
@@ -168,7 +168,7 @@ const planos = [
     id: 'plano_espiar',
     nome: 'Quero só espiar... 💋',
     emoji: '👀',
-    valor: 20.00,
+    valor: 9.90,
     descricao: 'Acesso temporário ao conteúdo'
   }
 ];
@@ -182,7 +182,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds1_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 27.00 },
-      { id: 'ds1_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 20.00 }
+      { id: 'ds1_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -192,7 +192,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds2_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 24.30 },
-      { id: 'ds2_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 18.00 }
+      { id: 'ds2_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -202,7 +202,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds3_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 25.65 },
-      { id: 'ds3_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 19.00 }
+      { id: 'ds3_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -212,7 +212,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds4_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 25.65 },
-      { id: 'ds4_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 19.00 }
+      { id: 'ds4_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -222,7 +222,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds5_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 24.30 },
-      { id: 'ds5_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 18.00 }
+      { id: 'ds5_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -232,7 +232,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds6_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 22.95 },
-      { id: 'ds6_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 17.00 }
+      { id: 'ds6_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -242,7 +242,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds7_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 22.95 },
-      { id: 'ds7_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 17.00 }
+      { id: 'ds7_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -252,7 +252,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds8_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 21.60 },
-      { id: 'ds8_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 16.00 }
+      { id: 'ds8_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -262,7 +262,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds9_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 21.60 },
-      { id: 'ds9_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 16.00 }
+      { id: 'ds9_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -272,7 +272,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds10_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 20.25 },
-      { id: 'ds10_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 15.00 }
+      { id: 'ds10_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -282,7 +282,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds11_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 20.25 },
-      { id: 'ds11_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 15.00 }
+      { id: 'ds11_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -292,7 +292,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds12_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 18.90 },
-      { id: 'ds12_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 14.00 }
+      { id: 'ds12_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   }
 ];

--- a/MODELO1/BOT/config.js
+++ b/MODELO1/BOT/config.js
@@ -168,7 +168,7 @@ const planos = [
     id: 'plano_espiar',
     nome: 'Quero só espiar... 💋',
     emoji: '👀',
-    valor: 20.00,
+    valor: 9.90,
     descricao: 'Acesso temporário ao conteúdo'
   }
 ];
@@ -182,7 +182,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds1_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 27.00 },
-      { id: 'ds1_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 20.00 }
+      { id: 'ds1_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -192,7 +192,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds2_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 24.30 },
-      { id: 'ds2_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 18.00 }
+      { id: 'ds2_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -202,7 +202,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds3_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 25.65 },
-      { id: 'ds3_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 19.00 }
+      { id: 'ds3_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -212,7 +212,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds4_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 25.65 },
-      { id: 'ds4_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 19.00 }
+      { id: 'ds4_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -222,7 +222,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds5_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 24.30 },
-      { id: 'ds5_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 18.00 }
+      { id: 'ds5_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -232,7 +232,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds6_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 22.95 },
-      { id: 'ds6_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 17.00 }
+      { id: 'ds6_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -242,7 +242,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds7_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 22.95 },
-      { id: 'ds7_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 17.00 }
+      { id: 'ds7_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -252,7 +252,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds8_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 21.60 },
-      { id: 'ds8_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 16.00 }
+      { id: 'ds8_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -262,7 +262,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds9_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 21.60 },
-      { id: 'ds9_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 16.00 }
+      { id: 'ds9_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -272,7 +272,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds10_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 20.25 },
-      { id: 'ds10_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 15.00 }
+      { id: 'ds10_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -282,7 +282,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds11_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 20.25 },
-      { id: 'ds11_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 15.00 }
+      { id: 'ds11_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   },
   {
@@ -292,7 +292,7 @@ const downsells = [
     tipoMidia: 'video',
     planos: [
       { id: 'ds12_vitalicio', nome: 'Vitalício + Presentinho', emoji: '💋', valorOriginal: 27.00, valorComDesconto: 18.90 },
-      { id: 'ds12_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 20.00, valorComDesconto: 14.00 }
+      { id: 'ds12_espiar', nome: 'Quero só espiar...', emoji: '👀', valorOriginal: 9.90, valorComDesconto: 9.90 }
     ]
   }
 ];

--- a/MODELO1/BOT/config1.js
+++ b/MODELO1/BOT/config1.js
@@ -26,14 +26,14 @@ ou volta pro Insta fingindo que não queria me ver... mas vai continuar pensando
 👇🏻👇🏻👇🏻`,
       opcoes: [
         { texto: '🔓 Acesso Vitalício – R$19,90', callback: 'plano_vitalicio' },
-        { texto: '💥 1 Semana – R$17,90', callback: 'plano_espiar' }
+        { texto: '💥 1 Semana – R$9,90', callback: 'plano_espiar' }
       ]
     }
   },
 
   planos: [
     { id: 'plano_vitalicio', nome: 'Vitalício', valor: 19.90 },
-    { id: 'plano_espiar', nome: '1 Semana', valor: 17.90 }
+    { id: 'plano_espiar', nome: '1 Semana', valor: 9.90 }
   ],
 
   downsells: [
@@ -67,8 +67,8 @@ ou volta pro Insta fingindo que não queria me ver... mas vai continuar pensando
           id: `ds${i+1}_uma_semana`,
           nome: '1 Semana',
           emoji: '💥',
-          valorOriginal: 17.90,
-          valorComDesconto: 17.90
+          valorOriginal: 9.90,
+          valorComDesconto: 9.90
         }
       ]
     }))

--- a/server.js
+++ b/server.js
@@ -557,6 +557,7 @@ const server = app.listen(PORT, '0.0.0.0', async () => {
   await inicializarModulos();
   
   console.log('✅ Servidor pronto!');
+console.log('📦 Valor do plano 1 semana atualizado para R$ 9,90 com sucesso.');
 });
 
 // Graceful shutdown


### PR DESCRIPTION
## Summary
- set the 1-week plan price to 9.90 in all bot configs
- update downsell prices for the 1-week plan
- adjust menu text in config1.js
- log price update message on server start

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686f9c932a90832a87bbc12d046ad4fc