### PR TITLE
Implement conditional test_event_code

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -108,9 +108,13 @@ async function sendFacebookEvent({
     data: [eventPayload]
   };
 
-  const finalTestCode = test_event_code || process.env.FB_TEST_EVENT_CODE;
-  if (finalTestCode) {
-    payload.test_event_code = finalTestCode;
+  const envTestCode = process.env.FB_TEST_EVENT_CODE;
+  if (
+    process.env.NODE_ENV !== 'production' &&
+    typeof envTestCode === 'string' &&
+    envTestCode.trim()
+  ) {
+    payload.test_event_code = envTestCode.trim();
   }
 
   try {


### PR DESCRIPTION
## Summary
- update Facebook service to only include `test_event_code` when not in production and the env var is non-empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a33ca9ae8832a98bc4acfb461e5d1