### PR TITLE
Add CAPI purchase endpoint and tests

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -417,6 +417,17 @@
 
         if (response.ok && dados?.status === 'paid') {
           console.log('✅ Token validado e pago. Enviando evento Purchase...');
+          try {
+            const fbpStorage = localStorage.getItem('fbp');
+            const fbcStorage = localStorage.getItem('fbc');
+            await fetch('/api/capi-purchase', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ token, value: valor, fbp: fbpStorage, fbc: fbcStorage })
+            });
+          } catch (e) {
+            console.warn('Falha ao chamar /api/capi-purchase:', e);
+          }
           await dispararEventoCompra(valor, token);
 
           let urlFinal = null;

--- a/capiPurchaseEndpoint.js
+++ b/capiPurchaseEndpoint.js
@@ -1,0 +1,62 @@
+const { sendFacebookEvent } = require('./services/facebook');
+
+function createCapiPurchaseHandler(getPool) {
+  return async function capiPurchase(req, res) {
+    const { token, value, fbp, fbc } = req.body || {};
+
+    if (!token) {
+      return res.status(400).json({ success: false });
+    }
+
+    const pool = typeof getPool === 'function' ? getPool() : getPool;
+    if (!pool) {
+      return res.status(500).json({ success: false });
+    }
+
+    try {
+      const result = await pool.query(
+        'SELECT valor, status, usado, event_time FROM tokens WHERE token = $1',
+        [token]
+      );
+
+      if (result.rows.length === 0) {
+        return res.status(400).json({ success: false });
+      }
+
+      const tokenData = result.rows[0];
+      if (tokenData.status !== 'valido' || tokenData.usado) {
+        return res.status(400).json({ success: false });
+      }
+
+      const valorFinal =
+        typeof value === 'number' ? value : parseFloat(tokenData.valor);
+      const eventTime = tokenData.event_time || Math.floor(Date.now() / 1000);
+
+      const fbResult = await sendFacebookEvent({
+        event_name: 'Purchase',
+        event_time: eventTime,
+        event_id: token,
+        action_source: 'website',
+        value: valorFinal,
+        currency: 'BRL',
+        fbp,
+        fbc
+      });
+
+      if (fbResult.success) {
+        await pool.query(
+          "UPDATE tokens SET status = 'expirado', usado = TRUE, data_uso = CURRENT_TIMESTAMP WHERE token = $1",
+          [token]
+        );
+        return res.json({ success: true });
+      }
+
+      return res.status(500).json({ success: false });
+    } catch (err) {
+      console.error('Erro no capi-purchase handler:', err.message);
+      res.status(500).json({ success: false });
+    }
+  };
+}
+
+module.exports = createCapiPurchaseHandler;

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "uuid": "^9.0.1"
       },
       "devDependencies": {
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "supertest": "^6.3.3"
       },
       "engines": {
         "node": "20.x"
@@ -972,6 +973,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1278,6 +1302,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asn1": {
       "version": "0.2.6",
@@ -2001,6 +2032,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -2079,6 +2120,13 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -2337,6 +2385,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2795,6 +2854,13 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2923,6 +2989,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -6608,6 +6690,82 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -24,6 +24,7 @@ const { sendFacebookEvent, generateEventId } = require('./services/facebook');
 const { isValidFbc } = require('./services/trackingValidation');
 const { extractHashedUserData, validStr, validCpf } = require('./services/userData');
 const protegerContraFallbacks = require('./services/protegerContraFallbacks');
+const createCapiPurchaseHandler = require('./capiPurchaseEndpoint');
 const extractFbc = require('./middlewares/fbc');
 let lastRateLimitLog = 0;
 const bot1 = require('./MODELO1/BOT/bot1');
@@ -217,6 +218,9 @@ app.post('/api/log-purchase', async (req, res) => {
     res.status(500).json({ sucesso: false });
   }
 });
+
+const capiPurchaseHandler = createCapiPurchaseHandler(() => pool);
+app.post('/api/capi-purchase', capiPurchaseHandler);
 
 // Registro de eventos vindos do Pixel/Facebook
 app.post('/api/log-fbq', async (req, res) => {

--- a/tests/capiPurchaseEndpoint.test.js
+++ b/tests/capiPurchaseEndpoint.test.js
@@ -1,0 +1,53 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../services/facebook', () => ({
+  sendFacebookEvent: jest.fn().mockResolvedValue({ success: true })
+}));
+
+const { sendFacebookEvent } = require('../services/facebook');
+const createHandler = require('../capiPurchaseEndpoint');
+
+test('valid request triggers Facebook CAPI and updates token', async () => {
+  const pool = {
+    query: jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ valor: 5, status: 'valido', usado: false, event_time: 111 }] })
+      .mockResolvedValueOnce({})
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.post('/api/capi-purchase', createHandler(() => pool));
+
+  const res = await request(app)
+    .post('/api/capi-purchase')
+    .send({ token: 'tok1', fbp: 'fbp', fbc: 'fbc' });
+
+  expect(res.status).toBe(200);
+  expect(res.body.success).toBe(true);
+
+  expect(sendFacebookEvent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      event_name: 'Purchase',
+      event_id: 'tok1',
+      action_source: 'website',
+      value: 5,
+      currency: 'BRL',
+      fbp: 'fbp',
+      fbc: 'fbc',
+      event_time: 111
+    })
+  );
+
+  expect(pool.query).toHaveBeenNthCalledWith(
+    1,
+    'SELECT valor, status, usado, event_time FROM tokens WHERE token = $1',
+    ['tok1']
+  );
+  expect(pool.query).toHaveBeenNthCalledWith(
+    2,
+    "UPDATE tokens SET status = 'expirado', usado = TRUE, data_uso = CURRENT_TIMESTAMP WHERE token = $1",
+    ['tok1']
+  );
+});


### PR DESCRIPTION
## Summary
- add new `/api/capi-purchase` endpoint to send Facebook CAPI purchase events
- trigger this endpoint from `obrigado.html`
- provide implementation in `capiPurchaseEndpoint.js`
- test new behaviour with `supertest`
- include `supertest` in devDependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b19f1c8e8832abebade7986c32678