### PR TITLE
Fix FB CAPI test event propagation

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -33,27 +33,41 @@ function isDuplicate(key) {
   return false;
 }
 
-async function sendFacebookEvent({
-  event_name,
-  event_time = Math.floor(Date.now() / 1000),
-  event_id,
-  event_source_url,
-  value,
-  currency = 'BRL',
-  fbp,
-  fbc,
-  external_id,
-  fn,
-  ln,
-  client_ip_address,
-  client_ip,
-  client_user_agent,
-  ip,
-  userAgent,
-  action_source = 'website',
-  custom_data = {},
-  test_event_code
-}) {
+async function sendFacebookEvent(params = {}) {
+  const shouldUseEnvCode =
+    process.env.FORCE_FB_TEST_MODE === '1' ||
+    process.env.NODE_ENV !== 'production';
+
+  if (
+    shouldUseEnvCode &&
+    typeof process.env.FB_TEST_EVENT_CODE === 'string' &&
+    process.env.FB_TEST_EVENT_CODE.trim() &&
+    !params.test_event_code
+  ) {
+    params.test_event_code = process.env.FB_TEST_EVENT_CODE.trim();
+  }
+
+  const {
+    event_name,
+    event_time = Math.floor(Date.now() / 1000),
+    event_id,
+    event_source_url,
+    value,
+    currency = 'BRL',
+    fbp,
+    fbc,
+    external_id,
+    fn,
+    ln,
+    client_ip_address,
+    client_ip,
+    client_user_agent,
+    ip,
+    userAgent,
+    action_source = 'website',
+    custom_data = {},
+    test_event_code
+  } = params;
   if (!ACCESS_TOKEN) {
     console.warn('FB_PIXEL_TOKEN não definido. Evento não será enviado.');
     return { success: false, error: 'FB_PIXEL_TOKEN not set' };
@@ -117,10 +131,6 @@ async function sendFacebookEvent({
       ? test_event_code.trim()
       : '';
 
-  const shouldUseEnvCode =
-    process.env.FORCE_FB_TEST_MODE === '1' ||
-    process.env.NODE_ENV !== 'production';
-
   let finalTestCode = argTestCode;
 
   if (!finalTestCode && shouldUseEnvCode) {
@@ -133,6 +143,8 @@ async function sendFacebookEvent({
   if (finalTestCode) {
     wrapper.test_event_code = finalTestCode;
   }
+
+  console.debug('[FB] Payload final:', JSON.stringify(wrapper, null, 2));
 
   try {
     console.log('[DEBUG] Payload enviado para o Facebook:', wrapper);

--- a/tests/capiPurchaseEndpoint.test.js
+++ b/tests/capiPurchaseEndpoint.test.js
@@ -1,14 +1,16 @@
 const express = require('express');
 const request = require('supertest');
 
-jest.mock('../services/facebook', () => ({
-  sendFacebookEvent: jest.fn().mockResolvedValue({ success: true })
-}));
-
-const { sendFacebookEvent } = require('../services/facebook');
-const createHandler = require('../capiPurchaseEndpoint');
+jest.mock('axios');
+let axios = require('axios');
 
 test('valid request triggers Facebook CAPI and updates token', async () => {
+  jest.resetModules();
+  jest.mock('../services/facebook', () => ({
+    sendFacebookEvent: jest.fn().mockResolvedValue({ success: true })
+  }));
+  const { sendFacebookEvent } = require('../services/facebook');
+  const createHandler = require('../capiPurchaseEndpoint');
   const pool = {
     query: jest
       .fn()
@@ -50,4 +52,44 @@ test('valid request triggers Facebook CAPI and updates token', async () => {
     "UPDATE tokens SET status = 'expirado', usado = TRUE, data_uso = CURRENT_TIMESTAMP WHERE token = $1",
     ['tok1']
   );
+});
+
+test('capi-purchase inclui test_event_code quando configurado', async () => {
+  jest.resetModules();
+  jest.unmock('../services/facebook');
+  process.env.FB_PIXEL_ID = 'PIXEL_TEST';
+  process.env.FB_PIXEL_TOKEN = 'TOKEN_TEST';
+  const facebook = require('../services/facebook');
+  jest.spyOn(facebook, 'sendFacebookEvent');
+  const createHandler = require('../capiPurchaseEndpoint');
+  axios = require('axios');
+  axios.post.mockResolvedValue({ data: { success: true } });
+  const pool = {
+    query: jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ valor: 5, status: 'valido', usado: false, event_time: 111 }] })
+      .mockResolvedValueOnce({})
+  };
+
+  const app = express();
+  app.use(express.json());
+  app.post('/api/capi-purchase', createHandler(() => pool));
+
+  process.env.FB_TEST_EVENT_CODE = 'PUR123';
+  process.env.NODE_ENV = 'production';
+  process.env.FORCE_FB_TEST_MODE = '1';
+
+  const res = await request(app)
+    .post('/api/capi-purchase')
+    .send({ token: 'tok1', fbp: 'fbp', fbc: 'fbc' });
+
+  expect(res.status).toBe(200);
+  const payload = facebook.sendFacebookEvent.mock.calls[0][0];
+  expect(payload.test_event_code).toBe('PUR123');
+
+  delete process.env.FB_TEST_EVENT_CODE;
+  delete process.env.NODE_ENV;
+  delete process.env.FORCE_FB_TEST_MODE;
+  delete process.env.FB_PIXEL_ID;
+  delete process.env.FB_PIXEL_TOKEN;
 });


### PR DESCRIPTION
## Summary
- insert `test_event_code` into params inside `sendFacebookEvent`
- log the final payload with `console.debug`
- update facebook event helper tests
- test that purchase endpoint propagates the test code

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c209b83a8832ab37d1f02d9c9d066