### PR TITLE
chore: validate DB_EXPECTED_ENV only when set

### DIFF
--- a/ENV_EXAMPLE.md
+++ b/ENV_EXAMPLE.md
@@ -35,7 +35,7 @@ LOG_ASYNC_ENABLED=true
 ```ini
 APP_ENV=production
 DATABASE_URL=postgresql://user:pass@host:5432/dbname
-DB_EXPECTED_ENV=prod
+# DB_EXPECTED_ENV=prod # opcional: se informado, valida se DATABASE_URL contém esse valor
 DB_SSL=true
 DB_POOL_MIN=2
 DB_POOL_MAX=10

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -31,7 +31,7 @@ if (env.APP_ENV === 'production') {
   }
 }
 
-if (env.DB_EXPECTED_ENV && !lowerUrl.includes(env.DB_EXPECTED_ENV.toLowerCase())) {
+if (env.DB_EXPECTED_ENV && env.DB_EXPECTED_ENV.trim() !== '' && !env.DATABASE_URL.includes(env.DB_EXPECTED_ENV)) {
   throw new Error(`DATABASE_URL does not contain expected environment marker '${env.DB_EXPECTED_ENV}'`);
 }
 


### PR DESCRIPTION
## Summary
- only check `DB_EXPECTED_ENV` when variable exists and is not empty
- document `DB_EXPECTED_ENV` as optional in environment example

## Testing
- `npm test` *(fails: "APP_ENV is required" etc. due to missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6897d7de4f5c832a8ea031113fdd1888