### PR TITLE
Validate fbc before sending to Facebook

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -50,7 +50,6 @@
   }
 
   function getPixelValue(lsKey, cookieName) {
-    const defaultValue = lsKey === 'fbp' ? 'nofbp' : 'nofbc';
     return new Promise(resolve => {
       try {
         const stored = localStorage.getItem(lsKey);
@@ -65,7 +64,7 @@
         console.error('Erro ao acessar storage/cookie', e);
       }
 
-      resolve(defaultValue);
+      resolve(null);
     });
   }
 

--- a/services/trackingValidation.js
+++ b/services/trackingValidation.js
@@ -1,9 +1,15 @@
+function isValidFbc(fbc) {
+  if (!fbc || typeof fbc !== 'string') return false;
+  const trimmed = fbc.trim();
+  return /^fb\.1\.\d+\.[a-zA-Z0-9_-]+$/.test(trimmed);
+}
+
 function isRealTrackingData(data) {
   if (!data) return false;
   const { fbp, fbc, ip, user_agent } = data;
 
   const validFbp = fbp && typeof fbp === 'string' && !/FALLBACK/i.test(fbp.trim());
-  const validFbc = fbc && typeof fbc === 'string' && !/FALLBACK/i.test(fbc.trim());
+  const validFbc = isValidFbc(fbc);
 
   if (!validFbp || !validFbc) {
     return false;
@@ -73,5 +79,5 @@ function mergeTrackingData(dadosSalvos = {}, dadosRequisicao = {}) {
   return resultado;
 }
 
-module.exports = { isRealTrackingData, mergeTrackingData };
+module.exports = { isRealTrackingData, mergeTrackingData, isValidFbc };
 


### PR DESCRIPTION
## Summary
- validate `fbc` format with new helper
- only send `fbc` to Facebook if valid
- remove fallback generation in `TelegramBotService`
- sanitize `fbc` in API endpoints and cron job
- avoid placeholder values for `fbc` in index page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f909d670832ab7d964059f87c094