### PR TITLE
Configurable debug logs

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const TelegramBot = require('node-telegram-bot-api');
 const axios = require('axios');
 const fs = require('fs');
@@ -416,14 +417,18 @@ class TelegramBotService {
       const abs = path.resolve(path.join(__dirname, '..', 'BOT'), caminho);
       if (!fs.existsSync(abs)) {
         const downsellPath = path.join('midia', 'downsells') + path.sep;
-        if (abs.includes(downsellPath)) {
-          if (!this.loggedMissingDownsellFiles.has(abs)) {
-            this.loggedMissingDownsellFiles.add(abs);
-            console.warn(`[${this.botId}] Arquivo não encontrado ${abs}`);
+          if (abs.includes(downsellPath)) {
+            if (!this.loggedMissingDownsellFiles.has(abs)) {
+              this.loggedMissingDownsellFiles.add(abs);
+              if (process.env.VERBOSE_BOT_MEDIA === 'true') {
+                console.warn(`[${this.botId}] Arquivo não encontrado ${abs}`);
+              }
+            }
+          } else {
+            if (process.env.VERBOSE_BOT_MEDIA === 'true') {
+              console.warn(`[${this.botId}] Arquivo não encontrado ${abs}`);
+            }
           }
-        } else {
-          console.warn(`[${this.botId}] Arquivo não encontrado ${abs}`);
-        }
         return false;
       }
       const stream = fs.createReadStream(abs);

--- a/database/postgres.js
+++ b/database/postgres.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const { Pool } = require('pg');
 const fs = require('fs');
 const path = require('path');
@@ -36,7 +37,9 @@ function createPool() {
     });
     
     globalPool.on('remove', (client) => {
-      console.log('🔌 Conexão PostgreSQL removida do pool');
+      if (process.env.DEBUG_POOL === 'true') {
+        console.log('🔌 Conexão PostgreSQL removida do pool');
+      }
     });
     
     return globalPool;

--- a/middlewares/trackingCookies.js
+++ b/middlewares/trackingCookies.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const { isValidFbc } = require('../services/trackingValidation');
 
 function parseCookies(str = '') {
@@ -32,7 +33,9 @@ module.exports = function captureTracking(req, res, next) {
     } else {
       fbc = gerarFallback();
       source = 'fallback';
-      console.log('[tracking] fbc fallback usado');
+      if (process.env.DEBUG_TRACKING === 'true') {
+        console.log('[tracking] fbc fallback usado');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- enable dotenv for TelegramBotService, Postgres pool, and trackingCookies
- wrap specific log messages with env variable checks

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bf980491c832ab310372ad320cb49