### PR TITLE
fix db log bootstrap path and guard rails

### DIFF
--- a/db-log.test.js
+++ b/db-log.test.js
@@ -1,0 +1,32 @@
+jest.setTimeout(30000);
+
+describe('db-log destination', () => {
+  const loggerPath = require.resolve('./src/infra/logger');
+  const bootstrapPath = require.resolve('./bootstrap');
+
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  test('silently ignores missing bootstrap', async () => {
+    const logger = { error: jest.fn() };
+    jest.doMock(loggerPath, () => logger);
+    jest.doMock(bootstrapPath, () => { throw new Error('MODULE_NOT_FOUND'); });
+    const dbLog = require('./src/infra/destinations/db-log');
+    await expect(dbLog({ foo: 'bar' })).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  test('inserts payload when pool available', async () => {
+    const mockQuery = jest.fn().mockResolvedValue({});
+    const mockPool = { query: mockQuery };
+    const logger = { error: jest.fn() };
+    jest.doMock(loggerPath, () => logger);
+    jest.doMock(bootstrapPath, () => ({ getDatabasePool: () => mockPool }));
+    const dbLog = require('./src/infra/destinations/db-log');
+    const payload = { hello: 'world' };
+    await expect(dbLog(payload)).resolves.toBeUndefined();
+    expect(mockQuery).toHaveBeenCalledWith('INSERT INTO logs(data) VALUES ($1)', [JSON.stringify(payload)]);
+  });
+});

--- a/src/infra/destinations/db-log.js
+++ b/src/infra/destinations/db-log.js
@@ -1,11 +1,19 @@
 const logger = require('../logger');
 
 module.exports = async function dbLog(payload) {
+  let getDatabasePool;
   try {
-    const { getDatabasePool } = require('../../bootstrap');
-    if (typeof getDatabasePool !== 'function') return;
-    const pool = getDatabasePool();
-    if (!pool) return;
+    ({ getDatabasePool } = require('../../../bootstrap'));
+  } catch (err) {
+    logger.error({ err }, 'db log bootstrap require error');
+    return;
+  }
+
+  if (typeof getDatabasePool !== 'function') return;
+  const pool = getDatabasePool();
+  if (!pool) return;
+
+  try {
     await pool.query('INSERT INTO logs(data) VALUES ($1)', [JSON.stringify(payload)]);
   } catch (err) {
     logger.error({ err }, 'db log error');


### PR DESCRIPTION
## Summary
- fix db log to require bootstrap three levels up and add guardrails
- add tests ensuring dbLog handles missing bootstrap and inserts with pool

## Testing
- `APP_ENV=development DATABASE_URL=postgres://localhost/postgres DB_SSL=false DB_POOL_MIN=0 DB_POOL_MAX=1 DB_CONN_TIMEOUT_MS=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897dc07cc50832a9acd54831b690534