### PR TITLE
Adjust fallback purchase sending

### DIFF
--- a/server.js
+++ b/server.js
@@ -263,9 +263,10 @@ function iniciarCronFallback() {
     if (!databasePool) return;
     try {
       const res = await databasePool.query(
-        "SELECT token, valor, utm_source, utm_medium, utm_campaign, utm_term, utm_content, fbp, fbc, criado_em, event_time FROM tokens WHERE status = 'pendente' AND criado_em < NOW() - INTERVAL '10 minutes'"
+        "SELECT token, valor, utm_source, utm_medium, utm_campaign, utm_term, utm_content, fbp, fbc, criado_em, event_time FROM tokens WHERE status = 'valido' AND (usado IS NULL OR usado = FALSE) AND criado_em < NOW() - INTERVAL '1 minute'"
       );
       for (const row of res.rows) {
+        console.log(`\u26A0\uFE0F Fallback CAPI: enviando evento atrasado para o token ${row.token}`);
         await sendFacebookEvent({
           event_name: 'Purchase',
           event_time: row.event_time || Math.floor(new Date(row.criado_em).getTime() / 1000),


### PR DESCRIPTION
## Summary
- shorten the waiting period before the CAPI fallback runs
- log when sending delayed Purchase events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687180c6857c832aa95c0f29143b4d4d