### PR TITLE
Fix undefined chatId in cobranca endpoint

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -566,7 +566,7 @@ async _executarGerarCobranca(req, res) {
     }
 
     const eventName = 'InitiateCheckout';
-    const eventId = generateEventId(eventName, chatId, eventTime);
+    const eventId = generateEventId(eventName, telegram_id, eventTime);
 
     console.log('[DEBUG] Enviando evento InitiateCheckout para Facebook com:', {
       event_name: eventName,


### PR DESCRIPTION
## Summary
- use `telegram_id` for Facebook event generation in charge endpoint

## Testing
- `npm install`
- `npm test` *(fails: `DATABASE_URL` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687ed4f56790832a8e9d8b8998c49a59