### PR TITLE
Enable Facebook test mode via FORCE_FB_TEST_MODE flag

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -112,16 +112,23 @@ async function sendFacebookEvent({
     data: [eventPayload]
   };
 
-  const envTestCode = process.env.FB_TEST_EVENT_CODE;
   const argTestCode =
     typeof test_event_code === 'string' && test_event_code.trim()
       ? test_event_code.trim()
       : '';
-  const finalTestCode = argTestCode
-    ? argTestCode
-    : typeof envTestCode === 'string' && envTestCode.trim()
-    ? envTestCode.trim()
-    : '';
+
+  const shouldUseEnvCode =
+    process.env.FORCE_FB_TEST_MODE === '1' ||
+    process.env.NODE_ENV !== 'production';
+
+  let finalTestCode = argTestCode;
+
+  if (!finalTestCode && shouldUseEnvCode) {
+    const envTestCode = process.env.FB_TEST_EVENT_CODE;
+    if (typeof envTestCode === 'string' && envTestCode.trim()) {
+      finalTestCode = envTestCode.trim();
+    }
+  }
 
   if (finalTestCode) {
     payload.test_event_code = finalTestCode;

--- a/services/facebookEvents.js
+++ b/services/facebookEvents.js
@@ -14,7 +14,15 @@ function sendAddToCartEvent({ value, event_id, fbp, fbc, client_ip_address, clie
     action_source: 'system_generated'
   };
 
-  if (typeof process.env.FB_TEST_EVENT_CODE === 'string' && process.env.FB_TEST_EVENT_CODE.trim()) {
+  const shouldUseEnvCode =
+    process.env.FORCE_FB_TEST_MODE === '1' ||
+    process.env.NODE_ENV !== 'production';
+
+  if (
+    shouldUseEnvCode &&
+    typeof process.env.FB_TEST_EVENT_CODE === 'string' &&
+    process.env.FB_TEST_EVENT_CODE.trim()
+  ) {
     params.test_event_code = process.env.FB_TEST_EVENT_CODE.trim();
   }
 


### PR DESCRIPTION
## Summary
- allow including Facebook `test_event_code` even on production when `FORCE_FB_TEST_MODE=1`
- guard AddToCart events with the same condition
- adjust unit tests and supply dummy pixel IDs/tokens
- add new test cases for FORCE_FB_TEST_MODE logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c09f362f0832a92a63b21bafadaf4