### PR TITLE
Corrige uso de ID da PushinPay

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -222,25 +222,14 @@ class TelegramBotService {
       return res.status(400).json({ error: 'Valor mínimo é R$0,50.' });
     }
     try {
-      const transactionId = uuidv4().toLowerCase();
       const ipRawList = req.headers['x-forwarded-for'] || req.socket.remoteAddress || '';
       const ipRaw = typeof ipRawList === 'string' ? ipRawList.split(',')[0].trim() : '';
       const ipCriacao = ipRaw && ipRaw !== '::1' && ipRaw !== '127.0.0.1' ? ipRaw : undefined;
       const uaCriacao = req.get('user-agent');
       const eventTime = Math.floor(DateTime.now().setZone('America/Sao_Paulo').toSeconds());
 
-      if (this.db) {
-        this.db.prepare(`
-          INSERT INTO tokens (id_transacao, token, valor, telegram_id, utm_source, utm_campaign, utm_medium, utm_term, utm_content, fbp, fbc, ip_criacao, user_agent_criacao, bot_id, status, event_time)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pendente', ?)
-        `).run(transactionId, transactionId, valorCentavos, telegram_id, utm_source, utm_campaign, utm_medium, utm_term, utm_content, fbp, fbc, ipCriacao, uaCriacao, this.botId, eventTime);
-        console.log('Token salvo:', transactionId);
-      }
-
       const response = await axios.post('https://api.pushinpay.com.br/api/pix/cashIn', {
         value: valorCentavos,
-        // Enviamos nosso próprio identificador para rastrear a transação
-        id: transactionId,
         webhook_url: `${this.baseUrl}/webhook/pushinpay`
       }, {
         headers: {
@@ -251,10 +240,22 @@ class TelegramBotService {
       });
 
       const { qr_code_base64, qr_code, id: apiId } = response.data;
-      if (apiId && apiId !== transactionId) {
-        console.warn(`[${this.botId}] PushinPay retornou id diferente do enviado: ${apiId}`);
+      const normalizedId = apiId ? apiId.toLowerCase() : null;
+      if (!normalizedId) {
+        throw new Error('ID da transação não retornado pela PushinPay');
       }
-      const normalizedId = transactionId;
+
+      if (this.db) {
+        this.db.prepare(`
+          INSERT INTO tokens (id_transacao, token, valor, telegram_id, utm_source, utm_campaign, utm_medium, utm_term, utm_content, fbp, fbc, ip_criacao, user_agent_criacao, bot_id, status, event_time)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pendente', ?)
+        `).run(normalizedId, normalizedId, valorCentavos, telegram_id, utm_source, utm_campaign, utm_medium, utm_term, utm_content, fbp, fbc, ipCriacao, uaCriacao, this.botId, eventTime);
+        console.log('Token salvo:', normalizedId);
+      }
+
+      if (apiId && apiId !== normalizedId) {
+        console.warn(`[${this.botId}] PushinPay retornou id: ${apiId}`);
+      }
       const pix_copia_cola = qr_code;
       // O token será copiado para o PostgreSQL somente após a confirmação de pagamento
 


### PR DESCRIPTION
## Resumo
- usar o id retornado pela PushinPay em vez de gerar um UUID
- registrar esse id no SQLite e enviar ao usuário

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871d395c2dc832a91249251870e9cb4