### PR TITLE
Update Facebook Pixel initialization

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -7,7 +7,21 @@
   <meta name="robots" content="noindex, nofollow" />
 
   <!-- Facebook Pixel -->
-  <script src="fb-config.js"></script>
+  <script>
+    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
+    async function loadFacebookConfig() {
+      try {
+        const r = await fetch('/api/config');
+        const cfg = await r.json();
+        window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
+        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
+        window.fbConfig.loaded = true;
+      } catch (e) {
+        console.error('Erro ao carregar config do Facebook', e);
+      }
+    }
+    loadFacebookConfig();
+  </script>
   <script>
     !function(f,b,e,v,n,t,s){
       if(f.fbq)return;n=f.fbq=function(){
@@ -20,7 +34,7 @@
 
     // Aguardar carregamento das configurações antes de inicializar
     function initializeFacebookPixel() {
-      if (window.fbConfig && window.fbConfig.loaded && window.fbConfig.FB_PIXEL_ID) {
+      if (window.fbConfig && window.fbConfig.loaded && window.fbConfig.FB_PIXEL_ID && typeof fbq === 'function') {
         fbq('init', window.fbConfig.FB_PIXEL_ID);
         
         const pageViewId = generateEventID('PageView');

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -8,7 +8,21 @@
   <meta name="robots" content="noindex, nofollow" />
 
   <!-- Facebook Pixel -->
-  <script src="fb-config.js"></script>
+  <script>
+    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
+    async function loadFacebookConfig() {
+      try {
+        const r = await fetch('/api/config');
+        const cfg = await r.json();
+        window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
+        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
+        window.fbConfig.loaded = true;
+      } catch (e) {
+        console.error('Erro ao carregar config do Facebook', e);
+      }
+    }
+    loadFacebookConfig();
+  </script>
   <script>
     !function(f,b,e,v,n,t,s){
       if(f.fbq)return;n=f.fbq=function(){
@@ -21,9 +35,9 @@
 
     // Aguardar carregamento das configurações antes de inicializar
     function initializeFacebookPixel() {
-      if (window.fbConfig && window.fbConfig.loaded && window.fbConfig.FB_PIXEL_ID) {
+      if (window.fbConfig && window.fbConfig.loaded && window.fbConfig.FB_PIXEL_ID && typeof fbq === 'function') {
         fbq('init', window.fbConfig.FB_PIXEL_ID);
-        
+
         const pageViewId = generateEventID('PageView');
         const pageViewData = { eventID: pageViewId };
         if (window.fbConfig.FB_TEST_EVENT_CODE) {

--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -105,7 +105,21 @@
   </div>
 
   <!-- Facebook Pixel -->
-  <script src="fb-config.js"></script>
+  <script>
+    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
+    async function loadFacebookConfig() {
+      try {
+        const r = await fetch('/api/config');
+        const cfg = await r.json();
+        window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
+        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
+        window.fbConfig.loaded = true;
+      } catch (e) {
+        console.error('Erro ao carregar config do Facebook', e);
+      }
+    }
+    loadFacebookConfig();
+  </script>
   <script>
     !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){
       n.callMethod ? n.callMethod.apply(n,arguments) : n.queue.push(arguments)};
@@ -117,7 +131,7 @@
 
     // Aguardar carregamento das configurações antes de inicializar
     function initializeFacebookPixel() {
-      if (window.fbConfig && window.fbConfig.loaded && window.fbConfig.FB_PIXEL_ID) {
+      if (window.fbConfig && window.fbConfig.loaded && window.fbConfig.FB_PIXEL_ID && typeof fbq === 'function') {
         fbq('init', window.fbConfig.FB_PIXEL_ID);
         
         const pageViewId = generateEventID('PageView');

--- a/MODELO1/WEB/viewcontent-integration-example.html
+++ b/MODELO1/WEB/viewcontent-integration-example.html
@@ -6,7 +6,21 @@
   <title>Exemplo ViewContent CAPI + Pixel</title>
   
   <!-- Facebook Pixel -->
-  <script src="fb-config.js"></script>
+  <script>
+    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
+    async function loadFacebookConfig() {
+      try {
+        const r = await fetch('/api/config');
+        const cfg = await r.json();
+        window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
+        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
+        window.fbConfig.loaded = true;
+      } catch (e) {
+        console.error('Erro ao carregar config do Facebook', e);
+      }
+    }
+    loadFacebookConfig();
+  </script>
   <script>
     !function(f,b,e,v,n,t,s){
       if(f.fbq)return;n=f.fbq=function(){
@@ -19,7 +33,7 @@
 
     // Aguardar carregamento das configurações antes de inicializar
     function initializeFacebookPixel() {
-      if (window.fbConfig && window.fbConfig.loaded && window.fbConfig.FB_PIXEL_ID) {
+      if (window.fbConfig && window.fbConfig.loaded && window.fbConfig.FB_PIXEL_ID && typeof fbq === 'function') {
         fbq('init', window.fbConfig.FB_PIXEL_ID);
         console.debug('🔧 Facebook Pixel inicializado com:', window.fbConfig.FB_PIXEL_ID);
       } else {


### PR DESCRIPTION
## Summary
- load FB Pixel config inline via `/api/config`
- initialize Pixel after fbq and config are available

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687ec8003ae4832a95929f9da4e931a1