### PR TITLE
Implement eventID deduplication for Pixel and CAPI

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -18,16 +18,20 @@
     }(window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js');
 
     fbq('init', '1429424624747459');
-    fbq('track', 'PageView');
+    const pageViewId = generateEventID('PageView');
+    fbq('track', 'PageView', { eventID: pageViewId });
+    const viewInitId = generateEventID('ViewContent');
     fbq('track', 'ViewContent', {
       value: parseFloat((Math.random() * (19.90 - 9.90) + 9.90).toFixed(2)),
-      currency: 'BRL'
+      currency: 'BRL',
+      eventID: viewInitId
     });
   </script>
 
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>
   <script src="utm-capture.js"></script>
+  <script src="event-id.js"></script>
 </head>
 <body>
   <div class="overlay">
@@ -147,7 +151,8 @@
         value: parseFloat((Math.random() * (19.90 - 9.90) + 9.90).toFixed(2)),
         currency: 'BRL',
         content_name: window.config.headline,
-        content_category: 'Bot Telegram'
+        content_category: 'Bot Telegram',
+        eventID: generateEventID('ViewContent')
       });
     });
 

--- a/MODELO1/WEB/event-id.js
+++ b/MODELO1/WEB/event-id.js
@@ -1,0 +1,14 @@
+function generateEventID(eventName, userId = '', timestamp = Date.now()) {
+  if (eventName === 'Purchase' && userId) return userId;
+  const input = `${eventName}_${userId}_${timestamp}`;
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    const chr = input.charCodeAt(i);
+    hash = (hash << 5) - hash + chr;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return 'e' + (hash >>> 0).toString(16);
+}
+
+// Expose globally
+window.generateEventID = generateEventID;

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -19,16 +19,20 @@
     }(window, document, 'script', 'https://connect.facebook.net/en_US/fbevents.js');
 
     fbq('init', '1429424624747459');
-    fbq('track', 'PageView');
+    const pageViewId = generateEventID('PageView');
+    fbq('track', 'PageView', { eventID: pageViewId });
+    const viewIdInit = generateEventID('ViewContent');
     fbq('track', 'ViewContent', {
       value: parseFloat((Math.random() * (19.90 - 9.90) + 9.90).toFixed(2)),
-      currency: 'BRL'
+      currency: 'BRL',
+      eventID: viewIdInit
     });
   </script>
 
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>
   <script src="utm-capture.js"></script>
+  <script src="event-id.js"></script>
 </head>
 <body>
   <div class="overlay">
@@ -165,7 +169,8 @@
         value: parseFloat((Math.random() * (19.90 - 9.90) + 9.90).toFixed(2)),
         currency: 'BRL',
         content_name: window.config.headline,
-        content_category: 'Bot Telegram'
+        content_category: 'Bot Telegram',
+        eventID: generateEventID('ViewContent')
       });
     } catch (e) {
       console.error('Facebook Pixel error', e);

--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -79,6 +79,7 @@
       margin-top: 15px;
     }
   </style>
+  <script src="event-id.js"></script>
 </head>
 <body>
   <div class="box">
@@ -113,10 +114,13 @@
       s.parentNode.insertBefore(t,s)
     }(window, document,'script','https://connect.facebook.net/en_US/fbevents.js');
   fbq('init', '1429424624747459');
-  fbq('track', 'PageView');
+  const pageViewId = generateEventID('PageView');
+  fbq('track', 'PageView', { eventID: pageViewId });
+  const viewContentInitId = generateEventID('ViewContent');
   fbq('track', 'ViewContent', {
     value: parseFloat((Math.random() * (19.90 - 9.90) + 9.90).toFixed(2)),
-    currency: 'BRL'
+    currency: 'BRL',
+    eventID: viewContentInitId
   });
 </script>
 
@@ -410,7 +414,8 @@
           console.log('💡 Possíveis causas: Pixel não carregou completamente, AdBlocker ativo, ou problema de timing');
           return;
         }
-        fbq('track', 'Purchase', dados, { eventID: token });
+        dados.eventID = token;
+        fbq('track', 'Purchase', dados);
         localStorage.setItem('purchase_sent_' + token, '1');
         console.log(`📤 Evento Purchase enviado via Pixel | eventID: ${token} | valor: ${valorNumerico.toFixed(2)}`);
         

--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -566,7 +566,7 @@ async _executarGerarCobranca(req, res) {
     }
 
     const eventName = 'InitiateCheckout';
-    const eventId = generateEventId(eventName);
+    const eventId = generateEventId(eventName, chatId, eventTime);
 
     console.log('[DEBUG] Enviando evento InitiateCheckout para Facebook com:', {
       event_name: eventName,
@@ -889,10 +889,11 @@ async _executarGerarCobranca(req, res) {
           // Buscar token do usuário para external_id
           const userToken = await this.buscarTokenUsuario(chatId);
           
+          const eventTime = Math.floor(Date.now() / 1000);
           const eventData = {
             event_name: 'AddToCart',
-            event_time: Math.floor(Date.now() / 1000),
-            event_id: generateEventId('AddToCart'),
+            event_time: eventTime,
+            event_id: generateEventId('AddToCart', chatId, eventTime),
             value: parseFloat(randomValue),
             currency: 'BRL',
             telegram_id: chatId, // 🔥 NOVO: Habilita rastreamento invisível automático

--- a/server.js
+++ b/server.js
@@ -236,7 +236,11 @@ app.post('/api/verificar-token', async (req, res) => {
           console.log(`⚠️ CAPI para token ${token} já está sendo processado ou foi enviado`);
         } else {
           // 2. Realizar envio do evento CAPI
-          const eventId = generateEventId('Purchase', token);
+          const eventId = generateEventId(
+            'Purchase',
+            token,
+            dadosToken.event_time || Math.floor(new Date(dadosToken.criado_em).getTime() / 1000)
+          );
           const capiResult = await sendFacebookEvent({
             event_name: 'Purchase',
             event_time: dadosToken.event_time || Math.floor(new Date(dadosToken.criado_em).getTime() / 1000),
@@ -755,7 +759,11 @@ function iniciarCronFallback() {
         }
 
         const eventName = 'Purchase';
-        const eventId = generateEventId(eventName, row.token);
+        const eventId = generateEventId(
+          eventName,
+          row.token,
+          row.event_time || Math.floor(new Date(row.criado_em).getTime() / 1000)
+        );
         
         const capiResult = await sendFacebookEvent({
           event_name: eventName,

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -1,5 +1,4 @@
 const axios = require('axios');
-const { v4: uuidv4 } = require('uuid');
 const crypto = require('crypto');
 const { getInstance: getSessionTracking } = require('./sessionTracking');
 
@@ -13,8 +12,11 @@ function getDedupKey({event_name, event_time, event_id, fbp, fbc}) {
   return [event_name, event_id || '', event_time, fbp || '', fbc || ''].join('|');
 }
 
-function generateEventId(eventName, token) {
-  return eventName === 'Purchase' && token ? token : uuidv4();
+function generateEventId(eventName, userId = '', timestamp = Date.now()) {
+  if (eventName === 'Purchase' && userId) return userId;
+  const input = `${eventName}_${userId}_${timestamp}`;
+  const hash = crypto.createHash('sha256').update(input).digest('hex');
+  return hash.substring(0, 16);
 }
 
 function isDuplicate(key) {


### PR DESCRIPTION
## Summary
- add deterministic `generateEventID` function for client and server
- attach event IDs to all Facebook Pixel events
- reuse same IDs when sending events from Node services

## Testing
- `npm install`
- `DATABASE_URL=postgresql://localhost:5432/test npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e1e189268832a8ba1a334b133cb0f