### PR TITLE
Add case-insensitive parameter parsing

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -218,15 +218,15 @@
       return match ? match[0] : null;
     }
 
-    // Obtém o parâmetro g da URL e converte para formato de grupo
+    // Obtém o parâmetro g ou G da URL e converte para formato de grupo
     function obterParametroG() {
       const params = new URLSearchParams(window.location.search);
-      const g = params.get('g');
-      
+      const g = params.get('g') || params.get('G');
+
       if (g === '1') return 'G1';
       if (g === '2') return 'G2';
       if (g === '3') return 'G3';
-      
+
       return null;
     }
 


### PR DESCRIPTION
## Summary
- accept both `g` and `G` query params when redirecting

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687d5cc9d244832aa5af9cd023421376