### PR TITLE
Fix eventID for Purchase Pixel

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -251,7 +251,7 @@
       const fbc = localStorage.getItem('fbc');
       if (fbp) dados._fbp = fbp;
       if (fbc) dados._fbc = fbc;
-      if (token) dados.external_id = token;
+      if (token) dados.eventID = token;
 
       if (fbp || fbc) {
         console.log('Dados do Pixel:', { fbp, fbc });


### PR DESCRIPTION
## Summary
- ensure Purchase events use `eventID` instead of `external_id`

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68716f679ca8832a8d0ab70a7c3ce467