### PR TITLE
Fix missing event_source_url for CAPI events

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -19,6 +19,7 @@ router.get('/api/config', (req, res) => {
 
 const dedupCache = new Map();
 const DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const DEFAULT_EVENT_SOURCE_URL = 'https://ohvips.xyz/obrigado.html';
 
 // 🔥 NOVA FUNÇÃO: Sincronização de timestamp para deduplicação perfeita
 function generateSyncedTimestamp(clientTimestamp = null) {
@@ -286,8 +287,9 @@ async function sendFacebookEvent({
     }
   };
 
-  if (event_source_url) {
-    eventPayload.event_source_url = event_source_url;
+  const finalEventSourceUrl = event_source_url || DEFAULT_EVENT_SOURCE_URL;
+  if (!eventPayload.event_source_url) {
+    eventPayload.event_source_url = finalEventSourceUrl;
   }
 
   const payload = {


### PR DESCRIPTION
## Summary
- ensure every CAPI event sets `event_source_url`

## Testing
- `NODE_ENV=development npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ee8a2d278832aa4823e5f593f2add