### PR TITLE
Ajusta taxa PushinPay na integração UTMify

### DIFF
--- a/services/utmify.js
+++ b/services/utmify.js
@@ -63,8 +63,8 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
     },
     commission: {
       totalPriceInCents: transactionValueCents,
-      gatewayFeeInCents: 0,
-      userCommissionInCents: 0
+      gatewayFeeInCents: 30,
+      userCommissionInCents: transactionValueCents - 30
     },
     isTest: false
   };


### PR DESCRIPTION
## Resumo
- define gatewayFeeInCents como 30
- calcula userCommissionInCents descontando a taxa de R$0,30

## Testes
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881502762f8832a9a19058a6524d516