### PR TITLE
Add Facebook tracking integration

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -53,6 +53,37 @@
         if (value) urlParams.set(key, value);
       });
 
+    // Captura _fbp, _fbc e IP se ainda não estiverem no localStorage
+    (function() {
+      function getCookie(name) {
+        const m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+        return m ? decodeURIComponent(m[1]) : null;
+      }
+      try {
+        const fbp = localStorage.getItem('fbp') || getCookie('_fbp');
+        const fbc = localStorage.getItem('fbc') || getCookie('_fbc');
+        if (fbp) localStorage.setItem('fbp', fbp);
+        if (fbc) localStorage.setItem('fbc', fbc);
+      } catch (e) {}
+      if (!localStorage.getItem('client_ip_address')) {
+        fetch('https://api.ipify.org?format=json').then(r => r.json()).then(d => {
+          if (d && d.ip) localStorage.setItem('client_ip_address', d.ip);
+        }).catch(() => {});
+      }
+    })();
+
+    // Constrói payload resumido para o Telegram
+    const trackParts = [];
+    const fbpPayload = localStorage.getItem('fbp');
+    if (fbpPayload) trackParts.push('fbp-' + fbpPayload);
+    const fbcPayload = localStorage.getItem('fbc');
+    if (fbcPayload) trackParts.push('fbc-' + fbcPayload);
+    const ipPayload = localStorage.getItem('client_ip_address');
+    if (ipPayload) trackParts.push('ip-' + ipPayload);
+    if (trackParts.length > 0) {
+      urlParams.set('p', trackParts.join('_'));
+    }
+
     const utmString = urlParams.toString();
     cta.href = utmString ? `${baseUrl}?start=${utmString}` : baseUrl;
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ Para executar testes básicos do banco de dados use:
 ```
 npm test
 ```
+
+Para versões antigas do banco PostgreSQL já existentes, adicione manualmente as colunas de rastreamento executando:
+
+```
+ALTER TABLE tokens ADD COLUMN IF NOT EXISTS fbp TEXT;
+ALTER TABLE tokens ADD COLUMN IF NOT EXISTS fbc TEXT;
+ALTER TABLE tokens ADD COLUMN IF NOT EXISTS ip_criacao TEXT;
+ALTER TABLE tokens ADD COLUMN IF NOT EXISTS user_agent_criacao TEXT;
+```
+

--- a/database/postgres.js
+++ b/database/postgres.js
@@ -159,6 +159,10 @@ async function createTables(pool) {
           utm_campaign TEXT,
           utm_term TEXT,
           utm_content TEXT,
+          fbp TEXT,
+          fbc TEXT,
+          ip_criacao TEXT,
+          user_agent_criacao TEXT,
           event_time INTEGER
         )
       `);
@@ -176,6 +180,30 @@ async function createTables(pool) {
           WHERE table_name='tokens' AND column_name='criado_em'
         ) THEN
           ALTER TABLE tokens ADD COLUMN criado_em TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='fbp'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN fbp TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='fbc'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN fbc TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='ip_criacao'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN ip_criacao TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='user_agent_criacao'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN user_agent_criacao TEXT;
         END IF;
       END
       $$;


### PR DESCRIPTION
## Summary
- capture `_fbp`, `_fbc` and IP on landing page and send as compact payload to Telegram
- parse payload in Telegram bot and store per user
- forward tracking data when generating charges
- store tracking columns in PostgreSQL and ensure creation/alteration
- send IP with fallback cron events
- document manual SQL migration commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687417310080832abefbfc92aaf96e8c