### PR TITLE
Fix pgPool usage

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -744,7 +744,7 @@ async _executarGerarCobranca(req, res) {
       // deixando o envio real do CAPI para o cron ou fallback
       try {
         // Atualizar flag para indicar que CAPI está pronto para ser enviado
-        await this.pool.query(
+        await this.pgPool.query(
           'UPDATE tokens SET capi_ready = TRUE WHERE token = $1',
           [novoToken]
         );


### PR DESCRIPTION
## Summary
- fix capi flag update query to use `this.pgPool`

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687cf02b866c832ab502b99470b1beba