### PR TITLE
Check token status before using

### DIFF
--- a/MODELO1/WEB/tokens.js
+++ b/MODELO1/WEB/tokens.js
@@ -207,7 +207,7 @@ module.exports = (app, databasePool) => {
       }
       
       const result = await databasePool.query(
-        'SELECT id, valor, usado FROM tokens WHERE token = $1',
+        'SELECT id, valor, usado, status FROM tokens WHERE token = $1',
         [token]
       );
       
@@ -219,11 +219,18 @@ module.exports = (app, databasePool) => {
       }
       
       const tokenData = result.rows[0];
-      
+
+      if (tokenData.status !== 'valido') {
+        return res.status(400).json({
+          sucesso: false,
+          erro: 'Token inválido'
+        });
+      }
+
       if (tokenData.usado) {
-        return res.status(400).json({ 
-          sucesso: false, 
-          erro: 'Token já foi usado' 
+        return res.status(400).json({
+          sucesso: false,
+          erro: 'Token já foi usado'
         });
       }
       

--- a/server.js
+++ b/server.js
@@ -129,7 +129,7 @@ app.post('/api/verificar-token', async (req, res) => {
     }
 
     const resultado = await databasePool.query(
-      'SELECT usado FROM tokens WHERE token = $1',
+      'SELECT usado, status FROM tokens WHERE token = $1',
       [token]
     );
 
@@ -137,7 +137,13 @@ app.post('/api/verificar-token', async (req, res) => {
       return res.json({ status: 'invalido' });
     }
 
-    if (resultado.rows[0].usado) {
+    const tokenData = resultado.rows[0];
+
+    if (tokenData.status !== 'valido') {
+      return res.json({ status: 'invalido' });
+    }
+
+    if (tokenData.usado) {
       return res.json({ status: 'usado' });
     }
 
@@ -169,7 +175,7 @@ app.get('/api/verificar-token', async (req, res) => {
     console.log('Token recebido:', token);
 
     const resultado = await databasePool.query(
-      'SELECT usado FROM tokens WHERE token = $1',
+      'SELECT usado, status FROM tokens WHERE token = $1',
       [token]
     );
 
@@ -179,7 +185,13 @@ app.get('/api/verificar-token', async (req, res) => {
       return res.json({ status: 'invalido' });
     }
 
-    if (resultado.rows[0].usado) {
+    const tokenData = resultado.rows[0];
+
+    if (tokenData.status !== 'valido') {
+      return res.json({ status: 'invalido' });
+    }
+
+    if (tokenData.usado) {
       return res.json({ status: 'usado' });
     }
 


### PR DESCRIPTION
## Summary
- validate token status is `valido` in `/api/verificar-token` endpoints
- ensure the tokens module only accepts tokens with status `valido`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68711af3f0c8832aa32ce2d808f27715