### PR TITLE
Add name/CPF validation before hashing

### DIFF
--- a/services/userData.js
+++ b/services/userData.js
@@ -4,17 +4,28 @@ function sha256(value = '') {
   return crypto.createHash('sha256').update(value).digest('hex');
 }
 
-function extractHashedUserData(payer_name = '', payer_cpf = '') {
-  const partes = String(payer_name).trim().split(/\s+/);
-  const fn = partes[0]?.toLowerCase() || '';
-  const ln = partes.at(-1)?.toLowerCase() || '';
-  const cpf = String(payer_cpf).replace(/\D/g, '');
-
-  return {
-    fn: fn ? sha256(fn) : undefined,
-    ln: ln ? sha256(ln) : undefined,
-    external_id: cpf ? sha256(cpf) : undefined
-  };
+function validStr(v) {
+  return typeof v === 'string' && !v.includes('{') && v.trim().length > 0;
 }
 
-module.exports = { extractHashedUserData };
+function validCpf(v) {
+  return (
+    typeof v === 'string' && !v.includes('{') && v.replace(/\D/g, '').length >= 11
+  );
+}
+
+function extractHashedUserData(payer_name = '', payer_cpf = '') {
+  const partes = String(payer_name).trim().split(/\s+/);
+  const fnRaw = partes[0] || '';
+  const lnRaw = partes.at(-1) || '';
+  const cpfRaw = String(payer_cpf).replace(/\D/g, '');
+
+  const result = {};
+  if (validStr(fnRaw)) result.fn = sha256(fnRaw.toLowerCase());
+  if (validStr(lnRaw)) result.ln = sha256(lnRaw.toLowerCase());
+  if (validCpf(cpfRaw)) result.external_id = sha256(cpfRaw);
+
+  return result;
+}
+
+module.exports = { extractHashedUserData, validStr, validCpf };


### PR DESCRIPTION
## Summary
- expose `validStr` and `validCpf` in `userData` service
- only hash payer name/CPF when they pass validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0e2edec4832aad7d44d6603084fd