### PR TITLE
Corrige header do axios para UTMify

### DIFF
--- a/services/utmify.js
+++ b/services/utmify.js
@@ -37,7 +37,12 @@ async function enviarConversaoParaUtmify(orderId, utms = {}) {
     }
   };
 
-  const config = { headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' } };
+  const config = {
+    headers: {
+      'x-api-token': token,
+      'Content-Type': 'application/json'
+    }
+  };
   const maxAttempts = 3;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {


### PR DESCRIPTION
## Resumo
- ajusta services/utmify.js para usar `x-api-token` no lugar de `Authorization`

## Testes
- `npm test` *(falha: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6880300f8b44832a9208728b741abe56