### PR TITLE
Fix UTM campaign parsing

### DIFF
--- a/services/utmify.js
+++ b/services/utmify.js
@@ -19,8 +19,19 @@ function formatDateUTC(date) {
   );
 }
 
+
 function gerarEmailFake() {
   return `${uuidv4()}@example.org`;
+}
+
+function sanitizeName(str) {
+  return (str || '')
+    .toString()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
 }
 
 async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionValueCents, trackingData, orderId }) {
@@ -37,7 +48,13 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
     utm_term = null
   } = trackingData;
 
-  const [campaignName, campaignId] = (utm_campaign || '').split('|');
+  const decodedCampaign = decodeURIComponent(utm_campaign || '');
+  const [campaignId, campaignNameRaw] = decodedCampaign.split('|');
+  const campaignName = sanitizeName(campaignNameRaw || '');
+
+  const decodedContent = decodeURIComponent(utm_content || '');
+  const [adId, adNameRaw] = decodedContent.split('|');
+  const adName = sanitizeName(adNameRaw || '');
   const payload = {
     orderId: finalOrderId,
     platform: 'telegram',
@@ -68,7 +85,7 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
       utm_source,
       utm_medium,
       utm_campaign: campaignName,
-      utm_content,
+      utm_content: adName,
       utm_term
     },
     commission: {
@@ -79,6 +96,12 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
     isTest: false
   };
   console.log('UTMify Payload:', JSON.stringify(payload, null, 2));
+  console.log('📊 UTM details:', {
+    campaignId,
+    campaignName,
+    adId,
+    adName
+  });
   try {
     const res = await axios.post(
       'https://api.utmify.com.br/api-credentials/orders',


### PR DESCRIPTION
## Summary
- sanitize and decode UTM parameters when sending events to UTMify
- split campaign and content values using the `ID|NAME` convention
- log parsed UTM details

## Testing
- `npm test` *(fails: DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_688222d971f8832a8097b6499d746fd2