### PR TITLE
Fix UTM persistence and redirects

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -66,7 +66,10 @@
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>
   <script src="utm-capture.js"></script>
+  <script src="fbclid-handler.js"></script>
   <script src="event-id.js"></script>
+  <script src="utmify-back-redirect.js"></script>
+  <script src="https://cdn.utmify.com.br/scripts/utms/latest.js" defer></script>
 </head>
 <body>
   <div class="overlay">

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -66,9 +66,11 @@
 
   <link rel="stylesheet" href="style.css" />
   <script src="config.js"></script>
-  <script src="fbclid-handler.js"></script>
   <script src="utm-capture.js"></script>
+  <script src="fbclid-handler.js"></script>
   <script src="event-id.js"></script>
+  <script src="utmify-back-redirect.js"></script>
+  <script src="https://cdn.utmify.com.br/scripts/utms/latest.js" defer></script>
 </head>
 <body>
   <div class="overlay">

--- a/MODELO1/WEB/obrigado.html
+++ b/MODELO1/WEB/obrigado.html
@@ -79,8 +79,11 @@
       margin-top: 15px;
     }
   </style>
+  <script src="utm-capture.js"></script>
   <script src="fbclid-handler.js"></script>
   <script src="event-id.js"></script>
+  <script src="utmify-back-redirect.js"></script>
+  <script src="https://cdn.utmify.com.br/scripts/utms/latest.js" defer></script>
 </head>
 <body>
   <div class="box">
@@ -379,7 +382,7 @@
       document.getElementById('erro-mensagem').textContent = mensagem;
       
       setTimeout(() => {
-        window.location.href = 'boasvindas.html';
+        window.location.href = 'boasvindas.html' + window.location.search;
       }, 4000);
     }
 
@@ -648,7 +651,7 @@
         } else {
           console.log('❌ Token inválido ou já utilizado');
           setTimeout(() => {
-            window.location.href = '/erro.html';
+            window.location.href = '/erro.html' + window.location.search;
           }, 10);
         }
       } catch (error) {

--- a/MODELO1/WEB/utmify-back-redirect.js
+++ b/MODELO1/WEB/utmify-back-redirect.js
@@ -1,0 +1,19 @@
+(function() {
+  const utmKeys = ['utm_source','utm_medium','utm_campaign','utm_term','utm_content'];
+  const params = new URLSearchParams(window.location.search);
+  utmKeys.forEach(k => {
+    const val = params.get(k) || localStorage.getItem(k);
+    if (val) {
+      localStorage.setItem(k, val);
+    }
+  });
+  const query = utmKeys.map(k => {
+    const v = localStorage.getItem(k);
+    return v ? `${k}=${encodeURIComponent(v)}` : null;
+  }).filter(Boolean).join('&');
+  const redirectUrl = `${window.location.pathname}${query ? '?' + query : ''}`;
+  window.history.pushState({}, '', window.location.href);
+  window.addEventListener('popstate', function() {
+    window.location.replace(redirectUrl);
+  });
+})();

--- a/routes/links.js
+++ b/routes/links.js
@@ -9,12 +9,16 @@ const router = express.Router();
 // Rota: /seusonho
 // Redireciona para: https://entry.ohvips.xyz/?utm_source=instagram&utm_medium=bio&utm_campaign=bio-instagram
 router.get('/seusonho', (req, res) => {
-  const targetUrl = 'https://entry.ohvips.xyz/?utm_source=instagram&utm_medium=bio&utm_campaign=bio-instagram';
-  
-  // Log do redirecionamento para analytics (opcional)
+  const params = new URLSearchParams(req.query);
+  if (!params.has('utm_source')) {
+    params.set('utm_source', 'instagram');
+    params.set('utm_medium', 'bio');
+    params.set('utm_campaign', 'bio-instagram');
+  }
+  const targetUrl = `https://entry.ohvips.xyz/?${params.toString()}`;
+
   console.log(`🔗 Redirecionamento /seusonho -> ${targetUrl} | IP: ${req.ip} | User-Agent: ${req.get('User-Agent')}`);
-  
-  // Redirecionamento 301 (permanente) para SEO
+
   res.redirect(301, targetUrl);
 });
 
@@ -22,5 +26,4 @@ router.get('/seusonho', (req, res) => {
 // router.get('/outro-link', (req, res) => {
 //   res.redirect(301, 'https://exemplo.com');
 // });
-
 module.exports = router;


### PR DESCRIPTION
## Summary
- load UTM capture before fbclid handler and include UTMify SDK
- add missing scripts to boas vindas and obrigado pages
- ensure error redirects preserve tracking parameters
- add back button redirect helper
- keep UTMs on `/seusonho` redirect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888e2f0b59c832a8a20ceb675710402