### PR TITLE
Prioritize payloadId for CTA click event ID

### DIFF
--- a/routes/track.js
+++ b/routes/track.js
@@ -97,7 +97,7 @@ router.post('/track/cta_click', async (req, res) => {
     const utm_content = utmsFromBody.utm_content ?? utmsFromReferer.utm_content ?? null;
     const utm_term = utmsFromBody.utm_term ?? utmsFromReferer.utm_term ?? null;
 
-    const eventId = sessionId ? `cta:${sessionId}` : `cta:${uuid()}`;
+    const eventId = payloadId ? `cta:${payloadId}` : (sessionId ? `cta:${sessionId}` : `cta:${uuid()}`);
 
     const pool = db.createPool();
     const result = await db.insertFunnelEvent(pool, {


### PR DESCRIPTION
## Summary
- Use payloadId to build CTA click event ID when available, falling back to sessionId or UUID

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_689917cf6610832ab16ded84ca7c7603