### PR TITLE
Fix pushinpay webhook body parsing

### DIFF
--- a/server.js
+++ b/server.js
@@ -1220,7 +1220,7 @@ async function carregarSistemaTokens() {
 }
 
 
-app.post('/webhook/pushinpay', async (req, res) => {
+app.post('/webhook/pushinpay', express.json(), async (req, res) => {
   try {
     const rawId = req.body?.token || req.body?.id || req.body?.transaction_id || '';
     const idTrimmed = String(rawId).trim();


### PR DESCRIPTION
## Summary
- add express.json middleware to `/webhook/pushinpay` so that PushinPay webhooks are parsed properly

## Testing
- `npm test` *(fails: `DATABASE_URL` not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687fe8f432b8832ab49e8cfa5eabb424