### PR TITLE
Deduplicate Purchase events in CAPI

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -6,7 +6,7 @@ const { v4: uuidv4 } = require('uuid');
 const cron = require('node-cron');
 const { DateTime } = require('luxon');
 const GerenciadorMidia = require('../BOT/utils/midia');
-const { sendFacebookEvent } = require('../../services/facebook');
+const { sendFacebookEvent, generateEventId } = require('../../services/facebook');
 const { mergeTrackingData, isRealTrackingData } = require('../../services/trackingValidation');
 
 // Fila global para controlar a geração de cobranças e evitar erros 429
@@ -486,10 +486,11 @@ async _executarGerarCobranca(req, res) {
       console.log('✅ Token salvo no SQLite:', normalizedId);
     }
 
-    const eventId = uuidv4();
+    const eventName = 'InitiateCheckout';
+    const eventId = generateEventId(eventName);
 
     console.log('[DEBUG] Enviando evento InitiateCheckout para Facebook com:', {
-      event_name: 'InitiateCheckout',
+      event_name: eventName,
       event_time: eventTime,
       event_id: eventId,
       value: valorCentavos / 100,
@@ -500,7 +501,7 @@ async _executarGerarCobranca(req, res) {
     });
 
     await sendFacebookEvent({
-      event_name: 'InitiateCheckout',
+      event_name: eventName,
       event_time: eventTime,
       event_id: eventId,
       value: valorCentavos / 100,

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ const compression = require('compression');
 const rateLimit = require('express-rate-limit');
 const cron = require('node-cron');
 const crypto = require('crypto');
-const { sendFacebookEvent } = require('./services/facebook');
+const { sendFacebookEvent, generateEventId } = require('./services/facebook');
 const protegerContraFallbacks = require('./services/protegerContraFallbacks');
 let lastRateLimitLog = 0;
 const bot1 = require('./MODELO1/BOT/bot1');
@@ -345,10 +345,12 @@ function iniciarCronFallback() {
       for (const row of res.rows) {
         if (row.fbp || row.fbc || row.ip_criacao) {
           console.log(`\u26A0\uFE0F Fallback CAPI: enviando evento atrasado para o token ${row.token}`);
+          const eventName = 'Purchase';
+          const eventId = generateEventId(eventName, row.token);
           await sendFacebookEvent({
-            event_name: 'Purchase',
+            event_name: eventName,
             event_time: row.event_time || Math.floor(new Date(row.criado_em).getTime() / 1000),
-            event_id: row.token,
+            event_id: eventId,
             value: parseFloat(row.valor),
             currency: 'BRL',
             fbp: row.fbp,

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+const { v4: uuidv4 } = require('uuid');
 
 const PIXEL_ID = process.env.FB_PIXEL_ID;
 const ACCESS_TOKEN = process.env.FB_PIXEL_TOKEN;
@@ -8,6 +9,10 @@ const DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
 function getDedupKey({event_name, event_time, event_id, fbp, fbc}) {
   return [event_name, event_id || '', event_time, fbp || '', fbc || ''].join('|');
+}
+
+function generateEventId(eventName, token) {
+  return eventName === 'Purchase' && token ? token : uuidv4();
 }
 
 function isDuplicate(key) {
@@ -111,4 +116,4 @@ async function sendFacebookEvent({
   }
 }
 
-module.exports = { sendFacebookEvent };
+module.exports = { sendFacebookEvent, generateEventId };


### PR DESCRIPTION
## Summary
- generate event IDs via `generateEventId`
- use transaction token as `event_id` for Purchase
- update `TelegramBotService` to obtain event IDs from helper
- adjust fallback cron in `server.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6875622d55b4832a8728e4a95b05e467