### PR TITLE
Add hashed user info to Facebook events

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -105,32 +105,52 @@
 
   <!-- Facebook Pixel -->
   <script>
-    const hashedFn = "{{HASHED_FN}}";
-    const hashedLn = "{{HASHED_LN}}";
-    const hashedCpf = "{{HASHED_CPF}}";
+    async function sha256(str) {
+      const buf = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
+      return [...new Uint8Array(buf)].map(b => b.toString(16).padStart(2, '0')).join('');
+    }
 
+    const payerName = '{{PAYER_NAME}}';
+    const cpf = '{{CPF}}';
     const urlParams = new URLSearchParams(window.location.search);
     const token = urlParams.get('token');
+
+    let hashedFn, hashedLn, hashedCpf;
+
+    (async () => {
+      if (payerName && cpf) {
+        const partes = payerName.trim().split(/\s+/);
+        const fn = partes[0]?.toLowerCase() || '';
+        const ln = partes.at(-1)?.toLowerCase() || '';
+        const cleanCpf = cpf.replace(/\D/g, '');
+        [hashedFn, hashedLn, hashedCpf] = await Promise.all([
+          sha256(fn),
+          sha256(ln),
+          sha256(cleanCpf)
+        ]);
+      }
+
+      !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){
+        n.callMethod ? n.callMethod.apply(n,arguments) : n.queue.push(arguments)};
+        if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+        n.queue=[];t=b.createElement(e);t.async=!0;
+        t.src=v;s=b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t,s)
+      }(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
+
+      const initData = {};
+      if (hashedCpf) initData.external_id = hashedCpf;
+      if (hashedFn) initData.fn = hashedFn;
+      if (hashedLn) initData.ln = hashedLn;
+
+      fbq('init', '1429424624747459', initData);
+      fbq('track', 'PageView');
+      fbq('track', 'ViewContent', {
+        value: 16.47,
+        currency: 'BRL'
+      });
+    })();
   </script>
-  <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){
-      n.callMethod ? n.callMethod.apply(n,arguments) : n.queue.push(arguments)};
-      if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-      n.queue=[];t=b.createElement(e);t.async=!0;
-      t.src=v;s=b.getElementsByTagName(e)[0];
-      s.parentNode.insertBefore(t,s)
-    }(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
-  fbq('init', '1429424624747459', {
-    external_id: hashedCpf,
-    fn: hashedFn,
-    ln: hashedLn
-  });
-  fbq('track', 'PageView');
-  fbq('track', 'ViewContent', {
-    value: 16.47,
-    currency: 'BRL'
-  });
-</script>
 
   <script>
     // Captura _fbp e _fbc diretamente dos cookies após o Pixel ser carregado
@@ -250,12 +270,11 @@
         return;
       }
 
-      fbq('track', 'Purchase', dados, {
-        eventID: token,
-        external_id: hashedCpf,
-        fn: hashedFn,
-        ln: hashedLn
-      });
+      const opts = { eventID: token };
+      if (hashedCpf) opts.external_id = hashedCpf;
+      if (hashedFn) opts.fn = hashedFn;
+      if (hashedLn) opts.ln = hashedLn;
+      fbq('track', 'Purchase', dados, opts);
       localStorage.setItem('purchase_sent_' + token, '1');
       console.log(`📤 Evento Purchase enviado via Pixel | eventID: ${token} | valor: ${valorNumerico.toFixed(2)}`);
     }

--- a/services/userData.js
+++ b/services/userData.js
@@ -1,0 +1,20 @@
+const crypto = require('crypto');
+
+function sha256(value = '') {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function extractHashedUserData(payer_name = '', payer_cpf = '') {
+  const partes = String(payer_name).trim().split(/\s+/);
+  const fn = partes[0]?.toLowerCase() || '';
+  const ln = partes.at(-1)?.toLowerCase() || '';
+  const cpf = String(payer_cpf).replace(/\D/g, '');
+
+  return {
+    fn: fn ? sha256(fn) : undefined,
+    ln: ln ? sha256(ln) : undefined,
+    external_id: cpf ? sha256(cpf) : undefined
+  };
+}
+
+module.exports = { extractHashedUserData };


### PR DESCRIPTION
## Summary
- hash payer info with `extractHashedUserData`
- include hashed fn/ln/external_id in CAPI webhook and fallback cron
- compute hashed data in Pixel event using Web Crypto API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687913b71f14832a9b09836e8594e4c4