### PR TITLE
Add debug logs to gatherTracking

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -106,6 +106,9 @@
     if (ua) fresh.user_agent = ua;
 
     Object.assign(trackData, fresh);
+    if (!fbp) console.warn('⚠️ fbp não encontrado');
+    if (!fbc) console.warn('⚠️ fbc não encontrado');
+    console.log('[DEBUG] trackData:', trackData);
     return fresh;
   }
 
@@ -136,6 +139,7 @@
 
     const compressed = urlParams.get('p');
     cta.href = compressed ? `${baseUrl}?start=${compressed}` : baseUrl;
+    console.log('[DEBUG] HREF final:', cta.href);
     if (!Object.keys(trackData).length) {
       console.warn('[DEBUG] trackData vazio, usando link base');
     }


### PR DESCRIPTION
## Summary
- add fallback warnings if Facebook pixel data is missing
- log `trackData` before returning from `gatherTracking`
- log final link after generating CTA href

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687473759b50832a84a7f517be3f7d71