### PR TITLE
Fix InitiateCheckout tracking data

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -72,7 +72,7 @@ async function sendFacebookEvent({
   if (finalUserAgent) user_data.client_user_agent = finalUserAgent;
   if (event_source_url) user_data.event_source_url = event_source_url;
 
-  console.log('🔧 user_data:', user_data);
+  console.log('🔧 user_data:', JSON.stringify(user_data));
 
   const eventPayload = {
     event_name,


### PR DESCRIPTION
## Summary
- fetch tracking data from `trackingData` when generating a charge
- store tracking info when inserting token record
- send InitiateCheckout event using fbp/fbc/ip/user_agent from tracking data
- improve logging of `user_data` in Facebook service

## Testing
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68742e0cb374832a8f75a2a947bee23a