### PR TITLE
Add Facebook Pixel Purchase event

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -112,8 +112,22 @@
       t.src=v;s=b.getElementsByTagName(e)[0];
       s.parentNode.insertBefore(t,s)
     }(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
-    fbq('init', '1429424624747459');
-    fbq('track', 'PageView');
+  fbq('init', '1429424624747459');
+  fbq('track', 'PageView');
+</script>
+
+  <script>
+    const urlParams = new URLSearchParams(window.location.search);
+    const token = urlParams.get('token');
+    const valor = urlParams.get('valor');
+
+    if (token && valor) {
+      fbq('track', 'Purchase', {
+        value: parseFloat(valor),
+        currency: 'BRL',
+        eventID: token
+      });
+    }
   </script>
 
   <script>

--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -362,7 +362,7 @@ class TelegramBotService {
       await sendFacebookEvent({
         event_name: 'Purchase',
         event_time: row.event_time,
-        event_id: row.token,
+        event_id: novoToken,
         value: (row.valor || 0) / 100,
         currency: 'BRL',
         event_source_url: `${this.frontendUrl}/obrigado.html`,

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -78,11 +78,12 @@ async function sendFacebookEvent({
         }
       }
     ],
-    access_token: ACCESS_TOKEN
+    access_token: ACCESS_TOKEN,
+    test_event_code: 'TEST43260'
   };
 
   try {
-    const url = `https://graph.facebook.com/v19.0/${PIXEL_ID}/events`;
+    const url = `https://graph.facebook.com/v18.0/${PIXEL_ID}/events`;
     const res = await axios.post(url, payload);
     return { success: true, response: res.data };
   } catch (err) {


### PR DESCRIPTION
## Summary
- track Purchase event via Facebook Pixel when visiting obrigado page
- send Purchase events to Facebook API with test_event_code and same event ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68715e7da2c8832a8c4ac9c959527e9e