### PR TITLE
Fix UTM field parsing for UTMify

### DIFF
--- a/services/utmify.js
+++ b/services/utmify.js
@@ -49,21 +49,21 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
   } = trackingData;
 
   const decodedCampaign = decodeURIComponent(utm_campaign || '');
-  const [campaignIdRaw, campaignNameRaw] = decodedCampaign.split('|');
-  const campaignId = campaignIdRaw || null;
+  const [campaignNameRaw, campaignIdRaw] = decodedCampaign.split('|');
   const campaignName = sanitizeName(campaignNameRaw || '');
+  const campaignId = campaignIdRaw || null;
 
   const decodedContent = decodeURIComponent(utm_content || '');
-  const [adIdRaw, adNameRaw] = decodedContent.split('|');
-  const adId = adIdRaw || null;
+  const [adNameRaw, adIdRaw] = decodedContent.split('|');
   const adName = sanitizeName(adNameRaw || '');
+  const adId = adIdRaw || null;
 
   if (!campaignId || !adId) {
     console.warn('UTM parsing issue:', { campaignId, adId, utm_campaign, utm_content });
   }
   const payload = {
     orderId: finalOrderId,
-    platform: 'telegram',
+    platform: 'pushinpay',
     paymentMethod: 'pix',
     status: 'paid',
     createdAt,


### PR DESCRIPTION
## Summary
- parse campaign and ad fields as `name|id`
- update payload platform to `pushinpay`

## Testing
- `NODE_ENV=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888ee5bf788832abe0e2d482747a127