### PR TITLE
Serve static panel route

### DIFF
--- a/server.js
+++ b/server.js
@@ -1747,6 +1747,14 @@ app.get('/api/eventos', async (req, res) => {
   }
 });
 
+// ====== Painel estático (/panel) ======
+const webDir = path.join(__dirname, 'MODELO1', 'WEB');
+app.use('/panel', express.static(webDir, {
+  index: false,
+  setHeaders: (res) => { res.setHeader('Cache-Control','no-store'); }
+}));
+app.get('/panel', (req, res) => res.redirect(301, '/panel/funnel-dashboard.html'));
+
 // Middleware para rotas não encontradas
 app.use((req, res, next) => {
   if (req.path.startsWith('/api/')) {


### PR DESCRIPTION
## Summary
- expose MODELO1/WEB as static panel under `/panel`
- redirect `/panel` to funnel dashboard

## Testing
- `DATABASE_URL=postgres://user:pass@localhost:5432/db npm test`
- `DATABASE_URL=postgres://user:pass@localhost:5432/db npm start`

------
https://chatgpt.com/codex/tasks/task_e_68990542912c832aba09793b5c472b8a