### PR TITLE
fix(facebook): send CAPI events with auth header

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -327,9 +327,18 @@ async function sendFacebookEvent({
 
 
       try {
-    let url = `https://graph.facebook.com/v18.0/${PIXEL_ID}/events?access_token=${ACCESS_TOKEN}`;
-    
-    const res = await axios.post(url, payload);
+    const url = `https://graph.facebook.com/v18.0/${PIXEL_ID}/events`;
+
+    const res = await axios.post(
+      url,
+      payload,
+      {
+        headers: {
+          Authorization: `Bearer ${ACCESS_TOKEN}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
     console.log(`✅ Evento ${event_name} enviado com sucesso via ${source.toUpperCase()}:`, res.data);
 
     // Atualizar flags no banco se token e pool fornecidos


### PR DESCRIPTION
## Summary
- add explicit `Authorization` and `Content-Type` headers when posting to Facebook Conversions API

## Testing
- `npm test` *(fails: DATABASE_URL não definida)*

------
https://chatgpt.com/codex/tasks/task_e_6881b35000d0832a89d2097f6f4d326e