### PR TITLE
Atualiza sequência de downsells

### DIFF
--- a/MODELO1/BOT/config1.js
+++ b/MODELO1/BOT/config1.js
@@ -37,22 +37,22 @@ ou volta pro Insta fingindo que não queria me ver... mas vai continuar pensando
   ],
 
   downsells: [
-    ...[19.90, 18.90, 18.90, 17.90, 17.90, 16.90, 16.90, 15.90, 15.90, 13.90, 13.90, 13.90].map((preco, i) => ({
+    ...[19.90, 18.90, 18.90, 17.90, 15.90, 15.90, 15.90, 15.90, 15.90, 15.90, 15.90, 15.90].map((preco, i) => ({
       id: `ds${i+1}`,
       emoji: '💋',
       texto: [
         'Ei, tá esperando o quê?\nVocê já viu tudo... e quer mais.\nR$19,90. Vitalício. Sem assinatura. Sem censura.\nPagou, entrou. Entrou, gozou.',
         'Tá indeciso?\nTe entendo... mas teu desejo é maior que tua dúvida.\nToma 5% OFF agora.\nR$18,90 – acesso vitalício.\nNão enrola. Uma vez só.',
-        'Você já sabe o que tem lá dentro.\nE já imagina o que vai fazer com aquele conteúdo… 😈\nÚltima vez com 5% OFF: R$18,90.\nEntra agora e se entrega.',
+        'Você já sabe o que tem lá dentro.\nE já imagina o que vai fazer com aquele conteúdo…\nÚltima vez com 5% OFF: R$18,90.\nEntra agora e se entrega.',
         'Te dou 10% agora. Mas é agora mesmo.\nR$17,90 – vitalício.\nSaiu dessa tela, acabou.\nVocê sabe que quer. Clica logo.',
-        'Tem gente lá dentro aproveitando tudo. Só falta você.\nEsse acesso é único, direto, completo.\n10% OFF: R$17,90.\nPaga uma vez, entra pra sempre.',
-        'Você quase entrou…\nE eu quase te mostrei tudo.\nQuer mesmo perder? Toma 15% OFF.\nR$16,90. Vitalício. Agora ou nunca. 🔥',
-        'Você viu meu corpo. Sentiu minha vibe.\nSabe que vai se arrepender se sair agora…\n15% de desconto só pra você: R$16,90.\nAceita seu desejo.',
-        'Se você tá aqui ainda, é porque quer.\nMas tá testando seus próprios limites...\nEu deixo mais fácil: R$15,90. 20% OFF.\nMostra que tem coragem. Vem.',
-        'Você tá resistindo por causa de 4 reais? Sério?\n20% OFF: R$15,90 – conteúdo completo, vitalício.\nNem tenta se enganar, você vai amar isso aqui.',
-        'Já recusou 9 vezes. Mas tá aqui ainda. Por quê?\nPorque você QUER. E eu quero que você entre.\nÚltima vez com 30% OFF: R$13,90.\nDepois disso, nem adianta pedir. 🔒',
-        'Você já viu tudo… mas ainda não pegou.\nTá esperando cair do céu? Não vai.\nR$13,90. Vitalício. Sem reembolso. Sem perdão.\nSó entra, e para de bancar o difícil. 😏',
-        'Essa é a última tela. Última chance. Último clique.\nSaiu? Perdeu pra sempre.\nR$13,90 – o menor valor de todos.\nSó entra se tiver coragem de gozar até o fim.'
+        'Você tá aqui ainda… então toma mais um empurrãozinho.\nR$15,90 – vitalício.\nSem assinatura. Sem limite. Pagou, entrou.\nDepois disso, esse valor é fixo.',
+        'Tem gente lá dentro aproveitando tudo. Só falta você.\nR$15,90 – acesso vitalício.\nEsse valor não cai mais. Só falta você entrar.',
+        'Você quase entrou… e eu quase te mostrei tudo.\nR$15,90 – vitalício.\nÚltima chamada pra quem tem coragem.',
+        'Você viu meu corpo. Sentiu minha vibe.\nSabe que vai se arrepender se sair agora…\nR$15,90 – fixo. Sem volta.',
+        'Se você tá aqui ainda, é porque quer.\nTá testando teu limite?\nEntão testa isso: R$15,90 vitalício. Entra ou some.',
+        'Já recusou várias vezes. Mas tá aqui ainda, né?\nR$15,90 – última chance real.\nDepois disso, só no print.',
+        'Tá se fazendo de difícil?\nR$15,90 – vitalício.\nMas se sair dessa tela, eu fecho tudo.',
+        'Essa é a última tela. Último clique. Último aviso.\nR$15,90 – acesso vitalício garantido.\nSaiu? Nunca mais.'
       ][i],
       tipoMidia: 'video',
       planos: [


### PR DESCRIPTION
## Summary
- atualiza a lista de preços e falas do bloco `.map()` em `config1.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871de3e3d10832ab9a1425181a086a2