### PR TITLE
Apply Facebook test codes automatically

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -7,7 +7,7 @@ const { v4: uuidv4 } = require('uuid');
 const cron = require('node-cron');
 const { DateTime } = require('luxon');
 const GerenciadorMidia = require('../BOT/utils/midia');
-const { sendFacebookEvent, generateEventId } = require('../../services/facebook');
+const { sendFacebookEvent, generateEventId, applyTestEventCode } = require('../../services/facebook');
 const { mergeTrackingData, isRealTrackingData, isValidFbc } = require('../../services/trackingValidation');
 const { extractHashedUserData } = require('../../services/userData');
 
@@ -267,7 +267,7 @@ class TelegramBotService {
 
       const eventId = track.addtocart_event_id || track.token || generateEventId('AddToCart');
 
-      const fbResult = await sendFacebookEvent({
+      const eventParams = applyTestEventCode({
         event_name: 'AddToCart',
         event_time: Math.floor(Date.now() / 1000),
         event_id: eventId,
@@ -279,6 +279,8 @@ class TelegramBotService {
         client_ip_address: track.ip,
         client_user_agent: track.user_agent
       });
+
+      const fbResult = await sendFacebookEvent(eventParams);
 
       if (fbResult.success) {
         let saved = false;
@@ -685,7 +687,7 @@ async _executarGerarCobranca(req, res) {
     } else if (req.fbc_source === 'fbclid') {
       console.log('[INFO] Enviando evento com fbc gerado a partir do fbclid');
     }
-    await sendFacebookEvent({
+    const eventParams = applyTestEventCode({
       event_name: eventName,
       event_time: eventTime,
       event_id: eventId,
@@ -704,6 +706,8 @@ async _executarGerarCobranca(req, res) {
         utm_content
       }
     });
+
+    await sendFacebookEvent(eventParams);
 
     return res.json({
       qr_code_base64,

--- a/capiPurchaseEndpoint.js
+++ b/capiPurchaseEndpoint.js
@@ -1,4 +1,4 @@
-const { sendFacebookEvent } = require('./services/facebook');
+const { sendFacebookEvent, applyTestEventCode } = require('./services/facebook');
 
 function createCapiPurchaseHandler(getPool) {
   return async function capiPurchase(req, res) {
@@ -32,7 +32,7 @@ function createCapiPurchaseHandler(getPool) {
         typeof value === 'number' ? value : parseFloat(tokenData.valor);
       const eventTime = tokenData.event_time || Math.floor(Date.now() / 1000);
 
-      const fbResult = await sendFacebookEvent({
+      const eventParams = applyTestEventCode({
         event_name: 'Purchase',
         event_time: eventTime,
         event_id: token,
@@ -42,6 +42,8 @@ function createCapiPurchaseHandler(getPool) {
         fbp,
         fbc
       });
+
+      const fbResult = await sendFacebookEvent(eventParams);
 
       if (fbResult.success) {
         await pool.query(

--- a/server.js
+++ b/server.js
@@ -20,7 +20,7 @@ const compression = require('compression');
 const rateLimit = require('express-rate-limit');
 const cron = require('node-cron');
 const crypto = require('crypto');
-const { sendFacebookEvent, generateEventId } = require('./services/facebook');
+const { sendFacebookEvent, generateEventId, applyTestEventCode } = require('./services/facebook');
 const { isValidFbc } = require('./services/trackingValidation');
 const { extractHashedUserData, validStr, validCpf } = require('./services/userData');
 const protegerContraFallbacks = require('./services/protegerContraFallbacks');
@@ -464,7 +464,7 @@ function iniciarCronFallback() {
               extractHashedUserData(row.payer_name, row.cpf));
           }
 
-          const result = await sendFacebookEvent({
+          const eventParams = applyTestEventCode({
             event_name: eventName,
             event_time: row.event_time || Math.floor(new Date(row.criado_em).getTime() / 1000),
             event_id: eventId,
@@ -487,6 +487,8 @@ function iniciarCronFallback() {
               modo_envio: 'fallback_cron'
             }
           });
+
+          const result = await sendFacebookEvent(eventParams);
 
           if (result.success) {
             if (await purchaseAlreadyLogged(row.token)) {

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -33,10 +33,16 @@ function isDuplicate(key) {
   return false;
 }
 
-async function sendFacebookEvent(params = {}) {
+function applyTestEventCode(params = {}) {
   const shouldUseEnvCode =
     process.env.FORCE_FB_TEST_MODE === '1' ||
     process.env.NODE_ENV !== 'production';
+
+  console.debug('[FB] applyTestEventCode shouldUseEnvCode:', shouldUseEnvCode);
+  console.debug('[FB] process.env.NODE_ENV:', process.env.NODE_ENV);
+  console.debug('[FB] process.env.FORCE_FB_TEST_MODE:', process.env.FORCE_FB_TEST_MODE);
+  console.debug('[FB] process.env.FB_TEST_EVENT_CODE:', process.env.FB_TEST_EVENT_CODE);
+  console.debug('[FB] original params.test_event_code:', params.test_event_code);
 
   if (
     shouldUseEnvCode &&
@@ -46,6 +52,15 @@ async function sendFacebookEvent(params = {}) {
   ) {
     params.test_event_code = process.env.FB_TEST_EVENT_CODE.trim();
   }
+
+  return params;
+}
+
+async function sendFacebookEvent(params = {}) {
+  params = applyTestEventCode(params);
+  const shouldUseEnvCode =
+    process.env.FORCE_FB_TEST_MODE === '1' ||
+    process.env.NODE_ENV !== 'production';
 
   const {
     event_name,
@@ -161,4 +176,4 @@ async function sendFacebookEvent(params = {}) {
   }
 }
 
-module.exports = { sendFacebookEvent, generateEventId };
+module.exports = { sendFacebookEvent, generateEventId, applyTestEventCode };

--- a/services/facebookEvents.js
+++ b/services/facebookEvents.js
@@ -1,7 +1,7 @@
-const { sendFacebookEvent } = require('./facebook');
+const { sendFacebookEvent, applyTestEventCode } = require('./facebook');
 
 function sendAddToCartEvent({ value, event_id, fbp, fbc, client_ip_address, client_user_agent }) {
-  const params = {
+  let params = {
     event_name: 'AddToCart',
     event_time: Math.floor(Date.now() / 1000),
     value,
@@ -13,24 +13,12 @@ function sendAddToCartEvent({ value, event_id, fbp, fbc, client_ip_address, clie
     client_user_agent,
     action_source: 'system_generated'
   };
-
-  const shouldUseEnvCode =
-    process.env.FORCE_FB_TEST_MODE === '1' ||
-    process.env.NODE_ENV !== 'production';
-
-  if (
-    shouldUseEnvCode &&
-    typeof process.env.FB_TEST_EVENT_CODE === 'string' &&
-    process.env.FB_TEST_EVENT_CODE.trim()
-  ) {
-    params.test_event_code = process.env.FB_TEST_EVENT_CODE.trim();
-  }
-
+  params = applyTestEventCode(params);
   return sendFacebookEvent(params);
 }
 
 function sendInitiateCheckoutEvent({ value, event_id, fbp, fbc, client_ip_address, client_user_agent, utms = {} }) {
-  return sendFacebookEvent({
+  const params = applyTestEventCode({
     event_name: 'InitiateCheckout',
     event_time: Math.floor(Date.now() / 1000),
     value,
@@ -43,6 +31,7 @@ function sendInitiateCheckoutEvent({ value, event_id, fbp, fbc, client_ip_addres
     action_source: 'system_generated',
     custom_data: utms
   });
+  return sendFacebookEvent(params);
 }
 
 module.exports = {

--- a/tests/capiPurchaseEndpoint.test.js
+++ b/tests/capiPurchaseEndpoint.test.js
@@ -7,7 +7,8 @@ let axios = require('axios');
 test('valid request triggers Facebook CAPI and updates token', async () => {
   jest.resetModules();
   jest.mock('../services/facebook', () => ({
-    sendFacebookEvent: jest.fn().mockResolvedValue({ success: true })
+    sendFacebookEvent: jest.fn().mockResolvedValue({ success: true }),
+    applyTestEventCode: jest.fn(p => p)
   }));
   const { sendFacebookEvent } = require('../services/facebook');
   const createHandler = require('../capiPurchaseEndpoint');


### PR DESCRIPTION
## Summary
- add `applyTestEventCode` helper for Facebook CAPI
- use helper in event senders and Telegram bot service
- use helper in purchase endpoint and server fallback
- export helper from facebook service
- adapt tests for new export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c2812a44c832aab2998262f3ec4a8