### PR TITLE
feat(db-log): store level and message columns

### DIFF
--- a/src/infra/destinations/db-log.js
+++ b/src/infra/destinations/db-log.js
@@ -14,7 +14,14 @@ module.exports = async function dbLog(payload) {
   if (!pool) return;
 
   try {
-    await pool.query('INSERT INTO logs(data) VALUES ($1)', [JSON.stringify(payload)]);
+    const lvl = payload && typeof payload.level === 'string' ? payload.level : 'INFO';
+    const msg =
+      payload && typeof payload.message === 'string' ? payload.message : 'no message';
+
+    await pool.query(
+      'INSERT INTO logs(level, message, data) VALUES ($1, $2, $3)',
+      [lvl, msg, JSON.stringify(payload)]
+    );
   } catch (err) {
     logger.error({ err }, 'db log error');
     throw err;


### PR DESCRIPTION
## Summary
- extract `level` and `message` from payload and insert into `logs` table
- default to INFO and 'no message' when fields absent
- test database logging with and without explicit level and message

## Testing
- `APP_ENV=development DATABASE_URL=postgres://user:pass@localhost:5432/db DB_SSL=false DB_POOL_MIN=0 DB_POOL_MAX=1 DB_CONN_TIMEOUT_MS=1000 npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897e00d4990832a972b17f36f91d5e8