### PR TITLE
Ensure event_id sent to Facebook API

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -154,6 +154,12 @@ async function sendFacebookEvent({
     return { success: false, error: 'FB_PIXEL_ID not set' };
   }
 
+  // Garantir que event_id sempre esteja presente para deduplicação
+  if (!event_id) {
+    event_id = generateEventId(event_name, telegram_id || token || '', event_time);
+    console.log(`⚠️ event_id não fornecido. Gerado automaticamente: ${event_id}`);
+  }
+
   // 🔥 NOVO: Buscar cookies do SessionTracking se telegram_id fornecido e fbp/fbc não estão definidos
   let finalFbp = fbp;
   let finalFbc = fbc;

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -155,9 +155,10 @@ async function sendFacebookEvent({
   }
 
   // Garantir que event_id sempre esteja presente para deduplicação
-  if (!event_id) {
-    event_id = generateEventId(event_name, telegram_id || token || '', event_time);
-    console.log(`⚠️ event_id não fornecido. Gerado automaticamente: ${event_id}`);
+  let finalEventId = event_id;
+  if (!finalEventId) {
+    finalEventId = generateEventId(event_name, telegram_id || token || '', event_time);
+    console.log(`⚠️ event_id não fornecido. Gerado automaticamente: ${finalEventId}`);
   }
 
   // 🔥 NOVO: Buscar cookies do SessionTracking se telegram_id fornecido e fbp/fbc não estão definidos
@@ -197,12 +198,12 @@ async function sendFacebookEvent({
   const syncedEventTime = generateSyncedTimestamp(client_timestamp) || event_time;
   
   // 🔥 DEDUPLICAÇÃO MELHORADA: Usar chave robusta para eventos Purchase
-  const dedupKey = event_name === 'Purchase' 
-    ? getEnhancedDedupKey({ event_name, event_time: syncedEventTime, event_id, fbp: finalFbp, fbc: finalFbc, client_timestamp })
-    : getDedupKey({ event_name, event_time: syncedEventTime, event_id, fbp: finalFbp, fbc: finalFbc });
+  const dedupKey = event_name === 'Purchase'
+    ? getEnhancedDedupKey({ event_name, event_time: syncedEventTime, event_id: finalEventId, fbp: finalFbp, fbc: finalFbc, client_timestamp })
+    : getDedupKey({ event_name, event_time: syncedEventTime, event_id: finalEventId, fbp: finalFbp, fbc: finalFbc });
     
   if (isDuplicate(dedupKey)) {
-    console.log(`🔄 Evento duplicado detectado e ignorado | ${source} | ${event_name} | ${event_id} | timestamp: ${syncedEventTime}`);
+    console.log(`🔄 Evento duplicado detectado e ignorado | ${source} | ${event_name} | ${finalEventId} | timestamp: ${syncedEventTime}`);
     return { success: false, duplicate: true };
   }
   
@@ -283,7 +284,7 @@ async function sendFacebookEvent({
   const eventPayload = {
     event_name,
     event_time: finalEventTime, // 🔥 USAR TIMESTAMP SINCRONIZADO
-    event_id,
+    event_id: finalEventId,
     action_source: 'website',
     user_data,
     custom_data: {


### PR DESCRIPTION
## Summary
- always generate event_id if missing to avoid null/undefined
- confirm event_id is included in the event payload

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687eec3d4f68832a922dfebfa0e370a0