### PR TITLE
Increase downsell interval to 20 minutes

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -452,7 +452,7 @@ class TelegramBotService {
     await this.bot.sendMessage(chatId, downsell.texto, { parse_mode: 'HTML', reply_markup: replyMarkup });
     await this.postgres.executeQuery(this.pgPool, 'UPDATE downsell_progress SET index_downsell = $1, last_sent_at = NOW() WHERE telegram_id = $2', [idx + 1, chatId]);
     if (idx + 1 < lista.length) {
-      setTimeout(() => this.enviarDownsell(chatId).catch(err => console.error('Erro no próximo downsell:', err.message)), 5 * 60 * 1000);
+      setTimeout(() => this.enviarDownsell(chatId).catch(err => console.error('Erro no próximo downsell:', err.message)), 20 * 60 * 1000);
     }
   }
 
@@ -474,7 +474,7 @@ class TelegramBotService {
         if (index_downsell >= this.config.downsells.length) continue;
         if (last_sent_at) {
           const diff = Date.now() - new Date(last_sent_at).getTime();
-          if (diff < 5 * 60 * 1000) continue;
+          if (diff < 20 * 60 * 1000) continue;
         }
         const downsell = this.config.downsells[index_downsell];
         await this.enviarMidiasHierarquicamente(telegram_id, this.config.midias.downsells[downsell.id] || {});

--- a/server.js
+++ b/server.js
@@ -243,8 +243,8 @@ function iniciarDownsellLoop() {
     } catch (err) {
       console.error('Erro no loop de downsells:', err);
     }
-  }, 5 * 60 * 1000);
-  console.log('⏰ Loop de downsells ativo a cada 5 minutos');
+  }, 20 * 60 * 1000);
+  console.log('⏰ Loop de downsells ativo a cada 20 minutos');
 }
 
 // Carregar módulos


### PR DESCRIPTION
## Summary
- extend sequential downsell delay to 20 minutes
- update check for last message time
- adjust downsell loop interval and logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68700309ae2c832a92c328632ed8da72