### PR TITLE
Improve FB CAPI tracking

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -606,7 +606,7 @@ async _executarGerarCobranca(req, res) {
 
     console.log('[DEBUG] Tracking data final que será usado:', finalTrackingData);
 
-    const eventTime = Math.floor(DateTime.now().setZone('America/Sao_Paulo').toSeconds());
+    const eventTime = Math.floor(Date.now() / 1000);
 
     const response = await axios.post('https://api.pushinpay.com.br/api/pix/cashIn', {
       value: valorCentavos,
@@ -684,6 +684,7 @@ async _executarGerarCobranca(req, res) {
       event_name: eventName,
       event_time: eventTime,
       event_id: eventId,
+      action_source: 'system_generated',
       value: valorCentavos / 100,
       currency: 'BRL',
       fbp: finalTrackingData.fbp,

--- a/__tests__/facebook-events.test.js
+++ b/__tests__/facebook-events.test.js
@@ -32,13 +32,15 @@ describe('facebook event helpers', () => {
     expect(sendFacebookEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         event_name: 'AddToCart',
+        event_time: expect.any(Number),
         value: params.value,
         currency: 'BRL',
         event_id: params.event_id,
         fbp: params.fbp,
         fbc: params.fbc,
         client_ip_address: params.client_ip_address,
-      client_user_agent: params.client_user_agent
+        client_user_agent: params.client_user_agent,
+        action_source: 'system_generated'
     })
   );
   });

--- a/capiPurchaseEndpoint.js
+++ b/capiPurchaseEndpoint.js
@@ -36,7 +36,7 @@ function createCapiPurchaseHandler(getPool) {
         event_name: 'Purchase',
         event_time: eventTime,
         event_id: token,
-        action_source: 'website',
+        action_source: 'system_generated',
         value: valorFinal,
         currency: 'BRL',
         fbp,

--- a/middlewares/fbp.js
+++ b/middlewares/fbp.js
@@ -13,10 +13,7 @@ function parseCookies(str = '') {
 
 module.exports = function extractFbp(req, res, next) {
   const cookies = parseCookies(req.headers['cookie'] || '');
-  let fbp = req.body?.fbp || req.body?._fbp || cookies._fbp || cookies.fbp;
-  if (!fbp) {
-    fbp = `fb.1.${Date.now()}.${Math.random().toString(36).substring(2,10)}`;
-  }
+  const fbp = req.body?.fbp || req.body?._fbp || cookies._fbp || cookies.fbp || null;
   req.fbp = fbp;
   next();
 };

--- a/server.js
+++ b/server.js
@@ -25,8 +25,7 @@ const { isValidFbc } = require('./services/trackingValidation');
 const { extractHashedUserData, validStr, validCpf } = require('./services/userData');
 const protegerContraFallbacks = require('./services/protegerContraFallbacks');
 const createCapiPurchaseHandler = require('./capiPurchaseEndpoint');
-const extractFbc = require('./middlewares/fbc');
-const extractFbp = require('./middlewares/fbp');
+const captureTracking = require('./middlewares/trackingCookies');
 let lastRateLimitLog = 0;
 const bot1 = require('./MODELO1/BOT/bot1');
 const bot2 = require('./MODELO1/BOT/bot2');
@@ -85,8 +84,7 @@ app.use(compression());
 app.use(cors({ origin: true, credentials: true }));
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
-app.use(extractFbp);
-app.use(extractFbc);
+app.use(captureTracking);
 
 // Webhook para BOT 1
 app.post('/bot1/webhook', (req, res) => {
@@ -470,6 +468,7 @@ function iniciarCronFallback() {
             event_name: eventName,
             event_time: row.event_time || Math.floor(new Date(row.criado_em).getTime() / 1000),
             event_id: eventId,
+            action_source: 'system_generated',
             value: parseFloat(row.valor),
             currency: 'BRL',
             fbp: row.fbp,

--- a/services/facebookEvents.js
+++ b/services/facebookEvents.js
@@ -3,13 +3,15 @@ const { sendFacebookEvent } = require('./facebook');
 function sendAddToCartEvent({ value, event_id, fbp, fbc, client_ip_address, client_user_agent }) {
   const params = {
     event_name: 'AddToCart',
+    event_time: Math.floor(Date.now() / 1000),
     value,
     currency: 'BRL',
     event_id,
     fbp,
     fbc,
     client_ip_address,
-    client_user_agent
+    client_user_agent,
+    action_source: 'system_generated'
   };
 
   if (typeof process.env.FB_TEST_EVENT_CODE === 'string' && process.env.FB_TEST_EVENT_CODE.trim()) {
@@ -22,6 +24,7 @@ function sendAddToCartEvent({ value, event_id, fbp, fbc, client_ip_address, clie
 function sendInitiateCheckoutEvent({ value, event_id, fbp, fbc, client_ip_address, client_user_agent, utms = {} }) {
   return sendFacebookEvent({
     event_name: 'InitiateCheckout',
+    event_time: Math.floor(Date.now() / 1000),
     value,
     currency: 'BRL',
     event_id,
@@ -29,6 +32,7 @@ function sendInitiateCheckoutEvent({ value, event_id, fbp, fbc, client_ip_addres
     fbc,
     client_ip_address,
     client_user_agent,
+    action_source: 'system_generated',
     custom_data: utms
   });
 }

--- a/tests/capiPurchaseEndpoint.test.js
+++ b/tests/capiPurchaseEndpoint.test.js
@@ -31,7 +31,7 @@ test('valid request triggers Facebook CAPI and updates token', async () => {
     expect.objectContaining({
       event_name: 'Purchase',
       event_id: 'tok1',
-      action_source: 'website',
+      action_source: 'system_generated',
       value: 5,
       currency: 'BRL',
       fbp: 'fbp',


### PR DESCRIPTION
## Summary
- capture pixel cookies through new middleware
- ensure server events use `system_generated`
- include event_time for AddToCart and InitiateCheckout
- fix event_time calculation
- adjust tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bf30cb170832a880dbb14a941c3aa