### PR TITLE
Migrate payload tracking to PostgreSQL

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -176,6 +176,16 @@ async function createTables(pool) {
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
       `);
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS payload_tracking (
+          payload_id TEXT PRIMARY KEY,
+          fbp TEXT,
+          fbc TEXT,
+          ip TEXT,
+          user_agent TEXT,
+          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+      `);
     } catch (err) {
       console.error('❌ Erro ao criar tabela tokens:', err.message);
       throw err;

--- a/server.js
+++ b/server.js
@@ -234,7 +234,7 @@ app.get('/api/url-final', (req, res) => {
   res.json({ sucesso: true, url });
 });
 
-app.post('/api/payload', (req, res) => {
+app.post('/api/payload', async (req, res) => {
   try {
     const payloadId = crypto.randomBytes(4).toString('hex');
     const { fbp = null, fbc = null } = req.body || {};
@@ -245,16 +245,28 @@ app.post('/api/payload', (req, res) => {
         .trim() ||
       req.connection?.remoteAddress ||
       req.socket?.remoteAddress ||
-      (req.connection && req.connection.socket
-        ? req.connection.socket.remoteAddress
-        : null);
+      (req.connection && req.connection.socket?.remoteAddress) ||
+      null;
 
-    const db = sqlite.get();
-    if (db) {
+    // SQLite desativado
+    // const db = sqlite.get();
+    // if (db) {
+    //   try {
+    //     db.prepare(
+    //       'INSERT INTO payload_tracking (payload_id, fbp, fbc, ip, user_agent) VALUES (?,?,?,?,?)'
+    //     ).run(payloadId, fbp, fbc, ip, userAgent);
+    //   } catch (e) {
+    //     console.error('Erro ao inserir payload_tracking:', e.message);
+    //   }
+    // }
+
+    if (databasePool) {
       try {
-        db.prepare(
-          'INSERT INTO payload_tracking (payload_id, fbp, fbc, ip, user_agent) VALUES (?,?,?,?,?)'
-        ).run(payloadId, fbp, fbc, ip, userAgent);
+        await databasePool.query(
+          `INSERT INTO payload_tracking (payload_id, fbp, fbc, ip, user_agent)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [payloadId, fbp, fbc, ip, userAgent]
+        );
       } catch (e) {
         console.error('Erro ao inserir payload_tracking:', e.message);
       }


### PR DESCRIPTION
## Summary
- update `/api/payload` endpoint to use PostgreSQL instead of SQLite
- create `payload_tracking` table in postgres initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68750d2ec094832a8425813e6c0d8a95