### PR TITLE
Remover fb_test_event_code do projeto

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -8,13 +8,12 @@
 
   <!-- Facebook Pixel -->
   <script>
-    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
+    window.fbConfig = { FB_PIXEL_ID: '', loaded: false };
     async function loadFacebookConfig() {
       try {
         const r = await fetch('/api/config');
         const cfg = await r.json();
         window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
-        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
         window.fbConfig.loaded = true;
       } catch (e) {
         console.error('Erro ao carregar config do Facebook', e);
@@ -39,9 +38,6 @@
         
         const pageViewId = generateEventID('PageView');
         const pageViewData = { eventID: pageViewId };
-        if (window.fbConfig.FB_TEST_EVENT_CODE) {
-          pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        }
         fbq('track', 'PageView', pageViewData);
         
         const viewInitId = generateEventID('ViewContent');
@@ -50,9 +46,6 @@
           currency: 'BRL',
           eventID: viewInitId
         };
-        if (window.fbConfig.FB_TEST_EVENT_CODE) {
-          viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        }
         fbq('track', 'ViewContent', viewContentData);
         
         console.debug('🔧 Facebook Pixel inicializado com:', window.fbConfig.FB_PIXEL_ID);
@@ -202,9 +195,6 @@
         content_category: 'Bot Telegram',
         eventID: generateEventID('ViewContent')
       };
-      if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-        viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-      }
       fbq('track', 'ViewContent', viewContentData);
     });
 

--- a/MODELO1/WEB/fb-config.js
+++ b/MODELO1/WEB/fb-config.js
@@ -1,7 +1,6 @@
 // fb-config.js - Configurações do Facebook Pixel carregadas do servidor
 window.fbConfig = {
   FB_PIXEL_ID: '',
-  FB_TEST_EVENT_CODE: '',
   loaded: false
 };
 
@@ -12,14 +11,12 @@ async function loadFacebookConfig() {
     const config = await response.json();
     
     window.fbConfig.FB_PIXEL_ID = config.FB_PIXEL_ID;
-    window.fbConfig.FB_TEST_EVENT_CODE = config.FB_TEST_EVENT_CODE;
     window.fbConfig.loaded = true;
     
     // Log discreto para debug
     if (console && console.debug) {
       console.debug('🔧 FB Config carregado:', {
-        pixelId: config.FB_PIXEL_ID ? 'DEFINIDO' : 'NÃO DEFINIDO',
-        testEventCode: config.FB_TEST_EVENT_CODE ? 'DEFINIDO' : 'NÃO DEFINIDO'
+        pixelId: config.FB_PIXEL_ID ? 'DEFINIDO' : 'NÃO DEFINIDO'
       });
     }
     

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -9,13 +9,12 @@
 
   <!-- Facebook Pixel -->
   <script>
-    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
+    window.fbConfig = { FB_PIXEL_ID: '', loaded: false };
     async function loadFacebookConfig() {
       try {
         const r = await fetch('/api/config');
         const cfg = await r.json();
         window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
-        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
         window.fbConfig.loaded = true;
       } catch (e) {
         console.error('Erro ao carregar config do Facebook', e);
@@ -40,9 +39,6 @@
 
         const pageViewId = generateEventID('PageView');
         const pageViewData = { eventID: pageViewId };
-        if (window.fbConfig.FB_TEST_EVENT_CODE) {
-          pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        }
         fbq('track', 'PageView', pageViewData);
         
         const viewIdInit = generateEventID('ViewContent');
@@ -51,9 +47,6 @@
           currency: 'BRL',
           eventID: viewIdInit
         };
-        if (window.fbConfig.FB_TEST_EVENT_CODE) {
-          viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        }
         fbq('track', 'ViewContent', viewContentData);
         
         console.debug('🔧 Facebook Pixel inicializado com:', window.fbConfig.FB_PIXEL_ID);
@@ -218,9 +211,6 @@
         content_category: 'Bot Telegram',
         eventID: generateEventID('ViewContent')
       };
-      if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-        viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-      }
       fbq('track', 'ViewContent', viewContentData);
     } catch (e) {
       console.error('Facebook Pixel error', e);

--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -106,13 +106,12 @@
 
   <!-- Facebook Pixel -->
   <script>
-    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
+    window.fbConfig = { FB_PIXEL_ID: '', loaded: false };
     async function loadFacebookConfig() {
       try {
         const r = await fetch('/api/config');
         const cfg = await r.json();
         window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
-        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
         window.fbConfig.loaded = true;
       } catch (e) {
         console.error('Erro ao carregar config do Facebook', e);
@@ -136,9 +135,6 @@
         
         const pageViewId = generateEventID('PageView');
         const pageViewData = { eventID: pageViewId };
-        if (window.fbConfig.FB_TEST_EVENT_CODE) {
-          pageViewData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        }
         fbq('track', 'PageView', pageViewData);
         
         const viewContentInitId = generateEventID('ViewContent');
@@ -147,9 +143,6 @@
           currency: 'BRL',
           eventID: viewContentInitId
         };
-        if (window.fbConfig.FB_TEST_EVENT_CODE) {
-          viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        }
         fbq('track', 'ViewContent', viewContentData);
         
         console.debug('🔧 Facebook Pixel inicializado com:', window.fbConfig.FB_PIXEL_ID);
@@ -466,9 +459,6 @@
           return;
         }
         dados.eventID = token;
-        if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-          dados.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        }
         
         // 🔥 CORREÇÃO CRÍTICA: Adicionar event_source_url para deduplicação
         dados.event_source_url = window.location.href;

--- a/MODELO1/WEB/timestamp-sync.js
+++ b/MODELO1/WEB/timestamp-sync.js
@@ -99,10 +99,6 @@ async function dispararPurchaseComTimestampSincronizado(token, valorNumerico, da
       ...dadosEvento
     };
     
-    if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-      dados.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-    }
-    
     // 6. Disparar evento Purchase via Facebook Pixel
     fbq('track', 'Purchase', dados);
     

--- a/MODELO1/WEB/viewcontent-capi-example.js
+++ b/MODELO1/WEB/viewcontent-capi-example.js
@@ -70,9 +70,6 @@ function sendViewContentPixel(eventId, options = {}) {
       content_category: options.content_category || 'Website',
       eventID: eventId // Usar o mesmo eventID para deduplicação
     };
-      if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-        viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-      }
     fbq('track', 'ViewContent', viewContentData);
     
     console.log('✅ ViewContent Pixel enviado:', { eventID: eventId });

--- a/MODELO1/WEB/viewcontent-integration-example.html
+++ b/MODELO1/WEB/viewcontent-integration-example.html
@@ -7,13 +7,12 @@
   
   <!-- Facebook Pixel -->
   <script>
-    window.fbConfig = { FB_PIXEL_ID: '', FB_TEST_EVENT_CODE: '', loaded: false };
+    window.fbConfig = { FB_PIXEL_ID: '', loaded: false };
     async function loadFacebookConfig() {
       try {
         const r = await fetch('/api/config');
         const cfg = await r.json();
         window.fbConfig.FB_PIXEL_ID = cfg.FB_PIXEL_ID;
-        window.fbConfig.FB_TEST_EVENT_CODE = cfg.FB_TEST_EVENT_CODE;
         window.fbConfig.loaded = true;
       } catch (e) {
         console.error('Erro ao carregar config do Facebook', e);
@@ -106,9 +105,6 @@
             content_category: options.content_category || 'Website',
             eventID: eventId // IMPORTANTE: mesmo ID para deduplicação
           };
-                if (window.fbConfig && window.fbConfig.FB_TEST_EVENT_CODE) {
-          viewContentData.test_event_code = window.fbConfig.FB_TEST_EVENT_CODE;
-        }
           fbq('track', 'ViewContent', viewContentData);
           
           addLog(`✅ ViewContent Pixel enviado com Event ID: ${eventId}`, 'success');

--- a/app.js
+++ b/app.js
@@ -14,8 +14,7 @@ app.use(express.static(path.join(__dirname, 'MODELO1/WEB')));
 // 🔥 NOVO: Endpoint para servir configurações do Facebook Pixel
 app.get('/api/config', (req, res) => {
   res.json({
-    FB_PIXEL_ID: process.env.FB_PIXEL_ID || '',
-    ...(process.env.FB_TEST_EVENT_CODE ? { FB_TEST_EVENT_CODE: process.env.FB_TEST_EVENT_CODE } : {})
+    FB_PIXEL_ID: process.env.FB_PIXEL_ID || ''
   });
 });
 

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -5,14 +5,12 @@ const { getInstance: getSessionTracking } = require('./sessionTracking');
 
 const PIXEL_ID = process.env.FB_PIXEL_ID;
 const ACCESS_TOKEN = process.env.FB_PIXEL_TOKEN;
-const TEST_EVENT_CODE = process.env.FB_TEST_EVENT_CODE; // Recupera código de evento de teste, se definido
 
 // Router para expor configurações do Facebook Pixel
 const router = express.Router();
 router.get('/api/config', (req, res) => {
   res.json({
-    FB_PIXEL_ID: process.env.FB_PIXEL_ID || '',
-    ...(process.env.FB_TEST_EVENT_CODE ? { FB_TEST_EVENT_CODE: process.env.FB_TEST_EVENT_CODE } : {})
+    FB_PIXEL_ID: process.env.FB_PIXEL_ID || ''
   });
   console.debug('[FB CONFIG] Endpoint /api/config carregado');
 });
@@ -136,7 +134,7 @@ async function sendFacebookEvent({
   ip,
   userAgent,
   custom_data = {},
-  test_event_code,
+
   user_data_hash = null, // Novos dados pessoais hasheados
   source = 'unknown', // Origem do evento: 'pixel', 'capi', 'cron'
   token = null, // Token para atualizar flags no banco
@@ -312,19 +310,10 @@ async function sendFacebookEvent({
     data: [eventPayload]
   };
 
-  // === COMENTAR FB TEST EVENT CODE ===
-  const finalTestEventCode = test_event_code || TEST_EVENT_CODE;
-  if (finalTestEventCode) {
-    payload.test_event_code = finalTestEventCode;
-    console.log(`🧪 Test Event Code adicionado: ${finalTestEventCode} | Fonte: ${source.toUpperCase()}`);
-  }
+
 
       try {
     let url = `https://graph.facebook.com/v18.0/${PIXEL_ID}/events?access_token=${ACCESS_TOKEN}`;
-    
-    if (finalTestEventCode) {
-      url += `&test_event_code=${finalTestEventCode}`;
-    }
     
     const res = await axios.post(url, payload);
     console.log(`✅ Evento ${event_name} enviado com sucesso via ${source.toUpperCase()}:`, res.data);

--- a/teste-deduplicacao.js
+++ b/teste-deduplicacao.js
@@ -69,8 +69,6 @@ async function testeConfiguracaoPixel() {
     
     console.log('✅ Configuração do Pixel:');
     console.log(`- FB_PIXEL_ID: ${config.FB_PIXEL_ID || 'NÃO DEFINIDO'}`);
-    // === COMENTAR FB TEST EVENT CODE ===
-    // console.log(`- FB_TEST_EVENT_CODE: ${config.FB_TEST_EVENT_CODE || 'NÃO DEFINIDO'}`);
     
     if (!config.FB_PIXEL_ID) {
       console.warn('⚠️ FB_PIXEL_ID não definido!');


### PR DESCRIPTION
Remove `FB_TEST_EVENT_CODE` variable and its related logic as it is no longer required for production Facebook CAPI functionality.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a4625c1e-9233-48f9-aed1-8e7a725437a3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a4625c1e-9233-48f9-aed1-8e7a725437a3)