### PR TITLE
Fix Facebook CAPI dedup and logging

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -258,8 +258,8 @@ class TelegramBotService {
         event_source_url: event_source_url || req.get('referer'),
         fbp,
         fbc,
-        ip: ipCriacao,
-        userAgent: uaCriacao,
+        client_ip_address: ipCriacao,
+        client_user_agent: uaCriacao,
         custom_data: {
           utm_source,
           utm_medium,


### PR DESCRIPTION
## Summary
- improve `sendFacebookEvent` to set IP/UA info
- log full API response for troubleshooting
- pass client IP and UA in TelegramBotService

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871c6db7c34832a892fc38feec0722a