### PR TITLE
Enhance /start payload tracking

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -169,6 +169,9 @@ async function createTables(pool) {
     await pool.query(`
         CREATE TABLE IF NOT EXISTS tracking_data (
           telegram_id BIGINT PRIMARY KEY,
+          utm_source TEXT,
+          utm_medium TEXT,
+          utm_campaign TEXT,
           fbp TEXT,
           fbc TEXT,
           ip TEXT,
@@ -215,6 +218,24 @@ async function createTables(pool) {
           WHERE table_name='tokens' AND column_name='user_agent_criacao'
         ) THEN
           ALTER TABLE tokens ADD COLUMN user_agent_criacao TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tracking_data' AND column_name='utm_source'
+        ) THEN
+          ALTER TABLE tracking_data ADD COLUMN utm_source TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tracking_data' AND column_name='utm_medium'
+        ) THEN
+          ALTER TABLE tracking_data ADD COLUMN utm_medium TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tracking_data' AND column_name='utm_campaign'
+        ) THEN
+          ALTER TABLE tracking_data ADD COLUMN utm_campaign TEXT;
         END IF;
       END
       $$;

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -40,6 +40,9 @@ function initialize(path = './pagamentos.db') {
     database.prepare(`
       CREATE TABLE IF NOT EXISTS tracking_data (
         telegram_id TEXT PRIMARY KEY,
+        utm_source TEXT,
+        utm_medium TEXT,
+        utm_campaign TEXT,
         fbp TEXT,
         fbc TEXT,
         ip TEXT,
@@ -75,8 +78,10 @@ function initialize(path = './pagamentos.db') {
     `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
     const payloadCols = database.prepare('PRAGMA table_info(payload_tracking)').all();
+    const trackingCols = database.prepare('PRAGMA table_info(tracking_data)').all();
     const checkCol = name => cols.some(c => c.name === name);
     const checkPayloadCol = name => payloadCols.some(c => c.name === name);
+    const checkTrackingCol = name => trackingCols.some(c => c.name === name);
 
     if (!checkCol('id_transacao')) {
       database.prepare('ALTER TABLE tokens ADD COLUMN id_transacao TEXT').run();
@@ -107,6 +112,15 @@ function initialize(path = './pagamentos.db') {
     }
     if (!checkPayloadCol('telegram_id')) {
       database.prepare('ALTER TABLE payload_tracking ADD COLUMN telegram_id TEXT').run();
+    }
+    if (!checkTrackingCol('utm_source')) {
+      database.prepare('ALTER TABLE tracking_data ADD COLUMN utm_source TEXT').run();
+    }
+    if (!checkTrackingCol('utm_medium')) {
+      database.prepare('ALTER TABLE tracking_data ADD COLUMN utm_medium TEXT').run();
+    }
+    if (!checkTrackingCol('utm_campaign')) {
+      database.prepare('ALTER TABLE tracking_data ADD COLUMN utm_campaign TEXT').run();
     }
     console.log('✅ SQLite inicializado');
   } catch (err) {


### PR DESCRIPTION
## Summary
- store extra UTM fields in tracking_data tables
- look up payload info when handling /start
- save utm_source/medium/campaign along with existing tracking data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68757b046790832aa7ebb80d07aa34bb