### PR TITLE
Adjust UTMify tracking parameters

### DIFF
--- a/services/utmify.js
+++ b/services/utmify.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const { v4: uuidv4 } = require('uuid');
+const adAccountId = process.env.UTMIFY_AD_ACCOUNT_ID; // ex: '129355640213755'
 
 function formatDateUTC(date) {
   const pad = n => String(n).padStart(2, '0');
@@ -27,7 +28,6 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
   const createdAt = formatDateUTC(now);
   const finalOrderId = orderId || uuidv4();
   const [campaignName, campaignId] = (tracking.utm_campaign || '').split('|');
-  const adAccountId = tracking.adAccountId || null;
   const payload = {
     orderId: finalOrderId,
     platform: 'telegram',

--- a/services/utmify.js
+++ b/services/utmify.js
@@ -26,6 +26,8 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
   const now = new Date();
   const createdAt = formatDateUTC(now);
   const finalOrderId = orderId || uuidv4();
+  const [campaignName, campaignId] = (tracking.utm_campaign || '').split('|');
+  const adAccountId = tracking.adAccountId || null;
   const payload = {
     orderId: finalOrderId,
     platform: 'telegram',
@@ -51,10 +53,10 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
       }
     ],
     trackingParameters: {
-      src: null,
-      sck: null,
+      src: adAccountId,
+      sck: campaignId,
       utm_source: tracking.utm_source,
-      utm_campaign: tracking.utm_campaign,
+      utm_campaign: campaignName,
       utm_medium: tracking.utm_medium,
       utm_content: tracking.utm_content,
       utm_term: tracking.utm_term


### PR DESCRIPTION
## Summary
- parse campaign info before building the UTMify payload
- send correct src/sck and utm_campaign fields to UTMify

## Testing
- `npm test` *(fails: DATABASE_URL não definida)*

------
https://chatgpt.com/codex/tasks/task_e_6881420dfdb8832a88562fa7a587bb7c