### PR TITLE
Send UTMs at top level of Facebook payload

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -34,6 +34,12 @@ async function sendFacebookEvent({
   event_time = Math.floor(Date.now() / 1000),
   event_id,
   event_source_url,
+  // UTMs podem ser passadas diretamente ou dentro de custom_data
+  utm_source,
+  utm_medium,
+  utm_campaign,
+  utm_term,
+  utm_content,
   value,
   currency = 'BRL',
   fbp,
@@ -79,16 +85,37 @@ async function sendFacebookEvent({
 
   console.log('🔧 user_data:', JSON.stringify(user_data));
 
+  // Extrai UTMs do topo do payload ou de custom_data
+  const utmData = {
+    utm_source: utm_source || custom_data.utm_source,
+    utm_medium: utm_medium || custom_data.utm_medium,
+    utm_campaign: utm_campaign || custom_data.utm_campaign,
+    utm_term: utm_term || custom_data.utm_term,
+    utm_content: utm_content || custom_data.utm_content
+  };
+
   const eventPayload = {
     event_name,
     event_time,
     event_id,
+    // UTMs no início do payload
+    ...(utmData.utm_source ? { utm_source: utmData.utm_source } : {}),
+    ...(utmData.utm_medium ? { utm_medium: utmData.utm_medium } : {}),
+    ...(utmData.utm_campaign ? { utm_campaign: utmData.utm_campaign } : {}),
+    ...(utmData.utm_term ? { utm_term: utmData.utm_term } : {}),
+    ...(utmData.utm_content ? { utm_content: utmData.utm_content } : {}),
     action_source: 'website',
     user_data,
     custom_data: {
       value,
       currency,
-      ...custom_data
+      ...custom_data,
+      // UTMs também dentro de custom_data
+      ...(utmData.utm_source ? { utm_source: utmData.utm_source } : {}),
+      ...(utmData.utm_medium ? { utm_medium: utmData.utm_medium } : {}),
+      ...(utmData.utm_campaign ? { utm_campaign: utmData.utm_campaign } : {}),
+      ...(utmData.utm_term ? { utm_term: utmData.utm_term } : {}),
+      ...(utmData.utm_content ? { utm_content: utmData.utm_content } : {})
     }
   };
 


### PR DESCRIPTION
## Summary
- expose UTM parameters in the sendFacebookEvent arguments
- send utm_source, utm_medium, utm_campaign, utm_term and utm_content at the beginning of the Facebook payload while still duplicating them in `custom_data`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687569e17754832a837f3df1a17d8769