### PR TITLE
Implement secure webhook and token tracking

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -140,7 +140,14 @@ async function createTables(pool) {
   
   try {
     console.log('📋 Criando/verificando tabelas...');
-    
+
+    // Tipo ENUM para status dos tokens
+    await client.query(`DO $$
+      BEGIN
+        CREATE TYPE IF NOT EXISTS token_status AS ENUM ('pendente','valido','expirado');
+      END
+    $$;`);
+
     // Tabela de tokens
     await client.query(`
       CREATE TABLE IF NOT EXISTS tokens (
@@ -148,6 +155,8 @@ async function createTables(pool) {
         token VARCHAR(255) UNIQUE NOT NULL,
         usado BOOLEAN DEFAULT FALSE,
         valor DECIMAL(10,2) DEFAULT 0.00,
+        status token_status DEFAULT 'pendente',
+        event_time BIGINT NULL,
         bot_id VARCHAR(50) NULL,
         utm_source VARCHAR(255) NULL,
         utm_campaign VARCHAR(255) NULL,
@@ -179,6 +188,8 @@ async function createTables(pool) {
       ALTER TABLE tokens ADD COLUMN IF NOT EXISTS fbc VARCHAR(255);
       ALTER TABLE tokens ADD COLUMN IF NOT EXISTS ip_criacao INET;
       ALTER TABLE tokens ADD COLUMN IF NOT EXISTS user_agent_criacao TEXT;
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS status token_status DEFAULT 'pendente';
+      ALTER TABLE tokens ADD COLUMN IF NOT EXISTS event_time BIGINT;
     `);
     
     // Criar índices para melhor performance

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -33,7 +33,8 @@ function initialize(path = './pagamentos.db') {
         user_agent_criacao TEXT,
         status TEXT DEFAULT 'pendente',
         token_uuid TEXT,
-        criado_em DATETIME DEFAULT CURRENT_TIMESTAMP
+        criado_em DATETIME DEFAULT CURRENT_TIMESTAMP,
+        event_time INTEGER
       )
     `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
@@ -62,6 +63,9 @@ function initialize(path = './pagamentos.db') {
     }
     if (!checkCol('user_agent_criacao')) {
       database.prepare('ALTER TABLE tokens ADD COLUMN user_agent_criacao TEXT').run();
+    }
+    if (!checkCol('event_time')) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN event_time INTEGER').run();
     }
     console.log('✅ SQLite inicializado');
   } catch (err) {


### PR DESCRIPTION
## Summary
- prevent deadlock with try/finally when processing queue
- store event_time when creating charge and reuse later
- guard webhook with payload validation and secret token
- skip duplicate token processing
- ensure all timestamps use Luxon
- add `token_status` enum with new event_time column in databases

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68705a8a3424832a9dfd0a1733696a82