### PR TITLE
Implement hashed external_id for Facebook Purchase events

### DIFF
--- a/server.js
+++ b/server.js
@@ -309,6 +309,7 @@ app.post('/api/verificar-token', async (req, res) => {
             fbc: dadosToken.fbc,
             client_ip_address: dadosToken.ip_criacao,
             client_user_agent: dadosToken.user_agent_criacao,
+            telegram_id: dadosToken.telegram_id,
             user_data_hash: userDataHash,
             source: 'capi',
             client_timestamp: dadosToken.event_time, // 🔥 PASSAR TIMESTAMP DO CLIENTE PARA SINCRONIZAÇÃO
@@ -1028,6 +1029,7 @@ function iniciarCronFallback() {
           fbc: row.fbc,
           client_ip_address: row.ip_criacao,
           client_user_agent: row.user_agent_criacao,
+          telegram_id: row.telegram_id,
           user_data_hash: userDataHash,
           source: 'cron',
           token: row.token,


### PR DESCRIPTION
## Summary
- create `generateExternalId` helper in Facebook service
- hash telegram_id, fbp and ip for `external_id`
- include telegram_id when sending Purchase via CAPI and cron

## Testing
- `npm test` *(fails: DATABASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68890c5654a4832a9e9da6ea11065ced