### PR TITLE
Fix multi-bot PushinPay webhooks

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -710,7 +710,7 @@ async _executarGerarCobranca(req, res) {
 
     const webhookUrl =
       typeof this.baseUrl === 'string'
-        ? `https://ohvips.xyz/${this.botId}/webhook`
+        ? `${this.baseUrl}/${this.botId}/webhook`
         : undefined;
 
     const pushPayload = {


### PR DESCRIPTION
## Summary
- dispatch PushinPay webhooks per bot
- route Telegram and PushinPay webhooks through `/botX/webhook`
- generate PushinPay charges using per-bot webhook URL

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ffc34a5dc832a994a03297b05edd7