### PR TITLE
Fix token generation only after payment

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -145,8 +145,8 @@ async function createTables(pool) {
     try {
       await pool.query(`
         CREATE TABLE IF NOT EXISTS tokens (
-          token TEXT PRIMARY KEY,
-          id_transacao TEXT UNIQUE,
+          id_transacao TEXT PRIMARY KEY,
+          token TEXT UNIQUE,
           telegram_id TEXT,
           valor NUMERIC,
           criado_em TIMESTAMP DEFAULT NOW(),

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -18,8 +18,8 @@ function initialize(path = './pagamentos.db') {
   try {
     database.prepare(`
       CREATE TABLE IF NOT EXISTS tokens (
-        token TEXT PRIMARY KEY,
-        id_transacao TEXT,
+        id_transacao TEXT PRIMARY KEY,
+        token TEXT UNIQUE,
         telegram_id TEXT,
         valor INTEGER,
         bot_id TEXT,


### PR DESCRIPTION
## Summary
- store transaction id when generating charges
- allow token to be null until payment is confirmed
- create token on webhook when status is paid
- tweak verify response message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871823e72ac832a8829c8e21e9b9d39