### PR TITLE
Intercepta evento Purchase do fbq

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -24,6 +24,7 @@
       currency: 'BRL'
     });
   </script>
+  <script src="fbq-interceptor.js"></script>
 
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>

--- a/MODELO1/WEB/fbq-interceptor.js
+++ b/MODELO1/WEB/fbq-interceptor.js
@@ -1,0 +1,45 @@
+(function(){
+  function setup(){
+    var fbq = window.fbq;
+    if(typeof fbq !== 'function'){
+      return false;
+    }
+    if(fbq.__intercepted) return true;
+    var original = fbq;
+    function wrapper(){
+      try {
+        if(arguments[0]==='track' && arguments[1]==='Purchase'){
+          var data = arguments[2] || {};
+          var opts = arguments[3] || {};
+          var eventId = (opts && opts.eventID) || data.event_id || '';
+          var value = data.value;
+          var currency = data.currency;
+          console.log('[FBQ] Evento:', 'Purchase', '| event_id:', eventId, '| valor:', value, '| moeda:', currency);
+          try{
+            fetch('/api/log-fbq',{
+              method:'POST',
+              headers:{'Content-Type':'application/json'},
+              body: JSON.stringify({ event: 'Purchase', data: data, options: opts })
+            });
+          }catch(e){
+            console.error('Falha no fetch /api/log-fbq', e);
+          }
+        }
+      } catch(e){
+        console.error('Erro no interceptor fbq', e);
+      }
+      return original.apply(this, arguments);
+    }
+    for(var prop in original){
+      try{wrapper[prop] = original[prop];}catch(e){}
+    }
+    wrapper.__intercepted = true;
+    window.fbq = wrapper;
+    return true;
+  }
+  var attempts = 0;
+  (function wait(){
+    if(setup()) return;
+    if(attempts++ < 50) setTimeout(wait, 100);
+  })();
+})();

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -25,6 +25,7 @@
       currency: 'BRL'
     });
   </script>
+  <script src="fbq-interceptor.js"></script>
 
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>

--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -151,6 +151,7 @@
       });
     })();
   </script>
+  <script src="fbq-interceptor.js"></script>
 
   <script>
     // Captura _fbp e _fbc diretamente dos cookies após o Pixel ser carregado


### PR DESCRIPTION
## Resumo
- adiciona script `fbq-interceptor.js` que encapsula `fbq` e envia log para `/api/log-fbq`
- inclui o script nas páginas `index.html`, `boasvindas.html` e `obrigado.html`

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a314ca820832abcc4283322dad379