### PR TITLE
Fix Facebook event values

### DIFF
--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -415,7 +415,7 @@
       }
       valorNumerico = parseFloat(valorNumerico.toFixed(2));
 
-      const dados = { value: valorNumerico, currency: 'BRL' };
+      const dados = { value: parseFloat(valorNumerico) / 100, currency: 'BRL' };
 
       const fbp = localStorage.getItem('fbp');
       const fbc = localStorage.getItem('fbc');

--- a/MODELO1/WEB/timestamp-sync.js
+++ b/MODELO1/WEB/timestamp-sync.js
@@ -93,7 +93,7 @@ async function dispararPurchaseComTimestampSincronizado(token, valorNumerico, da
     
     // 5. Preparar dados do evento Purchase
     const dados = {
-      value: valorNumerico,
+      value: parseFloat(valorNumerico) / 100,
       currency: 'BRL',
       eventID: token, // 🔥 IMPORTANTE: Usar token como eventID para deduplicação
       ...dadosEvento

--- a/server.js
+++ b/server.js
@@ -300,7 +300,7 @@ app.post('/api/verificar-token', async (req, res) => {
             event_time: dadosToken.event_time || Math.floor(new Date(dadosToken.criado_em).getTime() / 1000),
             event_id: eventId,
             event_source_url: eventSourceUrl, // 🔥 URL completa com todos os parâmetros
-            value: parseFloat(dadosToken.valor),
+            value: parseFloat(dadosToken.valor) / 100,
             currency: 'BRL',
             fbp: dadosToken.fbp,
             fbc: dadosToken.fbc,


### PR DESCRIPTION
## Summary
- send Purchase values in reais for CAPI
- adjust front-end Purchase tracking to also use reais

## Testing
- `NODE_ENV=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881675494bc832a9e341f227b5fe9a2