### PR TITLE
Fix fbq get with timeout

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -39,6 +39,7 @@
   const cta = document.getElementById("cta");
   const baseUrl = "https://t.me/vipshadrie_bot";
   const trackData = {};
+  const PIXEL_ID = '1429424624747459';
 
   function getCookie(name) {
     const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
@@ -46,19 +47,36 @@
   }
 
   function getPixelValue(lsKey, cookieName) {
+    const defaultValue = lsKey === 'fbp' ? 'nofbp' : 'nofbc';
     return new Promise(resolve => {
       const stored = localStorage.getItem(lsKey);
       if (stored) return resolve(stored);
+
+      const cookieVal = getCookie(cookieName);
+      let settled = false;
       const done = val => {
+        if (settled) return;
+        settled = true;
         if (val) localStorage.setItem(lsKey, val);
-        resolve(val || null);
+        resolve(val || defaultValue);
       };
+
       if (typeof fbq === 'function') {
         try {
-          fbq('get', lsKey, val => done(val || getCookie(cookieName)));
-        } catch (e) { done(getCookie(cookieName)); }
+          console.debug(`[Pixel] fbq get ${lsKey}`);
+          const timer = setTimeout(() => {
+            console.debug(`[Pixel] timeout ao obter ${lsKey}`);
+            done(cookieVal);
+          }, 500);
+          fbq('get', PIXEL_ID, lsKey, val => {
+            clearTimeout(timer);
+            done(val || cookieVal);
+          });
+        } catch (e) {
+          done(cookieVal);
+        }
       } else {
-        done(getCookie(cookieName));
+        done(cookieVal);
       }
     });
   }
@@ -70,6 +88,7 @@
       getPixelValue('fbp', '_fbp'),
       getPixelValue('fbc', '_fbc')
     ]);
+    console.debug('[Pixel] valores obtidos', { fbp, fbc });
 
     let ip = localStorage.getItem('client_ip_address');
     if (!ip) {
@@ -108,6 +127,7 @@
     Object.assign(trackData, fresh);
     if (!fbp) console.warn('⚠️ fbp não encontrado');
     if (!fbc) console.warn('⚠️ fbc não encontrado');
+    console.debug('[Pixel] valores finais:', { fbp: trackData.fbp, fbc: trackData.fbc });
     console.log('[DEBUG] trackData:', trackData);
     return fresh;
   }
@@ -151,7 +171,7 @@
 
     console.log('[DEBUG] Removido:', removed.length ? removed.join(', ') : 'nada');
     console.log('[DEBUG] Tamanho do start:', compressed ? compressed.length : 0);
-    console.log('[DEBUG] Link final:', finalLink);
+    console.debug('[DEBUG] URL final de redirecionamento:', finalLink);
     console.log('[DEBUG] trackData final usado no link:', trackData);
   }
 


### PR DESCRIPTION
## Summary
- add PIXEL_ID const to use when reading Facebook cookies
- make `getPixelValue` resilient with timeout and fallback values
- log final fbp/fbc and redirect URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687479e6c158832a8407780a29c4cab6