### PR TITLE
Enable Facebook test events

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -8,16 +8,13 @@
 
   <!-- Facebook Pixel -->
   <script>
-    // === COMENTAR FB TEST EVENT CODE ===
-    // window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
-    window.fbConfig = { FB_PIXEL_ID: '', loaded: false };
+    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
     async function loadFacebookConfig() {
       try {
         const r = await fetch('/api/config');
         const cfg = await r.json();
         window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
-        // === COMENTAR FB TEST EVENT CODE ===
-        // window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
+        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
         window.fbConfig.loaded = true;
       } catch (e) {
         console.error('Erro ao carregar config do Facebook', e);
@@ -42,10 +39,9 @@
         
         const pageViewId = generateEventID('PageView');
         const pageViewData = { eventID: pageViewId };
-        // === COMENTAR FB TEST EVENT CODE ===
-        // if (window.fbConfig.FB_TEST_EVENT_CODE) {
-        //   pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        // }
+        if (window.fbConfig.FB_TEST_EVENT_CODE) {
+          pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+        }
         fbq('track', 'PageView', pageViewData);
         
         const viewInitId = generateEventID('ViewContent');
@@ -54,10 +50,9 @@
           currency: 'BRL',
           eventID: viewInitId
         };
-        // === COMENTAR FB TEST EVENT CODE ===
-        // if (window.fbConfig.FB_TEST_EVENT_CODE) {
-        //   viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        // }
+        if (window.fbConfig.FB_TEST_EVENT_CODE) {
+          viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+        }
         fbq('track', 'ViewContent', viewContentData);
         
         console.debug('🔧 Facebook Pixel inicializado com:', window.fbConfig.FB_PIXEL_ID);
@@ -207,10 +202,9 @@
         content_category: 'Bot Telegram',
         eventID: generateEventID('ViewContent')
       };
-      // === COMENTAR FB TEST EVENT CODE ===
-      // if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-      //   viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-      // }
+      if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
+        viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+      }
       fbq('track', 'ViewContent', viewContentData);
     });
 

--- a/MODELO1/WEB/fb-config.js
+++ b/MODELO1/WEB/fb-config.js
@@ -1,12 +1,7 @@
 // fb-config.js - Configurações do Facebook Pixel carregadas do servidor
-// === COMENTAR FB TEST EVENT CODE ===
-// window.fbConfig = {
-//   FB_PIXEL_ID: '',
-//   FB_TEST_EVENT_CODE: '',
-//   loaded: false
-// };
 window.fbConfig = {
   FB_PIXEL_ID: '',
+  FB_TEST_EVENT_CODE: '',
   loaded: false
 };
 
@@ -17,16 +12,14 @@ async function loadFacebookConfig() {
     const config = await response.json();
     
     window.fbConfig.FB_PIXEL_ID = config.FB_PIXEL_ID;
-    // === COMENTAR FB TEST EVENT CODE ===
-    // window.fbConfig.FB_TEST_EVENT_CODE = config.FB_TEST_EVENT_CODE;
+    window.fbConfig.FB_TEST_EVENT_CODE = config.FB_TEST_EVENT_CODE;
     window.fbConfig.loaded = true;
     
     // Log discreto para debug
     if (console && console.debug) {
       console.debug('🔧 FB Config carregado:', {
-        pixelId: config.FB_PIXEL_ID ? 'DEFINIDO' : 'NÃO DEFINIDO'
-        // === COMENTAR FB TEST EVENT CODE ===
-        // testEventCode: config.FB_TEST_EVENT_CODE ? 'DEFINIDO' : 'NÃO DEFINIDO'
+        pixelId: config.FB_PIXEL_ID ? 'DEFINIDO' : 'NÃO DEFINIDO',
+        testEventCode: config.FB_TEST_EVENT_CODE ? 'DEFINIDO' : 'NÃO DEFINIDO'
       });
     }
     

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -9,16 +9,13 @@
 
   <!-- Facebook Pixel -->
   <script>
-    // === COMENTAR FB TEST EVENT CODE ===
-    // window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
-    window.fbConfig = { FB_PIXEL_ID: '', loaded: false };
+    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
     async function loadFacebookConfig() {
       try {
         const r = await fetch('/api/config');
         const cfg = await r.json();
         window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
-        // === COMENTAR FB TEST EVENT CODE ===
-        // window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
+        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
         window.fbConfig.loaded = true;
       } catch (e) {
         console.error('Erro ao carregar config do Facebook', e);
@@ -43,10 +40,9 @@
 
         const pageViewId = generateEventID('PageView');
         const pageViewData = { eventID: pageViewId };
-        // === COMENTAR FB TEST EVENT CODE ===
-        // if (window.fbConfig.FB_TEST_EVENT_CODE) {
-        //   pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        // }
+        if (window.fbConfig.FB_TEST_EVENT_CODE) {
+          pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+        }
         fbq('track', 'PageView', pageViewData);
         
         const viewIdInit = generateEventID('ViewContent');
@@ -55,10 +51,9 @@
           currency: 'BRL',
           eventID: viewIdInit
         };
-        // === COMENTAR FB TEST EVENT CODE ===
-        // if (window.fbConfig.FB_TEST_EVENT_CODE) {
-        //   viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        // }
+        if (window.fbConfig.FB_TEST_EVENT_CODE) {
+          viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+        }
         fbq('track', 'ViewContent', viewContentData);
         
         console.debug('🔧 Facebook Pixel inicializado com:', window.fbConfig.FB_PIXEL_ID);
@@ -223,10 +218,9 @@
         content_category: 'Bot Telegram',
         eventID: generateEventID('ViewContent')
       };
-      // === COMENTAR FB TEST EVENT CODE ===
-      // if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-      //   viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-      // }
+      if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
+        viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+      }
       fbq('track', 'ViewContent', viewContentData);
     } catch (e) {
       console.error('Facebook Pixel error', e);

--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -106,16 +106,13 @@
 
   <!-- Facebook Pixel -->
   <script>
-    // === COMENTAR FB TEST EVENT CODE ===
-    // window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
-    window.fbConfig = { FB_PIXEL_ID: '', loaded: false };
+    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
     async function loadFacebookConfig() {
       try {
         const r = await fetch('/api/config');
         const cfg = await r.json();
         window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
-        // === COMENTAR FB TEST EVENT CODE ===
-        // window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
+        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
         window.fbConfig.loaded = true;
       } catch (e) {
         console.error('Erro ao carregar config do Facebook', e);
@@ -139,10 +136,9 @@
         
         const pageViewId = generateEventID('PageView');
         const pageViewData = { eventID: pageViewId };
-        // === COMENTAR FB TEST EVENT CODE ===
-        // if (window.fbConfig.FB_TEST_EVENT_CODE) {
-        //   pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        // }
+        if (window.fbConfig.FB_TEST_EVENT_CODE) {
+          pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+        }
         fbq('track', 'PageView', pageViewData);
         
         const viewContentInitId = generateEventID('ViewContent');
@@ -151,10 +147,9 @@
           currency: 'BRL',
           eventID: viewContentInitId
         };
-        // === COMENTAR FB TEST EVENT CODE ===
-        // if (window.fbConfig.FB_TEST_EVENT_CODE) {
-        //   viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        // }
+        if (window.fbConfig.FB_TEST_EVENT_CODE) {
+          viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+        }
         fbq('track', 'ViewContent', viewContentData);
         
         console.debug('🔧 Facebook Pixel inicializado com:', window.fbConfig.FB_PIXEL_ID);
@@ -471,10 +466,9 @@
           return;
         }
         dados.eventID = token;
-        // === COMENTAR FB TEST EVENT CODE ===
-        // if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-        //   dados.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        // }
+        if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
+          dados.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+        }
         
         // 🔥 CORREÇÃO CRÍTICA: Adicionar event_source_url para deduplicação
         dados.event_source_url = window.location.href;

--- a/MODELO1/WEB/timestamp-sync.js
+++ b/MODELO1/WEB/timestamp-sync.js
@@ -99,11 +99,9 @@ async function dispararPurchaseComTimestampSincronizado(token, valorNumerico, da
       ...dadosEvento
     };
     
-    // === COMENTAR FB TEST EVENT CODE ===
-    // Adicionar test_event_code se disponível
-    // if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-    //   dados.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-    // }
+    if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
+      dados.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+    }
     
     // 6. Disparar evento Purchase via Facebook Pixel
     fbq('track', 'Purchase', dados);

--- a/MODELO1/WEB/viewcontent-capi-example.js
+++ b/MODELO1/WEB/viewcontent-capi-example.js
@@ -70,10 +70,9 @@ function sendViewContentPixel(eventId, options = {}) {
       content_category: options.content_category || 'Website',
       eventID: eventId // Usar o mesmo eventID para deduplicação
     };
-          // === COMENTAR FB TEST EVENT CODE ===
-      // if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-      //   viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-      // }
+      if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
+        viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+      }
     fbq('track', 'ViewContent', viewContentData);
     
     console.log('✅ ViewContent Pixel enviado:', { eventID: eventId });

--- a/MODELO1/WEB/viewcontent-integration-example.html
+++ b/MODELO1/WEB/viewcontent-integration-example.html
@@ -7,16 +7,13 @@
   
   <!-- Facebook Pixel -->
   <script>
-    // === COMENTAR FB TEST EVENT CODE ===
-    // window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
-    window.fbConfig = { FB_PIXEL_ID: '', loaded: false };
+    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
     async function loadFacebookConfig() {
       try {
         const r = await fetch('/api/config');
         const cfg = await r.json();
         window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
-        // === COMENTAR FB TEST EVENT CODE ===
-        // window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
+        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
         window.fbConfig.loaded = true;
       } catch (e) {
         console.error('Erro ao carregar config do Facebook', e);
@@ -109,10 +106,9 @@
             content_category: options.content_category || 'Website',
             eventID: eventId // IMPORTANTE: mesmo ID para deduplicação
           };
-                // === COMENTAR FB TEST EVENT CODE ===
-      // if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-      //   viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-      // }
+                if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
+          viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
+        }
           fbq('track', 'ViewContent', viewContentData);
           
           addLog(`✅ ViewContent Pixel enviado com Event ID: ${eventId}`, 'success');

--- a/app.js
+++ b/app.js
@@ -14,9 +14,8 @@ app.use(express.static(path.join(__dirname, 'MODELO1/WEB')));
 // 🔥 NOVO: Endpoint para servir configurações do Facebook Pixel
 app.get('/api/config', (req, res) => {
   res.json({
-    FB_PIXEL_ID: process.env.FB_PIXEL_ID || ''
-    // === COMENTAR FB TEST EVENT CODE ===
-    // FB_TEST_EVENT_CODE: process.env.FB_TEST_EVENT_CODE || ''
+    FB_PIXEL_ID: process.env.FB_PIXEL_ID || '',
+    ...(process.env.FB_TEST_EVENT_CODE ? { FB_TEST_EVENT_CODE: process.env.FB_TEST_EVENT_CODE } : {})
   });
 });
 


### PR DESCRIPTION
## Summary
- wire test_event_code through CAPI events
- surface FB_TEST_EVENT_CODE via `/api/config`
- include test_event_code on Pixel events in demo pages
- expose FB_TEST_EVENT_CODE in demo config loader

## Testing
- `npm test` *(fails: DATABASE_URL não definida)*

------
https://chatgpt.com/codex/tasks/task_e_687fe11812dc832aba9241c2951328f7