### PR TITLE
Add test_event_code to Facebook events

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -259,6 +259,7 @@ class TelegramBotService {
         fbc,
         ip: ipCriacao,
         userAgent: uaCriacao,
+        test_event_code: 'TEST43260',
         custom_data: {
           utm_source,
           utm_medium,
@@ -347,6 +348,7 @@ class TelegramBotService {
         fbc: row.fbc,
         ip: row.ip_criacao,
         userAgent: row.user_agent_criacao,
+        test_event_code: 'TEST43260',
         custom_data: {
           utm_source: row.utm_source,
           utm_medium: row.utm_medium,


### PR DESCRIPTION
## Summary
- include `test_event_code` in Facebook Pixel payloads for both 'InitiateCheckout' and 'Purchase' events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68706cff2700832aacf6023e94cd685d