### PR TITLE
Isolate env vars in tests

### DIFF
--- a/__tests__/facebook-events.test.js
+++ b/__tests__/facebook-events.test.js
@@ -14,7 +14,20 @@ const {
 
 describe('facebook event helpers', () => {
   beforeEach(() => {
+    process.env.FB_PIXEL_ID = 'PIXEL_TEST';
+    process.env.FB_PIXEL_TOKEN = 'TOKEN_TEST';
+    process.env.NODE_ENV = 'test';
+    delete process.env.FB_TEST_EVENT_CODE;
+    delete process.env.FORCE_FB_TEST_MODE;
     sendFacebookEvent.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.FB_PIXEL_ID;
+    delete process.env.FB_PIXEL_TOKEN;
+    delete process.env.NODE_ENV;
+    delete process.env.FB_TEST_EVENT_CODE;
+    delete process.env.FORCE_FB_TEST_MODE;
   });
 
   test('sendAddToCartEvent forwards correct params', async () => {

--- a/tests/tracking.test.js
+++ b/tests/tracking.test.js
@@ -1,22 +1,30 @@
 const fs = require('fs');
-const axios = require('axios');
-require('dotenv').config();
-process.env.FB_PIXEL_ID = 'PIXEL_TEST';
-process.env.FB_PIXEL_TOKEN = 'TOKEN_TEST';
-const { sendFacebookEvent, generateEventId } = require('../services/facebook');
-const { extractHashedUserData } = require('../services/userData');
 
 jest.mock('axios');
+let axios = require('axios');
+
+let sendFacebookEvent;
+let generateEventId;
+let extractHashedUserData;
 
 beforeEach(() => {
-  axios.post.mockReset();
+  jest.resetModules();
   process.env.FB_PIXEL_ID = 'PIXEL_TEST';
   process.env.FB_PIXEL_TOKEN = 'TOKEN_TEST';
+  process.env.NODE_ENV = 'test';
+  axios = require('axios');
+  ({ sendFacebookEvent, generateEventId } = require('../services/facebook'));
+  ({ extractHashedUserData } = require('../services/userData'));
+  axios.post.mockReset();
 });
 
 afterEach(() => {
   delete process.env.FB_PIXEL_ID;
   delete process.env.FB_PIXEL_TOKEN;
+  delete process.env.NODE_ENV;
+  delete process.env.FB_TEST_EVENT_CODE;
+  delete process.env.FORCE_FB_TEST_MODE;
+  jest.resetModules();
 });
 
 test('generateEventId uses token for Purchase events', () => {


### PR DESCRIPTION
## Summary
- avoid dotenv usage in tests
- set and clean Facebook env vars in tests before each run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0cb49864832a87cf7a8f6c9a6215