### PR TITLE
Fix delayed pixel data link build

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -121,7 +121,6 @@
 
     async function prepareLink() {
       await gatherTracking();
-      await new Promise(r => setTimeout(r, 800));
       rebuildParams();
       let utmString = urlParams.toString();
       if (utmString.length > 64) {


### PR DESCRIPTION
## Summary
- only build CTA link after `PageView` pixel loads
- remove extra delay in `prepareLink`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687461601364832ab9478864c8e25832