### PR TITLE
Link telegram_id to payload rows

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -694,20 +694,22 @@ class TelegramBotService {
                 try {
                   await this.postgres.executeQuery(
                     this.pgPool,
-                    'DELETE FROM payload_tracking WHERE payload_id = $1',
-                    [payloadRaw]
+                    'UPDATE payload_tracking SET telegram_id = $1 WHERE payload_id = $2',
+                    [chatId, payloadRaw]
                   );
+                  console.log(`[payload] Associado: ${chatId} \u21D2 ${payloadRaw}`);
                 } catch (err) {
-                  console.warn(`[${this.botId}] Erro ao remover payload PG:`, err.message);
+                  console.warn(`[${this.botId}] Erro ao associar payload PG:`, err.message);
                 }
               }
               if (this.db) {
                 try {
                   this.db
-                    .prepare('DELETE FROM payload_tracking WHERE payload_id = ?')
-                    .run(payloadRaw);
+                    .prepare('UPDATE payload_tracking SET telegram_id = ? WHERE payload_id = ?')
+                    .run(chatId, payloadRaw);
+                  console.log(`[payload] Associado: ${chatId} \u21D2 ${payloadRaw}`);
                 } catch (err) {
-                  console.warn(`[${this.botId}] Erro ao remover payload SQLite:`, err.message);
+                  console.warn(`[${this.botId}] Erro ao associar payload SQLite:`, err.message);
                 }
               }
             }

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -50,6 +50,7 @@ function initialize(path = './pagamentos.db') {
     database.prepare(`
       CREATE TABLE IF NOT EXISTS payload_tracking (
         payload_id TEXT PRIMARY KEY,
+        telegram_id TEXT,
         fbp TEXT,
         fbc TEXT,
         ip TEXT,
@@ -58,7 +59,9 @@ function initialize(path = './pagamentos.db') {
       )
     `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
+    const payloadCols = database.prepare('PRAGMA table_info(payload_tracking)').all();
     const checkCol = name => cols.some(c => c.name === name);
+    const checkPayloadCol = name => payloadCols.some(c => c.name === name);
 
     if (!checkCol('id_transacao')) {
       database.prepare('ALTER TABLE tokens ADD COLUMN id_transacao TEXT').run();
@@ -86,6 +89,9 @@ function initialize(path = './pagamentos.db') {
     }
     if (!checkCol('event_time')) {
       database.prepare('ALTER TABLE tokens ADD COLUMN event_time INTEGER').run();
+    }
+    if (!checkPayloadCol('telegram_id')) {
+      database.prepare('ALTER TABLE payload_tracking ADD COLUMN telegram_id TEXT').run();
     }
     console.log('✅ SQLite inicializado');
   } catch (err) {

--- a/init-postgres.js
+++ b/init-postgres.js
@@ -5,12 +5,17 @@ async function initPostgres() {
   await pool.query(`
     CREATE TABLE IF NOT EXISTS payload_tracking (
       payload_id TEXT PRIMARY KEY,
+      telegram_id BIGINT,
       fbp TEXT,
       fbc TEXT,
       ip TEXT,
       user_agent TEXT,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
+  `);
+  await pool.query(`
+    ALTER TABLE payload_tracking
+    ADD COLUMN IF NOT EXISTS telegram_id BIGINT;
   `);
   console.log('✅ Tabela payload_tracking verificada no PostgreSQL');
 }


### PR DESCRIPTION
## Summary
- record telegram id when /start is called with a payload id
- ensure payload_tracking table contains telegram_id in SQLite and PostgreSQL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687530519054832ab56d95d9f015033b