### PR TITLE
Fix fallback cron double-check

### DIFF
--- a/server.js
+++ b/server.js
@@ -490,6 +490,10 @@ function iniciarCronFallback() {
           });
 
           if (result.success) {
+            if (await purchaseAlreadyLogged(row.token)) {
+              console.log(`\u26A0\uFE0F Purchase já logado para o token ${row.token}. Pulo atualização.`);
+              continue;
+            }
             await pool.query(
               "UPDATE tokens SET status = 'expirado', usado = TRUE WHERE token = $1",
               [row.token]


### PR DESCRIPTION
## Summary
- prevent fallback cron from marking tokens as used if a purchase was logged between send and update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687949bd33c4832a81455f5fbe925898