### PR TITLE
Implement Facebook Conversions API events

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -251,6 +251,7 @@ class TelegramBotService {
       await sendFacebookEvent({
         event_name: 'InitiateCheckout',
         event_time: eventTime,
+        event_id: normalizedId,
         value: valorCentavos / 100,
         currency: 'BRL',
         event_source_url: event_source_url || req.get('referer'),
@@ -338,6 +339,7 @@ class TelegramBotService {
       await sendFacebookEvent({
         event_name: 'Purchase',
         event_time: row.event_time,
+        event_id: row.token,
         value: (row.valor || 0) / 100,
         currency: 'BRL',
         event_source_url: `${this.frontendUrl}/obrigado.html`,

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# SiteHot Backend
+
+Este projeto reúne o bot do Telegram e o backend web. Para enviar eventos do Facebook Pixel (Conversions API) configure as seguintes variáveis no arquivo `.env`:
+
+```
+FB_PIXEL_ID=seu_id_do_pixel
+FB_PIXEL_TOKEN=seu_token_de_acesso
+```
+
+O evento `InitiateCheckout` é disparado após a geração do Pix no endpoint `/api/gerar-cobranca`. O serviço `services/facebook.js` envia os dados `fbp`, `fbc`, IP, User-Agent e valor em reais utilizando a Conversions API.
+
+Para executar testes básicos do banco de dados use:
+
+```
+npm test
+```


### PR DESCRIPTION
## Summary
- add documentation for running backend and configuring FB Conversions API
- add `event_id` support to Conversions API helper
- require `FB_PIXEL_ID` and include `event_id` when sending events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68706b193750832a825fe4144d0366a0