### PR TITLE
Fix timing for Pixel cookie capture

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -142,8 +142,10 @@
     // Aplica imagem de fundo
     document.body.style.backgroundImage = `url('${window.config.backgroundImage}')`;
 
-    // Atualiza link final com payload gerado
-    gerarPayload();
+    // Atualiza link final com payload gerado somente após o carregamento
+    window.addEventListener('load', () => {
+      setTimeout(gerarPayload, 500);
+    });
   </script>
 
 </body>

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -149,12 +149,14 @@
     }
   }
 
-  window.addEventListener('load', async () => {
+  window.addEventListener('load', () => {
     cta.classList.add('disabled');
     cta.href = '#';
 
-    await gerarPayload();
-    cta.classList.remove('disabled');
+    setTimeout(async () => {
+      await gerarPayload();
+      cta.classList.remove('disabled');
+    }, 500);
   });
 
   cta.addEventListener("click", function () {

--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -121,8 +121,8 @@
 </script>
 
   <script>
-    // Captura _fbp e _fbc diretamente dos cookies e salva em localStorage
-    (function() {
+    // Captura _fbp e _fbc diretamente dos cookies após o Pixel ser carregado
+    function capturarCookiesPixel() {
       function getCookie(name) {
         const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
         return match ? decodeURIComponent(match[1]) : null;
@@ -142,7 +142,11 @@
       } catch (e) {
         console.error('Erro ao processar cookies do Facebook Pixel', e);
       }
-    })();
+    }
+
+    window.addEventListener('load', () => {
+      setTimeout(capturarCookiesPixel, 500);
+    });
 
     console.log('=== PÁGINA OBRIGADO CARREGADA ===');
     console.log('URL:', window.location.href);


### PR DESCRIPTION
## Summary
- capture `_fbp`/`_fbc` cookies after page load
- wait for the load event on boasvindas and index before generating the payload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877020bba00832a8a91aa49829b6782