### PR TITLE
Fix IP extraction for events

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -224,7 +224,8 @@ class TelegramBotService {
       const { qr_code_base64, qr_code, id } = response.data;
       const normalizedId = id.toLowerCase();
       const pix_copia_cola = qr_code;
-      const ipRaw = req.headers['x-forwarded-for'] || req.socket.remoteAddress || '';
+      const ipRawList = req.headers['x-forwarded-for'] || req.socket.remoteAddress || '';
+      const ipRaw = typeof ipRawList === 'string' ? ipRawList.split(',')[0].trim() : '';
       const ipCriacao = ipRaw && ipRaw !== '::1' && ipRaw !== '127.0.0.1' ? ipRaw : undefined;
       const uaCriacao = req.get('user-agent');
       // Timestamp usado também no evento de compra


### PR DESCRIPTION
## Summary
- parse `x-forwarded-for` header correctly in `TelegramBotService`
- first IP from header is stored and sent to Facebook if valid

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687075fb4a1c832aa8187c43294f733b