### PR TITLE
Implement Facebook Conversions API events

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -149,6 +149,15 @@ async function createTables(pool) {
         usado BOOLEAN DEFAULT FALSE,
         valor DECIMAL(10,2) DEFAULT 0.00,
         bot_id VARCHAR(50) NULL,
+        utm_source VARCHAR(255) NULL,
+        utm_campaign VARCHAR(255) NULL,
+        utm_medium VARCHAR(255) NULL,
+        utm_term VARCHAR(255) NULL,
+        utm_content VARCHAR(255) NULL,
+        fbp VARCHAR(255) NULL,
+        fbc VARCHAR(255) NULL,
+        ip_criacao INET NULL,
+        user_agent_criacao TEXT NULL,
         data_criacao TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         data_uso TIMESTAMP NULL,
         ip_uso INET NULL,
@@ -160,7 +169,16 @@ async function createTables(pool) {
 
     await client.query(`
       ALTER TABLE tokens
-      ADD COLUMN IF NOT EXISTS bot_id VARCHAR(50)
+      ADD COLUMN IF NOT EXISTS bot_id VARCHAR(50);
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS utm_source VARCHAR(255);
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS utm_campaign VARCHAR(255);
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS utm_medium VARCHAR(255);
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS utm_term VARCHAR(255);
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS utm_content VARCHAR(255);
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS fbp VARCHAR(255);
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS fbc VARCHAR(255);
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS ip_criacao INET;
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS user_agent_criacao TEXT;
     `);
     
     // Criar índices para melhor performance

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -25,19 +25,43 @@ function initialize(path = './pagamentos.db') {
         utm_source TEXT,
         utm_campaign TEXT,
         utm_medium TEXT,
+        utm_term TEXT,
+        utm_content TEXT,
+        fbp TEXT,
+        fbc TEXT,
+        ip_criacao TEXT,
+        user_agent_criacao TEXT,
         status TEXT DEFAULT 'pendente',
         token_uuid TEXT,
         criado_em DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
-    const hasUuid = cols.some(c => c.name === 'token_uuid');
-    const hasBotId = cols.some(c => c.name === 'bot_id');
-    if (!hasUuid) {
+    const checkCol = name => cols.some(c => c.name === name);
+
+    if (!checkCol('token_uuid')) {
       database.prepare('ALTER TABLE tokens ADD COLUMN token_uuid TEXT').run();
     }
-    if (!hasBotId) {
+    if (!checkCol('bot_id')) {
       database.prepare('ALTER TABLE tokens ADD COLUMN bot_id TEXT').run();
+    }
+    if (!checkCol('utm_term')) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN utm_term TEXT').run();
+    }
+    if (!checkCol('utm_content')) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN utm_content TEXT').run();
+    }
+    if (!checkCol('fbp')) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN fbp TEXT').run();
+    }
+    if (!checkCol('fbc')) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN fbc TEXT').run();
+    }
+    if (!checkCol('ip_criacao')) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN ip_criacao TEXT').run();
+    }
+    if (!checkCol('user_agent_criacao')) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN user_agent_criacao TEXT').run();
     }
     console.log('✅ SQLite inicializado');
   } catch (err) {

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -1,0 +1,82 @@
+const axios = require('axios');
+
+const PIXEL_ID = process.env.FB_PIXEL_ID || '1429424624747459';
+const ACCESS_TOKEN = process.env.FB_PIXEL_TOKEN;
+
+const dedupCache = new Map();
+const DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+function getDedupKey({event_name, event_time, fbp, fbc}) {
+  return [event_name, event_time, fbp || '', fbc || ''].join('|');
+}
+
+function isDuplicate(key) {
+  const now = Date.now();
+  const ts = dedupCache.get(key);
+  if (ts && now - ts < DEDUP_TTL_MS) {
+    return true;
+  }
+  dedupCache.set(key, now);
+  // cleanup
+  for (const [k, t] of dedupCache) {
+    if (now - t > DEDUP_TTL_MS) dedupCache.delete(k);
+  }
+  return false;
+}
+
+async function sendFacebookEvent({
+  event_name,
+  event_time = Math.floor(Date.now() / 1000),
+  event_source_url,
+  value,
+  currency = 'BRL',
+  fbp,
+  fbc,
+  ip,
+  userAgent,
+  custom_data = {}
+}) {
+  if (!ACCESS_TOKEN) {
+    console.warn('FB_PIXEL_TOKEN não definido. Evento não será enviado.');
+    return { success: false, error: 'FB_PIXEL_TOKEN not set' };
+  }
+
+  const key = getDedupKey({ event_name, event_time, fbp, fbc });
+  if (isDuplicate(key)) {
+    return { success: false, duplicate: true };
+  }
+
+  const payload = {
+    data: [
+      {
+        event_name,
+        event_time,
+        event_source_url,
+        action_source: 'website',
+        user_data: {
+          client_ip_address: ip,
+          client_user_agent: userAgent,
+          fbp,
+          fbc
+        },
+        custom_data: {
+          value,
+          currency,
+          ...custom_data
+        }
+      }
+    ],
+    access_token: ACCESS_TOKEN
+  };
+
+  try {
+    const url = `https://graph.facebook.com/v19.0/${PIXEL_ID}/events`;
+    const res = await axios.post(url, payload);
+    return { success: true, response: res.data };
+  } catch (err) {
+    console.error('Erro ao enviar evento Facebook:', err.response?.data || err.message);
+    return { success: false, error: err.response?.data || err.message };
+  }
+}
+
+module.exports = { sendFacebookEvent };


### PR DESCRIPTION
## Summary
- create reusable `services/facebook.js` for sending events to Meta
- store Facebook Pixel data and UTM params when generating Pix
- send `InitiateCheckout` to the Conversions API on charge creation
- send `Purchase` to the Conversions API when payment is confirmed
- expand SQLite and PostgreSQL schemas with new tracking columns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68705479aba8832ab5e593bd3c69cc4c