### PR TITLE
feat(config): optional DB_EXPECTED_ENV check

### DIFF
--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -31,7 +31,11 @@ if (env.APP_ENV === 'production') {
   }
 }
 
-if (env.DB_EXPECTED_ENV && env.DB_EXPECTED_ENV.trim() !== '' && !env.DATABASE_URL.includes(env.DB_EXPECTED_ENV)) {
+if (
+  env.DB_EXPECTED_ENV &&
+  env.DB_EXPECTED_ENV.trim() !== '' &&
+  !lowerUrl.includes(env.DB_EXPECTED_ENV.toLowerCase())
+) {
   throw new Error(`DATABASE_URL does not contain expected environment marker '${env.DB_EXPECTED_ENV}'`);
 }
 


### PR DESCRIPTION
## Summary
- ensure DB_EXPECTED_ENV validation only runs when non-empty and match case-insensitively

## Testing
- `APP_ENV=development DATABASE_URL=postgres://user:pass@localhost:5432/db DB_SSL=false DB_POOL_MIN=0 DB_POOL_MAX=1 DB_CONN_TIMEOUT_MS=1000 npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897d9479280832a8305a97ddf1f05d6