### PR TITLE
fix(bot1-prices): atualizar plano fixo 1 Semana de 9,90 para 15,90

### DIFF
--- a/IMPLEMENTACAO_NOME_OFERTA_DINAMICO.md
+++ b/IMPLEMENTACAO_NOME_OFERTA_DINAMICO.md
@@ -81,7 +81,7 @@ Baseado nas configurações dos bots:
 
 ### Bot1 (config1.js)
 - `Vitalício` (R$19,90)
-- `1 Semana` (R$9,90)
+- `1 Semana` (R$15,90)
 - Downsells: `Vitalício` com diferentes preços (R$18,90, R$17,90, R$15,90)
 
 ### Bot2 (config2.js)

--- a/MODELO1/BOT/config1.js
+++ b/MODELO1/BOT/config1.js
@@ -26,7 +26,7 @@ ou volta pro Insta fingindo que não queria me ver... mas vai continuar pensando
 👇🏻👇🏻👇🏻`,
       opcoes: [
         { texto: '🔓 Acesso Vitalício – R$19,90', callback: 'plano_vitalicio' },
-        { texto: '💥 1 Semana – R$9,90', callback: 'plano_espiar' }
+        { texto: '💥 1 Semana – R$15,90', callback: 'plano_espiar' }
       ]
     }
   },

--- a/server.js
+++ b/server.js
@@ -2185,7 +2185,7 @@ const server = app.listen(PORT, '0.0.0.0', async () => {
   await inicializarModulos();
   
       console.log('Servidor pronto!');
-  console.log('Valor do plano 1 semana atualizado para R$ 9,90 com sucesso.');
+  console.log('Valor do plano 1 semana atualizado para R$ 15,90 com sucesso.');
 });
 
 // Graceful shutdown


### PR DESCRIPTION
## Summary
- corrigir botão do plano 1 Semana do Bot1 para exibir R$15,90
- ajustar mensagem de inicialização do servidor para refletir novo valor
- atualizar documentação de oferta dinâmica com novo preço do plano

## Testing
- `npm test` *(falhou: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_6891606fc018832ab49bd057d8f96be7