### PR TITLE
Ensure unique CAPI event IDs

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -486,10 +486,12 @@ async _executarGerarCobranca(req, res) {
       console.log('✅ Token salvo no SQLite:', normalizedId);
     }
 
+    const eventId = uuidv4();
+
     console.log('[DEBUG] Enviando evento InitiateCheckout para Facebook com:', {
       event_name: 'InitiateCheckout',
       event_time: eventTime,
-      event_id: normalizedId,
+      event_id: eventId,
       value: valorCentavos / 100,
       fbp: finalTrackingData.fbp,
       fbc: finalTrackingData.fbc,
@@ -500,7 +502,7 @@ async _executarGerarCobranca(req, res) {
     await sendFacebookEvent({
       event_name: 'InitiateCheckout',
       event_time: eventTime,
-      event_id: normalizedId,
+      event_id: eventId,
       value: valorCentavos / 100,
       currency: 'BRL',
       fbp: finalTrackingData.fbp,


### PR DESCRIPTION
## Summary
- generate a random event_id for InitiateCheckout events
- keep Purchase events using the token event_id for browser deduplication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687557de547c832aa820a936849821bb