### PR TITLE
Melhora prepareLink

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -130,18 +130,33 @@
       ];
 
       let data = { ...trackData };
+
+      if (!Object.keys(data).length) {
+        data = { fbp: 'nofbp' };
+      }
+
       let compressed = LZString.compressToEncodedURIComponent(JSON.stringify(data));
 
-      while (compressed && compressed.length > 64 && removalOrder.length) {
+      while (compressed && compressed.length > 64 && removalOrder.length > 0) {
         const key = removalOrder.shift();
         delete data[key];
         compressed = LZString.compressToEncodedURIComponent(JSON.stringify(data));
       }
 
+      if (compressed && compressed.length > 64) {
+        data = { fbp: trackData.fbp || 'nofbp' };
+        compressed = LZString.compressToEncodedURIComponent(JSON.stringify(data));
+      }
+
+      const dataKeys = Object.keys(data);
+      const removed = Object.keys(trackData).filter(k => !dataKeys.includes(k));
+
       const finalLink = compressed ? `${baseUrl}?start=${compressed}` : baseUrl;
       cta.href = finalLink;
 
+      console.log('[DEBUG] Dados removidos:', removed);
       console.log('[DEBUG] trackData final usado no link:', data);
+      console.log('[DEBUG] Tamanho final:', compressed ? compressed.length : 0);
       console.log('[DEBUG] URL final de redirecionamento:', finalLink);
     } catch (e) {
       console.error('Erro ao preparar link', e);


### PR DESCRIPTION
## Summary
- garante fallback para dados vazios
- ajusta compressão e campos removidos
- registra dados removidos e tamanho final

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687482863510832aa54e10ffc00bdccd