### PR TITLE
Fix Facebook cookie capture

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -59,12 +59,30 @@
         const m = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
         return m ? decodeURIComponent(m[1]) : null;
       }
-      try {
-        const fbp = localStorage.getItem('fbp') || getCookie('_fbp');
-        const fbc = localStorage.getItem('fbc') || getCookie('_fbc');
-        if (fbp) localStorage.setItem('fbp', fbp);
-        if (fbc) localStorage.setItem('fbc', fbc);
-      } catch (e) {}
+
+      function storePixelCookies() {
+        try {
+          if (!localStorage.getItem('fbp')) {
+            if (typeof fbq === 'function') {
+              fbq('get', 'fbp', val => { if (val) localStorage.setItem('fbp', val); });
+            } else {
+              const fbp = getCookie('_fbp');
+              if (fbp) localStorage.setItem('fbp', fbp);
+            }
+          }
+          if (!localStorage.getItem('fbc')) {
+            if (typeof fbq === 'function') {
+              fbq('get', 'fbc', val => { if (val) localStorage.setItem('fbc', val); });
+            } else {
+              const fbc = getCookie('_fbc');
+              if (fbc) localStorage.setItem('fbc', fbc);
+            }
+          }
+        } catch (e) {}
+      }
+
+      setTimeout(storePixelCookies, 500);
+
       if (!localStorage.getItem('client_ip_address')) {
         fetch('https://api.ipify.org?format=json').then(r => r.json()).then(d => {
           if (d && d.ip) localStorage.setItem('client_ip_address', d.ip);


### PR DESCRIPTION
## Summary
- ensure Facebook pixel cookies are saved only after they are available
- delay retrieval of `_fbp` and `_fbc` using `fbq('get')`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687446860c68832a861278b9490ed9dd