### PR TITLE
Implement AddToCart CAPI dispatch on /start

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -47,6 +47,7 @@ async function sendFacebookEvent({
   client_user_agent,
   ip,
   userAgent,
+  action_source = 'website',
   custom_data = {},
   test_event_code
 }) {
@@ -91,7 +92,7 @@ async function sendFacebookEvent({
     event_name,
     event_time,
     event_id,
-    action_source: 'website',
+    action_source,
     user_data,
     custom_data: {
       value,


### PR DESCRIPTION
## Summary
- allow overriding the action source in Facebook API helper
- track AddToCart events in memory
- load extended tracking data fields
- trigger AddToCart event when a user sends `/start`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bb2e36d30832abe6e71b96ea05975