### PR TITLE
Implementa nova lógica de envio de Purchase

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -257,16 +257,56 @@
     }
 
     // Aguarda o Pixel carregar para enviar o Purchase
-    async function enviarPurchaseQuandoPixelEstiverPronto(dados, token, valorNumerico) {
+    async function enviarPurchaseQuandoPixelEstiverPronto(dados, token, valorNumerico, inicio, pendenteEnviado) {
+      if (!inicio) inicio = Date.now();
+      if (Date.now() - inicio > 5000) {
+        try {
+          await fetch('/api/log-purchase', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token, modo_envio: 'fallback_frontend' })
+          });
+          console.warn('⏰ Pixel não carregou. Registro enviado para reenvio posterior.');
+        } catch (e) {
+          console.warn('Falha ao registrar fallback:', e);
+        }
+        localStorage.setItem('purchase_sent_' + token, '1');
+        return;
+      }
+
       if (typeof fbq === 'undefined') {
-        setTimeout(() => enviarPurchaseQuandoPixelEstiverPronto(dados, token, valorNumerico), 100);
+        if (!pendenteEnviado) {
+          try {
+            await fetch('/api/log-purchase', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ token, modo_envio: 'pixel_pendente' })
+            });
+          } catch (e) {
+            console.warn('Falha ao registrar pixel_pendente:', e);
+          }
+          pendenteEnviado = true;
+        }
+        setTimeout(() => enviarPurchaseQuandoPixelEstiverPronto(dados, token, valorNumerico, inicio, pendenteEnviado), 100);
         return;
       }
 
       const fbp = localStorage.getItem('fbp');
       const fbc = localStorage.getItem('fbc');
       if (!fbp || !fbc) {
-        setTimeout(() => enviarPurchaseQuandoPixelEstiverPronto(dados, token, valorNumerico), 100);
+        if (!pendenteEnviado) {
+          try {
+            await fetch('/api/log-purchase', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ token, modo_envio: 'pixel_pendente' })
+            });
+          } catch (e) {
+            console.warn('Falha ao registrar pixel_pendente:', e);
+          }
+          pendenteEnviado = true;
+        }
+        setTimeout(() => enviarPurchaseQuandoPixelEstiverPronto(dados, token, valorNumerico, inicio, pendenteEnviado), 100);
         return;
       }
 
@@ -379,12 +419,8 @@
           return;
         }
 
-        if (response.ok && (dados?.status === 'paid' || dados?.status === 'pendente')) {
-          if (dados?.status === 'pendente') {
-            console.log('⏳ Pagamento pendente no backend. Enviando evento Purchase mesmo assim...');
-          } else {
-            console.log('✅ Token validado e pago. Enviando evento Purchase...');
-          }
+        if (response.ok && dados?.status === 'paid') {
+          console.log('✅ Token validado e pago. Enviando evento Purchase...');
           await dispararEventoCompra(valor, token);
 
           let urlFinal = null;

--- a/MODELO1/WEB/tokens.js
+++ b/MODELO1/WEB/tokens.js
@@ -192,74 +192,7 @@ module.exports = (app, databasePool) => {
     }
   });
 
-  // Verificar e usar token
-  router.post('/verificar-token', async (req, res) => {
-    try {
-      const { token } = req.body;
-      const ip = obterIP(req);
-      const userAgent = sanitizeInput(req.get('User-Agent') || '');
-      
-      if (!token || !isValidToken(token)) {
-        return res.status(400).json({ 
-          sucesso: false, 
-          erro: 'Token inválido' 
-        });
-      }
-      
-      const result = await databasePool.query(
-        'SELECT id, valor, usado, status FROM tokens WHERE token = $1',
-        [token]
-      );
-      
-      if (result.rows.length === 0) {
-        return res.status(404).json({ 
-          sucesso: false, 
-          erro: 'Token inválido' 
-        });
-      }
-      
-      const tokenData = result.rows[0];
 
-      if (tokenData.status !== 'valido') {
-        return res.status(400).json({
-          sucesso: false,
-          erro: 'Token inválido'
-        });
-      }
-
-      if (tokenData.usado) {
-        return res.status(400).json({
-          sucesso: false,
-          erro: 'Token já foi usado'
-        });
-      }
-      
-      await databasePool.query(
-        'UPDATE tokens SET usado = TRUE, data_uso = CURRENT_TIMESTAMP, ip_uso = $1, user_agent = $2 WHERE token = $3',
-        [ip, userAgent, token]
-      );
-      
-      cache.del('estatisticas');
-      
-      log('info', 'Token usado com sucesso', { 
-        token: token.substring(0, 8) + '...', 
-        valor: tokenData.valor
-      });
-      
-      res.json({ 
-        sucesso: true, 
-        valor: parseFloat(tokenData.valor),
-        mensagem: 'Acesso liberado com sucesso!' 
-      });
-      
-    } catch (error) {
-      log('error', 'Erro ao verificar token', { erro: error.message });
-      res.status(500).json({ 
-        sucesso: false, 
-        erro: 'Erro interno do servidor' 
-      });
-    }
-  });
 
   // Listar tokens
   router.get('/tokens', async (req, res) => {

--- a/database/postgres.js
+++ b/database/postgres.js
@@ -282,6 +282,7 @@ async function createTables(pool) {
     await client.query(`
       CREATE INDEX IF NOT EXISTS idx_logs_timestamp ON logs(timestamp);
       CREATE INDEX IF NOT EXISTS idx_logs_level ON logs(level);
+      CREATE INDEX IF NOT EXISTS idx_logs_token ON logs ((meta->>'token'));
     `);
     
     console.log('✅ Tabelas criadas/verificadas com sucesso');


### PR DESCRIPTION
## Resumo
- marca token como usado somente após o sucesso de `/api/log-purchase`
- distingue logs pendentes (`pixel_pendente`) e ignora ao checar duplicidade
- simplifica `/api/verificar-token` e remove rota duplicada
- adiciona índice de token à tabela de logs
- trata timeout do Pixel no frontend e envia `fallback_frontend`

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687951050934832a90be3a70ecfb5c36