### PR TITLE
Fix purchase pixel flow

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -285,8 +285,12 @@
       }
       
       try {
-        // Fazer requisição para verificar token
-        const response = await fetch(`/api/verificar-token?token=${encodeURIComponent(token)}`);
+        // Fazer requisição para verificar token usando POST para obter o valor correto
+        const response = await fetch('/api/verificar-token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token })
+        });
 
         let dados = {};
         try {
@@ -303,7 +307,7 @@
           return;
         }
 
-        if (dados.status === 'valido') {
+        if (dados.sucesso) {
           console.log('✅ Token válido, acesso liberado');
           dispararEventoCompra(dados.valor || valor, token);
 


### PR DESCRIPTION
## Summary
- ensure POST `/api/verificar-token` is used so the token value is returned
- fire the `Purchase` event only when `sucesso` is true

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68705010e8dc832abef02ab1bcae6749