### PR TITLE
Revert Bot1 1-week plan price to R$9,90

### DIFF
--- a/MODELO1/BOT/config1.js
+++ b/MODELO1/BOT/config1.js
@@ -26,14 +26,14 @@ ou volta pro Insta fingindo que não queria me ver... mas vai continuar pensando
 👇🏻👇🏻👇🏻`,
       opcoes: [
         { texto: '🔓 Acesso Vitalício – R$19,90', callback: 'plano_vitalicio' },
-        { texto: '💥 1 Semana – R$15,90', callback: 'plano_espiar' }
+        { texto: '💥 1 Semana – R$9,90', callback: 'plano_espiar' }
       ]
     }
   },
 
   planos: [
     { id: 'plano_vitalicio', nome: 'Vitalício', valor: 19.90 },
-    { id: 'plano_espiar', nome: '1 Semana', valor: 15.90 }
+    { id: 'plano_espiar', nome: '1 Semana', valor: 9.90 }
   ],
 
   downsells: [
@@ -65,8 +65,8 @@ ou volta pro Insta fingindo que não queria me ver... mas vai continuar pensando
           id: `ds${i+1}_uma_semana`,
           nome: '1 Semana',
           emoji: '💥',
-          valorOriginal: 15.90,
-          valorComDesconto: 15.90
+          valorOriginal: 9.90,
+          valorComDesconto: 9.90
         }
       ]
     }))

--- a/MODELO1/WEB/viewcontent-capi-example.js
+++ b/MODELO1/WEB/viewcontent-capi-example.js
@@ -24,7 +24,7 @@ async function sendViewContentCAPI(options = {}) {
       fbp: fbpCookie,
       fbc: fbcCookie,
       content_type: options.content_type || 'product',
-      value: options.value || parseFloat((Math.random() * (19.90 - 15.90) + 15.90).toFixed(2)),
+      value: options.value || parseFloat((Math.random() * (19.90 - 9.90) + 9.90).toFixed(2)),
       currency: options.currency || 'BRL'
     };
 
@@ -64,7 +64,7 @@ async function sendViewContentCAPI(options = {}) {
 function sendViewContentPixel(eventId, options = {}) {
   try {
     const viewContentData = {
-      value: options.value || parseFloat((Math.random() * (19.90 - 15.90) + 15.90).toFixed(2)),
+      value: options.value || parseFloat((Math.random() * (19.90 - 9.90) + 9.90).toFixed(2)),
       currency: options.currency || 'BRL',
       content_name: options.content_name || document.title,
       content_category: options.content_category || 'Website',
@@ -130,7 +130,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   await sendViewContentComplete({
     content_name: 'Página Principal',
     content_category: 'Landing Page',
-    value: 15.90
+    value: 9.90
   });
 });
 

--- a/MODELO1/WEB/viewcontent-integration-example.html
+++ b/MODELO1/WEB/viewcontent-integration-example.html
@@ -177,7 +177,7 @@
         content_name: 'Página Principal',
         content_category: 'Landing Page',
         content_type: 'website',
-        value: 15.90
+        value: 9.90
       });
     });
 

--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1161,8 +1161,8 @@ async _executarGerarCobranca(req, res) {
         this.addToCartCache.set(chatId, true);
         
         try {
-                  // Gerar valor aleatório entre 15.90 e 19.90 com máximo 2 casas decimais
-        const randomValue = (Math.random() * (19.90 - 15.90) + 15.90).toFixed(2);
+                  // Gerar valor aleatório entre 9.90 e 19.90 com máximo 2 casas decimais
+        const randomValue = (Math.random() * (19.90 - 9.90) + 9.90).toFixed(2);
           
           // Buscar dados de tracking do usuário
           let trackingData = this.getTrackingData(chatId) || await this.buscarTrackingData(chatId);

--- a/server.js
+++ b/server.js
@@ -2185,7 +2185,7 @@ const server = app.listen(PORT, '0.0.0.0', async () => {
   await inicializarModulos();
   
       console.log('Servidor pronto!');
-  console.log('Valor do plano 1 semana atualizado para R$ 15,90 com sucesso.');
+  console.log('Valor do plano 1 semana atualizado para R$ 9,90 com sucesso.');
 });
 
 // Graceful shutdown


### PR DESCRIPTION
## Summary
- revert Bot1's 1 Semana plan to R$9,90 across menu, plan values, and downsell pricing
- align AddToCart event and ViewContent templates with the 9,90 starting price
- update server startup log to reflect the restored price

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_689543e9ee7c832a919c356a8370a48e