### PR TITLE
Improve FB event code handling

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -110,12 +110,18 @@ async function sendFacebookEvent({
   };
 
   const envTestCode = process.env.FB_TEST_EVENT_CODE;
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    typeof envTestCode === 'string' &&
-    envTestCode.trim()
-  ) {
-    payload.test_event_code = envTestCode.trim();
+  const argTestCode =
+    typeof test_event_code === 'string' && test_event_code.trim()
+      ? test_event_code.trim()
+      : '';
+  const finalTestCode = argTestCode
+    ? argTestCode
+    : typeof envTestCode === 'string' && envTestCode.trim()
+    ? envTestCode.trim()
+    : '';
+
+  if (finalTestCode) {
+    payload.test_event_code = finalTestCode;
   }
 
   try {


### PR DESCRIPTION
## Summary
- drop NODE_ENV restriction for FB test codes
- prioritize `test_event_code` arg over `FB_TEST_EVENT_CODE`
- cover new behaviour in tracking tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687be484eb2c832a9c6d0b65af17ddb9