### PR TITLE
Fix event_source_url placement

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -162,7 +162,6 @@ async function sendFacebookEvent({
   if (finalFbc) user_data.fbc = finalFbc;
   if (finalIp) user_data.client_ip_address = finalIp;
   if (finalUserAgent) user_data.client_user_agent = finalUserAgent;
-  if (event_source_url) user_data.event_source_url = event_source_url;
 
   // Para AddToCart, adicionar external_id usando hash do token se disponível
   if (event_name === 'AddToCart' && (token || telegram_id)) {


### PR DESCRIPTION
## Summary
- move `event_source_url` out of `user_data`
- keep field at top level of Facebook API payload

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687e1c47ba9c832a88a6a2ed108aac43