### PR TITLE
Refactor payload tracking init

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -176,16 +176,7 @@ async function createTables(pool) {
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
       `);
-    await pool.query(`
-        CREATE TABLE IF NOT EXISTS payload_tracking (
-          payload_id TEXT PRIMARY KEY,
-          fbp TEXT,
-          fbc TEXT,
-          ip TEXT,
-          user_agent TEXT,
-          created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-        )
-      `);
+    // tabela payload_tracking movida para init-postgres
     } catch (err) {
       console.error('❌ Erro ao criar tabela tokens:', err.message);
       throw err;

--- a/init-postgres.js
+++ b/init-postgres.js
@@ -1,0 +1,18 @@
+const { createPool } = require('./database/postgres');
+
+async function initPostgres() {
+  const pool = createPool();
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS payload_tracking (
+      payload_id TEXT PRIMARY KEY,
+      fbp TEXT,
+      fbc TEXT,
+      ip TEXT,
+      user_agent TEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+  console.log('✅ Tabela payload_tracking verificada no PostgreSQL');
+}
+
+module.exports = initPostgres;


### PR DESCRIPTION
## Summary
- add `init-postgres.js` and invoke during server startup
- remove `payload_tracking` table creation from postgres module
- rename connection variable to `pool`
- clean `/api/payload` endpoint and log new payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68750eb2fa5c832aaef2379202754c42