### PR TITLE
Fix UTMify payload product fields

### DIFF
--- a/services/utmify.js
+++ b/services/utmify.js
@@ -44,6 +44,8 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
       {
         id: 'curso-vitalicio',
         name: 'Curso Vitalício',
+        planId: 'curso-vitalicio',
+        planName: 'Curso Vitalício',
         quantity: 1,
         priceInCents: transactionValueCents
       }


### PR DESCRIPTION
## Summary
- add required `planId` and `planName` to UTMify payload products

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688044bf5994832aa04d888089300cb4