### PR TITLE
Add payload tracking route and table

### DIFF
--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -47,6 +47,16 @@ function initialize(path = './pagamentos.db') {
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     `).run();
+    database.prepare(`
+      CREATE TABLE IF NOT EXISTS payload_tracking (
+        payload_id TEXT PRIMARY KEY,
+        fbp TEXT,
+        fbc TEXT,
+        ip TEXT,
+        user_agent TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
     const checkCol = name => cols.some(c => c.name === name);
 


### PR DESCRIPTION
## Summary
- create `payload_tracking` table during SQLite init
- add `/api/payload` endpoint to store tracking info and return an id

## Testing
- `npm test`
- `node - <<'EOF'
const db=require('./database/sqlite').initialize(':memory:');
const row=db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='payload_tracking'").get();
console.log('exists',!!row);
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68750af0c410832a845443d78a975894