### PR TITLE
Fix trackingData null handling

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -481,10 +481,10 @@ async _executarGerarCobranca(req, res) {
   const utm_campaign = tracking.utm_campaign || null;
   const utm_term = tracking.utm_term || null;
   const utm_content = tracking.utm_content || null;
-  const reqFbp = tracking.fbp || null;
-  const reqFbc = tracking.fbc || null;
-  const reqIp = tracking.ip || req.ip || null;
-  const reqUa = tracking.user_agent || req.headers['user-agent'] || null;
+  const fbp = tracking.fbp || null;
+  const fbc = tracking.fbc || null;
+  const ip = tracking.ip || req.ip || null;
+  const user_agent = tracking.user_agent || req.headers['user-agent'] || null;
 
   console.log('📡 API: POST /api/gerar-cobranca');
   console.log('🔍 Tracking recebido:', {
@@ -493,10 +493,10 @@ async _executarGerarCobranca(req, res) {
     utm_campaign,
     utm_term,
     utm_content,
-    fbp: reqFbp,
-    fbc: reqFbc,
-    ip: reqIp,
-    user_agent: reqUa
+    fbp,
+    fbc,
+    ip,
+    user_agent
   });
   console.log('[DEBUG] Dados recebidos:', { telegram_id, plano, valor });
   console.log('[DEBUG] trackingData do req.body:', req.body.trackingData);
@@ -581,10 +581,10 @@ async _executarGerarCobranca(req, res) {
     const cookies = parseCookies(req.headers['cookie']);
 
     const dadosRequisicao = {
-      fbp: reqFbp || req.body.fbp || req.body._fbp || cookies._fbp || cookies.fbp || null,
-      fbc: reqFbc || req.body.fbc || req.body._fbc || cookies._fbc || cookies.fbc || null,
-      ip: reqIp || ipBody || ipRaw || null,
-      user_agent: reqUa || uaCriacao || null,
+      fbp: fbp || req.body.fbp || req.body._fbp || cookies._fbp || cookies.fbp || null,
+      fbc: fbc || req.body.fbc || req.body._fbc || cookies._fbc || cookies.fbc || null,
+      ip: ip || ipBody || ipRaw || null,
+      user_agent: user_agent || uaCriacao || null,
       // 🔥 CORREÇÃO: Incluir UTMs da URL atual
       utm_source: utm_source || null,
       utm_medium: utm_medium || null,

--- a/RELATORIO_CORRECAO_UTM_BUG.md
+++ b/RELATORIO_CORRECAO_UTM_BUG.md
@@ -51,10 +51,10 @@ if (hasNewUtms) {
 ### 2. **Inclusão de UTMs em `dadosRequisicao`**
 ```javascript
 const dadosRequisicao = {
-  fbp: reqFbp || req.body.fbp || req.body._fbp || cookies._fbp || cookies.fbp || null,
-  fbc: reqFbc || req.body.fbc || req.body._fbc || cookies._fbc || cookies.fbc || null,
-  ip: reqIp || ipBody || ipRaw || null,
-  user_agent: reqUa || uaCriacao || null,
+  fbp: fbp || req.body.fbp || req.body._fbp || cookies._fbp || cookies.fbp || null,
+  fbc: fbc || req.body.fbc || req.body._fbc || cookies._fbc || cookies.fbc || null,
+  ip: ip || ipBody || ipRaw || null,
+  user_agent: user_agent || uaCriacao || null,
   // 🔥 CORREÇÃO: Incluir UTMs da URL atual
   utm_source: utm_source || null,
   utm_medium: utm_medium || null,


### PR DESCRIPTION
## Summary
- rename tracking variables to match documentation and always set safe fallbacks
- update docs with new variable names

## Testing
- `npm test` *(fails: `DATABASE_URL não definida`)*

------
https://chatgpt.com/codex/tasks/task_e_687fd1521838832a8b2cf3ac21d9df1b