### PR TITLE
Ensure usado column exists in SQLite

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -68,6 +68,16 @@ class TelegramBotService {
       console.error(`[${this.botId}] BASE_URL não definida`);
     }
     this.db = this.sqlite ? this.sqlite.initialize() : null;
+    if (this.db) {
+      try {
+        this.db.prepare(`ALTER TABLE tokens ADD COLUMN usado INTEGER DEFAULT 0`).run();
+        console.log(`[${this.botId}] 🧩 Coluna 'usado' adicionada ao SQLite`);
+      } catch (e) {
+        if (!e.message.includes('duplicate column name')) {
+          console.error(`[${this.botId}] ⚠️ Erro ao adicionar coluna 'usado' no SQLite:`, e.message);
+        }
+      }
+    }
 
     console.log(`\n[${this.botId}] 🔍 Verificando integridade das mídias...`);
     const integridade = this.gerenciadorMidia.verificarIntegridade();


### PR DESCRIPTION
## Summary
- add dynamic check for `usado` column when initializing TelegramBotService
- install dependencies so tests run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68713fd1ac98832ab7ef10f6ed16ec84