### PR TITLE
Include FB test code in AddToCart events

### DIFF
--- a/__tests__/facebook-events.test.js
+++ b/__tests__/facebook-events.test.js
@@ -38,9 +38,57 @@ describe('facebook event helpers', () => {
         fbp: params.fbp,
         fbc: params.fbc,
         client_ip_address: params.client_ip_address,
-        client_user_agent: params.client_user_agent
-      })
-    );
+      client_user_agent: params.client_user_agent
+    })
+  );
+  });
+
+  test('sendAddToCartEvent inclui codigo de teste do ambiente', async () => {
+    const prev = process.env.FB_TEST_EVENT_CODE;
+    process.env.FB_TEST_EVENT_CODE = 'TEST123';
+
+    const params = {
+      value: 1,
+      event_id: 'evtEnv',
+      fbp: 'fbp_env',
+      fbc: 'fbc_env',
+      client_ip_address: '1.1.1.1',
+      client_user_agent: 'JestEnv/1.0'
+    };
+
+    await sendAddToCartEvent(params);
+
+    const called = sendFacebookEvent.mock.calls[0][0];
+    expect(called.test_event_code).toBe('TEST123');
+
+    if (prev === undefined) {
+      delete process.env.FB_TEST_EVENT_CODE;
+    } else {
+      process.env.FB_TEST_EVENT_CODE = prev;
+    }
+  });
+
+  test('sendAddToCartEvent omite codigo de teste quando ambiente nao define', async () => {
+    const prev = process.env.FB_TEST_EVENT_CODE;
+    delete process.env.FB_TEST_EVENT_CODE;
+
+    const params = {
+      value: 2,
+      event_id: 'evtNoEnv',
+      fbp: 'fbp_noenv',
+      fbc: 'fbc_noenv',
+      client_ip_address: '2.2.2.2',
+      client_user_agent: 'JestNoEnv/1.0'
+    };
+
+    await sendAddToCartEvent(params);
+
+    const called = sendFacebookEvent.mock.calls[0][0];
+    expect(called.test_event_code).toBeUndefined();
+
+    if (prev !== undefined) {
+      process.env.FB_TEST_EVENT_CODE = prev;
+    }
   });
 
   test('sendInitiateCheckoutEvent forwards correct params with utms', async () => {

--- a/services/facebookEvents.js
+++ b/services/facebookEvents.js
@@ -1,7 +1,7 @@
 const { sendFacebookEvent } = require('./facebook');
 
 function sendAddToCartEvent({ value, event_id, fbp, fbc, client_ip_address, client_user_agent }) {
-  return sendFacebookEvent({
+  const params = {
     event_name: 'AddToCart',
     value,
     currency: 'BRL',
@@ -10,7 +10,13 @@ function sendAddToCartEvent({ value, event_id, fbp, fbc, client_ip_address, clie
     fbc,
     client_ip_address,
     client_user_agent
-  });
+  };
+
+  if (typeof process.env.FB_TEST_EVENT_CODE === 'string' && process.env.FB_TEST_EVENT_CODE.trim()) {
+    params.test_event_code = process.env.FB_TEST_EVENT_CODE.trim();
+  }
+
+  return sendFacebookEvent(params);
 }
 
 function sendInitiateCheckoutEvent({ value, event_id, fbp, fbc, client_ip_address, client_user_agent, utms = {} }) {


### PR DESCRIPTION
## Summary
- inject `FB_TEST_EVENT_CODE` in `sendAddToCartEvent`
- test that AddToCart events forward `test_event_code` when defined
- test omission when undefined

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687be7aa0cd8832aaad07655b604532e