### PR TITLE
Support t query alias for tokens

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -108,7 +108,7 @@
     const payerName = '{{PAYER_NAME}}';
     const cpf = '{{CPF}}';
     const urlParams = new URLSearchParams(window.location.search);
-    const token = urlParams.get('token');
+    const token = urlParams.get('token') || urlParams.get('t');
 
     const partes = String(payerName || '').trim().split(/\s+/);
     const fnRaw = partes[0] || '';
@@ -378,7 +378,7 @@
     // Função para verificar token via API
     async function verificarToken() {
       const urlParams = new URLSearchParams(window.location.search);
-      const token = urlParams.get('token');
+      const token = urlParams.get('token') || urlParams.get('t');
       const valor = urlParams.get('valor');
       const grupo = obterGrupo();
 

--- a/MODELO1/WEB/verify-token.js
+++ b/MODELO1/WEB/verify-token.js
@@ -11,7 +11,7 @@ app.use(express.static('public')); // Para servir arquivos estáticos
 
 // Endpoint de verificação de token
 app.get('/verify-token', (req, res) => {
-  const token = (req.query.token || '').trim().toLowerCase();
+  const token = (req.query.token || req.query.t || '').trim().toLowerCase();
 
   if (!token) {
     return res.status(400).json({ 

--- a/server.js
+++ b/server.js
@@ -164,7 +164,7 @@ app.post('/api/verificar-token', async (req, res) => {
 
 
 app.get('/api/marcar-usado', async (req, res) => {
-  const token = String(req.query.token || '').trim();
+  const token = String(req.query.token || req.query.t || '').trim();
   if (!token) {
     return res.status(400).json({ sucesso: false });
   }
@@ -184,7 +184,7 @@ app.get('/api/marcar-usado', async (req, res) => {
 });
 
 app.get('/api/purchase-enviado', async (req, res) => {
-  const token = String(req.query.token || '').trim();
+  const token = String(req.query.token || req.query.t || '').trim();
   if (!token) {
     return res.status(400).json({ enviado: false });
   }

--- a/tests/tracking.test.js
+++ b/tests/tracking.test.js
@@ -21,6 +21,11 @@ test('obrigado.html sends Purchase with token as eventID', () => {
   expect(html).toMatch(/eventID\s*:\s*token/);
 });
 
+test('obrigado.html accepts t query alias', () => {
+  const html = fs.readFileSync('MODELO1/WEB/obrigado.html', 'utf8');
+  expect(html).toMatch(/urlParams\.get\('token'\)\s*\|\|\s*urlParams\.get\('t'\)/);
+});
+
 test('sendFacebookEvent forwards valid fbp and fbc', async () => {
   axios.post.mockResolvedValue({ data: { success: true } });
 


### PR DESCRIPTION
## Summary
- support `t` as an alias for `token` in `obrigado.html`
- accept the alias on `/api/marcar-usado` and `/api/purchase-enviado`
- update the standalone token verifier
- test alias handling in HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b1f34b370832aaab6302655d88285