### PR TITLE
Implement payload endpoint with UTM storage

### DIFF
--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -58,6 +58,21 @@ function initialize(path = './pagamentos.db') {
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     `).run();
+    database.prepare(`
+      CREATE TABLE IF NOT EXISTS payloads (
+        payload_id TEXT PRIMARY KEY,
+        utm_source TEXT,
+        utm_medium TEXT,
+        utm_campaign TEXT,
+        utm_term TEXT,
+        utm_content TEXT,
+        fbp TEXT,
+        fbc TEXT,
+        ip TEXT,
+        user_agent TEXT,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+      )
+    `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
     const payloadCols = database.prepare('PRAGMA table_info(payload_tracking)').all();
     const checkCol = name => cols.some(c => c.name === name);

--- a/init-postgres.js
+++ b/init-postgres.js
@@ -14,9 +14,25 @@ async function initPostgres() {
     );
   `);
   await pool.query(`
+    CREATE TABLE IF NOT EXISTS payloads (
+      payload_id TEXT PRIMARY KEY,
+      utm_source TEXT,
+      utm_medium TEXT,
+      utm_campaign TEXT,
+      utm_term TEXT,
+      utm_content TEXT,
+      fbp TEXT,
+      fbc TEXT,
+      ip TEXT,
+      user_agent TEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+  await pool.query(`
     ALTER TABLE payload_tracking
     ADD COLUMN IF NOT EXISTS telegram_id BIGINT;
   `);
+  console.log('✅ Tabela payloads verificada no PostgreSQL');
   console.log('✅ Tabela payload_tracking verificada no PostgreSQL');
 }
 


### PR DESCRIPTION
## Summary
- add new `payloads` table creation on DB init
- extend SQLite schema with new `payloads` table
- update `/api/gerar-payload` route to record UTM data and normalize fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687579705218832aac6241421c4331e0