### PR TITLE
Update UTM params with tracking data

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -993,9 +993,9 @@ async _executarGerarCobranca(req, res) {
         telegram_id: chatId,
         plano: plano.nome,
         valor: plano.valor,
-        utm_source: 'telegram',
-        utm_campaign: 'bot_principal',
-        utm_medium: 'telegram_bot',
+        utm_source: track.utm_source || 'telegram',
+        utm_campaign: track.utm_campaign || 'bot_principal',
+        utm_medium: track.utm_medium || 'telegram_bot',
         bot_id: this.botId,
         trackingData: {
           fbp: track.fbp,


### PR DESCRIPTION
## Summary
- use user's tracking data for UTM parameters when generating charges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687585147884832a808d1a8326d089a9