### PR TITLE
Remove Facebook test event code

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -261,7 +261,6 @@ class TelegramBotService {
         fbc,
         ip: ipCriacao,
         userAgent: uaCriacao,
-        test_event_code: 'TEST43260',
         custom_data: {
           utm_source,
           utm_medium,
@@ -350,7 +349,6 @@ class TelegramBotService {
         fbc: row.fbc,
         ip: row.ip_criacao,
         userAgent: row.user_agent_criacao,
-        test_event_code: 'TEST43260',
         custom_data: {
           utm_source: row.utm_source,
           utm_medium: row.utm_medium,


### PR DESCRIPTION
## Summary
- purge test event code from Facebook conversion events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68711de5b3c4832aa2681e60e617540f