### PR TITLE
Fix tokens timestamp column

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -240,7 +240,7 @@ class TelegramBotService {
           SELECT token 
           FROM tokens 
           WHERE telegram_id = ? AND status = 'valido' AND token IS NOT NULL
-          ORDER BY created_at DESC 
+          ORDER BY criado_em DESC
           LIMIT 1
         `).get(cleanTelegramId);
       } catch (error) {
@@ -256,7 +256,7 @@ class TelegramBotService {
           `SELECT token 
            FROM tokens 
            WHERE telegram_id = $1 AND status = 'valido' AND token IS NOT NULL
-           ORDER BY created_at DESC 
+           ORDER BY criado_em DESC
            LIMIT 1`,
           [cleanTelegramId]
         );


### PR DESCRIPTION
## Summary
- fix SQL queries to use `criado_em` column when reading from `tokens`

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687f1052db38832aa91ac49d2613d7cd