### PR TITLE
Fix pending Purchase events

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -379,8 +379,12 @@
           return;
         }
 
-        if (response.ok && dados?.status === 'paid') {
-          console.log('✅ Token validado e pago. Enviando evento Purchase...');
+        if (response.ok && (dados?.status === 'paid' || dados?.status === 'pendente')) {
+          if (dados?.status === 'pendente') {
+            console.log('⏳ Pagamento pendente no backend. Enviando evento Purchase mesmo assim...');
+          } else {
+            console.log('✅ Token validado e pago. Enviando evento Purchase...');
+          }
           await dispararEventoCompra(valor, token);
 
           let urlFinal = null;

--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -219,7 +219,7 @@ class TelegramBotService {
     return row;
   }
 
-  async logPurchaseEvent(token, modo_envio, data = {}) {
+  async logPurchaseEvent(token, modo_envio, data = {}, message = 'Purchase enviado') {
     if (!this.pgPool) return;
     try {
       await this.postgres.executeQuery(
@@ -227,7 +227,7 @@ class TelegramBotService {
         'INSERT INTO logs (level, message, meta) VALUES ($1,$2,$3)',
         [
           'info',
-          'Purchase enviado',
+          message,
           JSON.stringify({
             token,
             modo_envio,
@@ -724,12 +724,17 @@ async _executarGerarCobranca(req, res) {
       }
 
       // Registrar que o Purchase será enviado posteriormente
-      await this.logPurchaseEvent(novoToken, 'pendente', {
-        fbp: row.fbp,
-        fbc: row.fbc,
-        ip: row.ip_criacao,
-        user_agent: row.user_agent_criacao
-      });
+      await this.logPurchaseEvent(
+        novoToken,
+        'pendente',
+        {
+          fbp: row.fbp,
+          fbc: row.fbc,
+          ip: row.ip_criacao,
+          user_agent: row.user_agent_criacao
+        },
+        'Purchase pendente'
+      );
 
       // Purchase será enviado via Pixel ou cron de fallback
 

--- a/server.js
+++ b/server.js
@@ -435,7 +435,7 @@ async function purchaseAlreadyLogged(token) {
   if (!pool) return false;
   try {
     const res = await pool.query(
-      "SELECT 1 FROM logs WHERE message = 'Purchase enviado' AND meta->>'token' = $1 LIMIT 1",
+      "SELECT 1 FROM logs WHERE message = 'Purchase enviado' AND meta->>'token' = $1 AND COALESCE(meta->>'modo_envio','') <> 'pendente' LIMIT 1",
       [token]
     );
     return res.rowCount > 0;


### PR DESCRIPTION
## Summary
- ignore pending events in `purchaseAlreadyLogged`
- track pending purchases with distinct log message
- send Facebook Purchase when backend indicates pending

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68794e6e3954832aaafd6541ccb6aca2