### PR TITLE
Fix Telegram link generation

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -134,7 +134,13 @@
       urlParams.delete('p'); utmString = urlParams.toString();
     }
 
-    cta.href = `${baseUrl}?start=${urlParams.get('p')}`;
+    const compressed = urlParams.get('p');
+    cta.href = compressed ? `${baseUrl}?start=${compressed}` : baseUrl;
+    if (!Object.keys(trackData).length) {
+      console.warn('[DEBUG] trackData vazio, usando link base');
+    }
+    console.log('[DEBUG] start final:', compressed);
+    console.log('[DEBUG] Link final:', cta.href);
     console.log('[DEBUG] trackData final usado no link:', trackData);
   }
 


### PR DESCRIPTION
## Summary
- ensure `prepareLink()` only adds `start` param when tracking data exists
- add debug logs for final link and parameter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874719db600832a8bd90a31341669a3