### PR TITLE
Adiciona atraso para ativar CTA com dados de tracking

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -139,10 +139,27 @@
     }
 
     window.addEventListener('load', () => {
-      setTimeout(async () => {
+      cta.classList.add('disabled');
+      cta.href = '#';
+
+      let activated = false;
+
+      const activate = async () => {
+        if (activated) return;
+        activated = true;
         await prepareLink();
+        cta.classList.remove('disabled');
         console.log('[DEBUG] trackData final usado no link:', trackData);
-      }, 300);
+      };
+
+      const fallback = setTimeout(activate, 3000);
+
+      gatherTracking().then(() => {
+        if (trackData.fbp || trackData.fbc) {
+          clearTimeout(fallback);
+          activate();
+        }
+      });
     });
 
     // Evento de clique com redirecionamento direto

--- a/MODELO1/WEB/style.css
+++ b/MODELO1/WEB/style.css
@@ -108,6 +108,12 @@ body {
   box-shadow: 0 5px 10px rgba(199, 44, 72, 0.4);
 }
 
+.disabled {
+  opacity: 0.6;
+  pointer-events: none;
+  cursor: default;
+}
+
 .btn-pastel:hover {
   background-color: #A02136;
 }


### PR DESCRIPTION
## Summary
- desativa o botão CTA inicialmente
- ativa o link ao capturar `fbp` ou `fbc` ou após 3s
- adiciona estilo `.disabled` para opacidade e cursor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687463c42f20832a8321927d39673987