### PR TITLE
Implement fbclid to fbc tracking

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -28,6 +28,7 @@
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>
   <script src="utm-capture.js"></script>
+  <script src="fbc-generator.js"></script>
 </head>
 <body>
   <div class="overlay">

--- a/MODELO1/WEB/fbc-generator.js
+++ b/MODELO1/WEB/fbc-generator.js
@@ -1,0 +1,13 @@
+(function() {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const fbclid = params.get('fbclid');
+    if (!fbclid) return;
+    const ts = Math.floor(Date.now() / 1000);
+    const value = `fb.1.${ts}.${fbclid}`;
+    localStorage.setItem('fbc', value);
+    document.cookie = `_fbc=${encodeURIComponent(value)}; path=/; max-age=63072000`;
+  } catch (e) {
+    console.error('fbc-generator error', e);
+  }
+})();

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -29,6 +29,7 @@
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>
   <script src="utm-capture.js"></script>
+  <script src="fbc-generator.js"></script>
 </head>
 <body>
   <div class="overlay">

--- a/middlewares/fbc.js
+++ b/middlewares/fbc.js
@@ -1,0 +1,32 @@
+const { isValidFbc } = require('../services/trackingValidation');
+
+function parseCookies(str = '') {
+  const out = {};
+  if (!str) return out;
+  for (const part of str.split(';')) {
+    const idx = part.indexOf('=');
+    if (idx === -1) continue;
+    const k = part.slice(0, idx).trim();
+    const v = decodeURIComponent(part.slice(idx + 1).trim());
+    out[k] = v;
+  }
+  return out;
+}
+
+module.exports = function extractFbc(req, res, next) {
+  const cookies = parseCookies(req.headers['cookie'] || '');
+  const fbclid = req.query.fbclid || req.body?.fbclid || cookies.fbclid || null;
+  let fbc = req.body?.fbc || req.body?._fbc || cookies._fbc || cookies.fbc;
+  let source = null;
+
+  if (!isValidFbc(fbc)) {
+    const base = fbclid || Math.random().toString(36).substring(2, 10);
+    source = fbclid ? 'fbclid' : 'fallback';
+    fbc = `fb.1.${Math.floor(Date.now() / 1000)}.${base}`;
+  }
+
+  req.fbclid = fbclid || null;
+  req.fbc = fbc;
+  req.fbc_source = source; // null | 'fbclid' | 'fallback'
+  next();
+};


### PR DESCRIPTION
## Summary
- add client-side script to convert `fbclid` to `fbc`
- inject the new script in `index.html` and `boasvindas.html`
- create Express middleware to normalize `fbclid`/`fbc`
- use new middleware in server and update payload routes
- improve Cobranca flow to generate `fbc` from `fbclid` or fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792e6508c4832a841a30b42d2a9ae4