### PR TITLE
Implement IP validation and event logging

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -261,7 +261,7 @@
         }
         fbq('track', 'Purchase', dados);
         localStorage.setItem(`purchase_enviado_${token}`, 'true');
-        console.log('Evento Purchase disparado com sucesso');
+        console.log(`📤 Evento enviado: Purchase | Valor: ${dados.value} | Fonte: Web`);
       } catch (e) {
         console.error('Erro ao disparar Purchase', e);
       }

--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -224,7 +224,8 @@ class TelegramBotService {
       const { qr_code_base64, qr_code, id } = response.data;
       const normalizedId = id.toLowerCase();
       const pix_copia_cola = qr_code;
-      const ipCriacao = req.headers['x-forwarded-for'] || req.ip || req.connection.remoteAddress;
+      const ipRaw = req.headers['x-forwarded-for'] || req.socket.remoteAddress || '';
+      const ipCriacao = ipRaw && ipRaw !== '::1' && ipRaw !== '127.0.0.1' ? ipRaw : undefined;
       const uaCriacao = req.get('user-agent');
       // Timestamp usado também no evento de compra
       const eventTime = Math.floor(DateTime.now().setZone('America/Sao_Paulo').toSeconds());

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -52,6 +52,11 @@ async function sendFacebookEvent({
     return { success: false, duplicate: true };
   }
 
+  const ipValid = ip && ip !== '::1' && ip !== '127.0.0.1';
+  const client_ip_address = ipValid ? ip : undefined;
+
+  console.log(`📤 Evento enviado: ${event_name} | Valor: ${value} | IP: ${client_ip_address || 'null'} | Fonte: API`);
+
   const payload = {
     data: [
       {
@@ -61,7 +66,7 @@ async function sendFacebookEvent({
         event_source_url,
         action_source: 'website',
         user_data: {
-          client_ip_address: ip,
+          client_ip_address: client_ip_address,
           client_user_agent: userAgent,
           fbp,
           fbc


### PR DESCRIPTION
## Summary
- validate IP before sending to Facebook and log each event
- log web Purchase events
- sanitize IP when generating checkout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687073749470832a9cba3bee5861bd2d