### PR TITLE
Fix telegram_id cast in eventos query

### DIFF
--- a/server.js
+++ b/server.js
@@ -1197,7 +1197,8 @@ app.get('/api/eventos', async (req, res) => {
         COALESCE(t.utm_source, td.utm_source, p.utm_source, 'desconhecido') as utm_source,
         COALESCE(t.utm_medium, td.utm_medium, p.utm_medium) as utm_medium,
         COALESCE(t.utm_campaign, td.utm_campaign, p.utm_campaign) as utm_campaign,
-        COALESCE(t.telegram_id, 'não_disponível') as telegram_id,
+        -- Evitar cast inválido: manter NULL para tratamento na camada de apresentação
+        t.telegram_id as telegram_id,
         CASE 
           WHEN t.pixel_sent = true OR t.capi_sent = true OR t.cron_sent = true THEN 'enviado'
           ELSE 'pendente'
@@ -1221,7 +1222,8 @@ app.get('/api/eventos', async (req, res) => {
         COALESCE(td.utm_source, 'desconhecido') as utm_source,
         COALESCE(td.utm_medium, 'none') as utm_medium,
         COALESCE(td.utm_campaign, 'sem_campanha') as utm_campaign,
-        COALESCE(td.telegram_id, 'não_disponível') as telegram_id,
+        -- Conversão para TEXT preservando valores NULL
+        td.telegram_id::text as telegram_id,
         'enviado' as status_envio,
         'tracking_data' as source_table
       FROM tracking_data td


### PR DESCRIPTION
## Summary
- avoid casting errors in `/api/eventos` query by leaving `telegram_id` null
- cast `td.telegram_id` to text when selecting from `tracking_data`

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687d8559ca9c832aa6e4ae83f54209a1