### PR TITLE
Add missing UTM columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ CREATE TABLE tracking_data (
   utm_source TEXT,
   utm_medium TEXT,
   utm_campaign TEXT,
+  utm_term TEXT,
+  utm_content TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```
@@ -200,6 +202,8 @@ CREATE TABLE payloads (
   utm_source TEXT,
   utm_medium TEXT,
   utm_campaign TEXT,
+  utm_term TEXT,
+  utm_content TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 ```

--- a/database/postgres.js
+++ b/database/postgres.js
@@ -182,6 +182,8 @@ async function createTables(pool) {
           utm_source TEXT,
           utm_medium TEXT,
           utm_campaign TEXT,
+          utm_term TEXT,
+          utm_content TEXT,
           fbp TEXT,
           fbc TEXT,
           ip TEXT,
@@ -307,6 +309,18 @@ async function createTables(pool) {
           WHERE table_name='tracking_data' AND column_name='utm_campaign'
         ) THEN
           ALTER TABLE tracking_data ADD COLUMN utm_campaign TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tracking_data' AND column_name='utm_term'
+        ) THEN
+          ALTER TABLE tracking_data ADD COLUMN utm_term TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tracking_data' AND column_name='utm_content'
+        ) THEN
+          ALTER TABLE tracking_data ADD COLUMN utm_content TEXT;
         END IF;
       END
       $$;

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -46,6 +46,8 @@ function initialize(path = './pagamentos.db') {
         utm_source TEXT,
         utm_medium TEXT,
         utm_campaign TEXT,
+        utm_term TEXT,
+        utm_content TEXT,
         fbp TEXT,
         fbc TEXT,
         ip TEXT,
@@ -133,6 +135,12 @@ function initialize(path = './pagamentos.db') {
     }
     if (!checkTrackingCol('utm_campaign')) {
       database.prepare('ALTER TABLE tracking_data ADD COLUMN utm_campaign TEXT').run();
+    }
+    if (!checkTrackingCol('utm_term')) {
+      database.prepare('ALTER TABLE tracking_data ADD COLUMN utm_term TEXT').run();
+    }
+    if (!checkTrackingCol('utm_content')) {
+      database.prepare('ALTER TABLE tracking_data ADD COLUMN utm_content TEXT').run();
     }
     console.log('✅ SQLite inicializado');
   } catch (err) {


### PR DESCRIPTION
## Summary
- include `utm_term` and `utm_content` when creating `tracking_data` in both database layers
- ensure existing databases add these columns when initializing
- document the new columns in README

## Testing
- `DATABASE_URL=postgres://user:pass@localhost:5432/db npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f1f9fa718832a9103ffee28089be8