### PR TITLE
Persist tracking info between sessions

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -143,7 +143,7 @@ async function createTables(pool) {
 
     // Tabela de tokens
     try {
-      await pool.query(`
+    await pool.query(`
         CREATE TABLE IF NOT EXISTS tokens (
           id_transacao TEXT PRIMARY KEY,
           token TEXT UNIQUE,
@@ -164,6 +164,16 @@ async function createTables(pool) {
           ip_criacao TEXT,
           user_agent_criacao TEXT,
           event_time INTEGER
+        )
+      `);
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS tracking_data (
+          telegram_id BIGINT PRIMARY KEY,
+          fbp TEXT,
+          fbc TEXT,
+          ip TEXT,
+          user_agent TEXT,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
       `);
     } catch (err) {

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -37,6 +37,16 @@ function initialize(path = './pagamentos.db') {
         event_time INTEGER
       )
     `).run();
+    database.prepare(`
+      CREATE TABLE IF NOT EXISTS tracking_data (
+        telegram_id TEXT PRIMARY KEY,
+        fbp TEXT,
+        fbc TEXT,
+        ip TEXT,
+        user_agent TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
     const checkCol = name => cols.some(c => c.name === name);
 


### PR DESCRIPTION
## Summary
- create new `tracking_data` table for SQLite and PostgreSQL
- add helper methods in `TelegramBotService` for saving and retrieving tracking data
- persist tracking data on `/start` and retrieve it on charge creation
- periodically clean old tracking entries

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68748826ec58832a95f231ee094f40d8