### PR TITLE
Corrigir erro de rastreamento nulo

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -493,6 +493,12 @@ async _executarGerarCobranca(req, res) {
     // 3. Fazer mergeTrackingData(dadosSalvos, dadosRequisicao)
     const finalTrackingData = mergeTrackingData(dadosSalvos, dadosRequisicao);
 
+    // 🔧 PROTEÇÃO CRÍTICA: Verificar se finalTrackingData é válido antes de prosseguir
+    if (!finalTrackingData || typeof finalTrackingData !== 'object') {
+      console.error('[ERRO CRÍTICO] finalTrackingData está null ou inválido. Abortando geração de cobrança.');
+      return res.status(500).json({ error: 'Tracking inválido - dados ausentes.' });
+    }
+
     console.log('[DEBUG] Final tracking data após merge:', finalTrackingData);
     
     // 🔥 CORREÇÃO: Log específico dos UTMs finais

--- a/services/trackingValidation.js
+++ b/services/trackingValidation.js
@@ -97,6 +97,12 @@ function mergeTrackingData(dadosSalvos = {}, dadosRequisicao = {}) {
     }
   }
 
+  // 🔧 PROTEÇÃO: Garantir que nunca retorne null ou undefined
+  if (!resultado || typeof resultado !== 'object') {
+    console.warn('[ERRO] mergeTrackingData retornou resultado inválido:', resultado);
+    return {};
+  }
+
   return resultado;
 }
 


### PR DESCRIPTION
Add robust validation for tracking data to prevent "Cannot read properties of null" errors during billing generation.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-daf68919-ab9c-4565-a412-31a5317cb745) · [Cursor](https://cursor.com/background-agent?bcId=bc-daf68919-ab9c-4565-a412-31a5317cb745)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)