### PR TITLE
fix: align plan price with displayed value

### DIFF
--- a/MODELO1/BOT/config2.js
+++ b/MODELO1/BOT/config2.js
@@ -1,5 +1,9 @@
 const base = require('./config.default');
 
+// 💰 Valores oficiais dos planos
+const valorVitalicio = 24.90;
+const valorAcesso = 20.90;
+
 module.exports = {
   ...base,
   inicio: {
@@ -10,7 +14,7 @@ Você já me viu se tocando, rebolando, gemendo só pra você.
 Mas agora chegou a parte que quase ninguém vê…
 Meus vídeos acompanhada.
 
-  Por apenas R$24,90 (vitalício):
+  Por apenas R$${valorVitalicio.toFixed(2)} (vitalício):
 
 💋 Cenas com homem, com mulher… e às vezes com os dois
 
@@ -28,21 +32,21 @@ Você já viu meu corpo... Agora vai ver o que fazem com ele.
 
 Mas atenção: essa chance aparece uma única vez
 Perdeu, perdeu.`,
-     menuInicial: {
-  texto: `Você já me viu sozinha…
+    menuInicial: {
+      texto: `Você já me viu sozinha…
 Agora pode me ver de um jeito que poucos viram.
 Acompanhada. Entregue. E com uma surpresa só sua. 😌
 
 👇 Quero ver agora, sem censura 👇`,
-        opcoes: [
-          { texto: '💎 Acesso Vitalício + Punheta Guiada – R$24,90', callback: 'vitalicio' },
-          { texto: '🔓 Acesso Vitalício – R$20,90', callback: 'semanal' }
-        ]
+      opcoes: [
+        { texto: `💎 Acesso Vitalício + Punheta Guiada – R$${valorVitalicio.toFixed(2)}`, callback: 'vitalicio' },
+        { texto: `🔓 Acesso Vitalício – R$${valorAcesso.toFixed(2)}`, callback: 'semanal' }
+      ]
     }
   },
   planos: [
-    { id: 'vitalicio', nome: 'Acesso Vitalício + Punheta Guiada', valor: 29.90, emoji: '💎' },
-    { id: 'semanal', nome: 'Acesso Vitalício', valor: 25.90, emoji: '🔓' }
+    { id: 'vitalicio', nome: 'Acesso Vitalício + Punheta Guiada', valor: valorVitalicio, emoji: '💎' },
+    { id: 'semanal', nome: 'Acesso Vitalício', valor: valorAcesso, emoji: '🔓' }
   ],
   midias: {
     inicial: { video: './midia/inicial2.mp4' }


### PR DESCRIPTION
## Summary
- ensure bot2 plan values match buttons and PIX charges
- remove R$5 discrepancy by sharing constants for display and backend

## Testing
- `NODE_ENV=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_689405a5b318832ab02da853aba1b5f7