### PR TITLE
Add browser user-agent tracking

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -53,7 +53,7 @@
         if (value) urlParams.set(key, value);
       });
 
-    // Captura _fbp, _fbc e IP se ainda não estiverem no localStorage
+    // Captura _fbp, _fbc, IP e User-Agent se ainda não estiverem no localStorage
     (function() {
       function getCookie(name) {
         const m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
@@ -70,6 +70,11 @@
           if (d && d.ip) localStorage.setItem('client_ip_address', d.ip);
         }).catch(() => {});
       }
+      if (!localStorage.getItem('user_agent_criacao')) {
+        try {
+          localStorage.setItem('user_agent_criacao', navigator.userAgent);
+        } catch (e) {}
+      }
     })();
 
     // Constrói payload resumido para o Telegram
@@ -80,6 +85,8 @@
     if (fbcPayload) trackParts.push('fbc-' + fbcPayload);
     const ipPayload = localStorage.getItem('client_ip_address');
     if (ipPayload) trackParts.push('ip-' + ipPayload);
+    const uaPayload = localStorage.getItem('user_agent_criacao');
+    if (uaPayload) trackParts.push('ua-' + encodeURIComponent(uaPayload));
     if (trackParts.length > 0) {
       urlParams.set('p', trackParts.join('_'));
     }

--- a/server.js
+++ b/server.js
@@ -259,7 +259,7 @@ function iniciarCronFallback() {
     if (!databasePool) return;
     try {
       const res = await databasePool.query(
-        "SELECT token, valor, utm_source, utm_medium, utm_campaign, utm_term, utm_content, fbp, fbc, ip_criacao, criado_em, event_time FROM tokens WHERE status = 'valido' AND (usado IS NULL OR usado = FALSE) AND criado_em < NOW() - INTERVAL '1 minute'"
+        "SELECT token, valor, utm_source, utm_medium, utm_campaign, utm_term, utm_content, fbp, fbc, ip_criacao, user_agent_criacao, criado_em, event_time FROM tokens WHERE status = 'valido' AND (usado IS NULL OR usado = FALSE) AND criado_em < NOW() - INTERVAL '1 minute'"
       );
       for (const row of res.rows) {
         if (row.fbp || row.fbc || row.ip_criacao) {
@@ -273,6 +273,7 @@ function iniciarCronFallback() {
             fbp: row.fbp,
             fbc: row.fbc,
             client_ip_address: row.ip_criacao,
+            client_user_agent: row.user_agent_criacao,
             custom_data: {
               utm_source: row.utm_source,
               utm_medium: row.utm_medium,


### PR DESCRIPTION
## Summary
- capture browser user agent in `index.html`
- parse `ua-` payload in `TelegramBotService`
- forward user agent to `/api/gerar-cobranca` and store it
- include stored user agent when sending events to Facebook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687427213fd0832a8175fff5c78415a7