### PR TITLE
Load dotenv for tests

### DIFF
--- a/tests/tracking.test.js
+++ b/tests/tracking.test.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const axios = require('axios');
-process.env.FB_PIXEL_ID = '123';
-process.env.FB_PIXEL_TOKEN = 'token';
+require('dotenv').config();
 const { sendFacebookEvent, generateEventId } = require('../services/facebook');
 const { extractHashedUserData } = require('../services/userData');
 


### PR DESCRIPTION
## Summary
- load real env vars via `dotenv` in `tracking.test.js`

## Testing
- `npm test --silent` *(fails: FB_PIXEL_TOKEN not set)*

------
https://chatgpt.com/codex/tasks/task_e_687c028b8a60832abffa0de15f78344d