### PR TITLE
Add criado_em column check

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -167,6 +167,20 @@ async function createTables(pool) {
       throw err;
     }
     
+    // Garantir coluna criado_em existente
+    await pool.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='criado_em'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN criado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+        END IF;
+      END
+      $$;
+    `);
+
     // Criar índice para status dos tokens
     await pool.query(`
       CREATE INDEX IF NOT EXISTS idx_tokens_status ON tokens(status)


### PR DESCRIPTION
## Summary
- ensure `tokens.criado_em` column exists on DB init using `information_schema`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68717281f500832a8e321f623caaf7e6