### PR TITLE
Fix PushinPay token handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -441,7 +441,12 @@ async function carregarSistemaTokens() {
 
 app.post('/webhook/pushinpay', async (req, res) => {
   try {
-    const token = (req.body?.token || req.body?.id || '').toLowerCase().trim();
+    const token =
+      (req.body?.token || req.body?.id || req.body?.transaction_id || '')
+        .toLowerCase()
+        .trim();
+    console.log('📥 Webhook recebido da PushinPay:', req.body);
+    console.log('🔍 Token extraído do webhook:', token);
     if (!token) {
       return res.status(400).json({ error: 'Token ausente' });
     }


### PR DESCRIPTION
## Summary
- ensure `/webhook/pushinpay` also checks `transaction_id`
- log webhook data and extracted token for debugging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871ba4e7940832a862b566e8126a133