### PR TITLE
Add Facebook event helper tests

### DIFF
--- a/__tests__/facebook-events.test.js
+++ b/__tests__/facebook-events.test.js
@@ -1,0 +1,82 @@
+jest.mock('../services/facebook', () => {
+  const original = jest.requireActual('../services/facebook');
+  return {
+    ...original,
+    sendFacebookEvent: jest.fn().mockResolvedValue({ success: true })
+  };
+});
+
+const { sendFacebookEvent } = require('../services/facebook');
+const {
+  sendAddToCartEvent,
+  sendInitiateCheckoutEvent
+} = require('../services/facebookEvents');
+
+describe('facebook event helpers', () => {
+  beforeEach(() => {
+    sendFacebookEvent.mockClear();
+  });
+
+  test('sendAddToCartEvent forwards correct params', async () => {
+    const params = {
+      value: 12.34,
+      event_id: 'evt123',
+      fbp: 'fbp_test',
+      fbc: 'fbc_test',
+      client_ip_address: '8.8.8.8',
+      client_user_agent: 'JestAgent/1.0'
+    };
+
+    await sendAddToCartEvent(params);
+
+    expect(sendFacebookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: 'AddToCart',
+        value: params.value,
+        currency: 'BRL',
+        event_id: params.event_id,
+        fbp: params.fbp,
+        fbc: params.fbc,
+        client_ip_address: params.client_ip_address,
+        client_user_agent: params.client_user_agent
+      })
+    );
+  });
+
+  test('sendInitiateCheckoutEvent forwards correct params with utms', async () => {
+    const utms = {
+      utm_source: 'google',
+      utm_medium: 'cpc',
+      utm_campaign: 'summer',
+      utm_term: 'hot',
+      utm_content: 'banner'
+    };
+
+    const params = {
+      value: 99.99,
+      event_id: 'evt999',
+      fbp: 'fbp_ic',
+      fbc: 'fbc_ic',
+      client_ip_address: '1.2.3.4',
+      client_user_agent: 'JestAgent/2.0',
+      utms
+    };
+
+    await sendInitiateCheckoutEvent(params);
+
+    expect(sendFacebookEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: 'InitiateCheckout',
+        value: params.value,
+        currency: 'BRL',
+        event_id: params.event_id,
+        fbp: params.fbp,
+        fbc: params.fbc,
+        client_ip_address: params.client_ip_address,
+        client_user_agent: params.client_user_agent,
+        custom_data: expect.objectContaining(utms)
+      })
+    );
+  });
+});
+

--- a/services/facebookEvents.js
+++ b/services/facebookEvents.js
@@ -1,0 +1,33 @@
+const { sendFacebookEvent } = require('./facebook');
+
+function sendAddToCartEvent({ value, event_id, fbp, fbc, client_ip_address, client_user_agent }) {
+  return sendFacebookEvent({
+    event_name: 'AddToCart',
+    value,
+    currency: 'BRL',
+    event_id,
+    fbp,
+    fbc,
+    client_ip_address,
+    client_user_agent
+  });
+}
+
+function sendInitiateCheckoutEvent({ value, event_id, fbp, fbc, client_ip_address, client_user_agent, utms = {} }) {
+  return sendFacebookEvent({
+    event_name: 'InitiateCheckout',
+    value,
+    currency: 'BRL',
+    event_id,
+    fbp,
+    fbc,
+    client_ip_address,
+    client_user_agent,
+    custom_data: utms
+  });
+}
+
+module.exports = {
+  sendAddToCartEvent,
+  sendInitiateCheckoutEvent
+};


### PR DESCRIPTION
## Summary
- add helper functions to send AddToCart and InitiateCheckout events
- add unit tests verifying these helpers call `sendFacebookEvent` correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bd09297b4832a9485653cefc9c711