### PR TITLE
Ensure database sanity before starting tracking and bots

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -49,7 +49,7 @@ class TelegramBotService {
     let grupo = 'G1';
     if (this.token === process.env.TELEGRAM_TOKEN_BOT2) grupo = 'G2';
     this.grupo = grupo;
-    this.pgPool = this.postgres ? this.postgres.createPool() : null;
+    this.pgPool = this.postgres ? this.postgres.getPool() : null;
     if (this.pgPool) {
       this.postgres.limparDownsellsAntigos(this.pgPool);
       setInterval(() => this.postgres.limparDownsellsAntigos(this.pgPool), 60 * 60 * 1000);
@@ -777,7 +777,7 @@ async _executarGerarCobranca(req, res) {
 
     // 🔗 Funil: pix_created
     try {
-      const pool = this.postgres && this.postgres.createPool ? this.postgres.createPool() : null;
+      const pool = this.pgPool;
       if (pool) {
         const eventId = `pix:${normalizedId}`;
         const meta = {
@@ -938,7 +938,7 @@ async _executarGerarCobranca(req, res) {
       
       // 🔗 Funil: purchase (pagamento confirmado)
       try {
-        const pool = this.postgres && this.postgres.createPool ? this.postgres.createPool() : null;
+        const pool = this.pgPool;
         if (pool) {
           let utmRow = null;
           try {
@@ -1275,7 +1275,7 @@ async _executarGerarCobranca(req, res) {
       
       // 🔗 Funil: bot_start no início do /start
       try {
-        const pool = this.postgres && this.postgres.createPool ? this.postgres.createPool() : null;
+        const pool = this.pgPool;
         if (pool) {
           let track = this.getTrackingData(chatId) || await this.buscarTrackingData(chatId);
           track = track || {};

--- a/db/sanity/funnelEventsSanity.js
+++ b/db/sanity/funnelEventsSanity.js
@@ -1,0 +1,111 @@
+const columnsSql = `
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema='public' AND table_name='funnel_events'
+ORDER BY ordinal_position;`;
+
+const indexesSql = `
+SELECT i.relname AS index_name, ix.indisunique, ix.indisvalid, ix.indisready,
+       pg_get_indexdef(ix.indexrelid) AS index_def
+FROM pg_index ix
+JOIN pg_class t ON t.oid = ix.indrelid
+JOIN pg_class i ON i.oid = ix.indexrelid
+JOIN pg_namespace n ON n.oid = t.relnamespace
+WHERE n.nspname='public' AND t.relname='funnel_events'
+ORDER BY i.relname;`;
+
+const triggersSql = `
+SELECT t.tgname, p.oid AS proc_oid, p.proname, pg_get_triggerdef(t.oid) AS trigger_def
+FROM pg_trigger t
+JOIN pg_proc p ON p.oid = t.tgfoid
+WHERE t.tgrelid='public.funnel_events'::regclass AND NOT t.tgisinternal
+ORDER BY t.tgname;`;
+
+async function loadFunctionSrc(client, oid) {
+  const { rows } = await client.query('SELECT pg_get_functiondef($1::oid) AS src', [oid]);
+  return rows[0] ? rows[0].src : '';
+}
+
+function analyzeTriggers(triggers, colMap, client) {
+  return Promise.all(triggers.map(async trig => {
+    const src = await loadFunctionSrc(client, trig.proc_oid);
+    const lines = src.split('\n').slice(0, 3);
+    const newRefs = Array.from(src.matchAll(/NEW\.([a-zA-Z0-9_]+)/g)).map(m => m[1]);
+    const missing = newRefs.filter(c => !colMap[c]);
+    const suspicious = newRefs.includes('ip') || missing.length > 0;
+    return {
+      trigger_name: trig.tgname,
+      function_name: trig.proname,
+      oid: trig.proc_oid,
+      trigger_def: trig.trigger_def,
+      src_first_lines: lines,
+      suspicious,
+      missing_columns: missing
+    };
+  }));
+}
+
+async function ensureFunnelEventsReady(pool) {
+  const client = await pool.connect();
+  try {
+    // Columns
+    const { rows: columns } = await client.query(columnsSql);
+    const colMap = Object.fromEntries(columns.map(c => [c.column_name, c]));
+    const col = colMap.event_id;
+    if (!col || col.data_type !== 'text' || col.is_nullable !== 'NO') {
+      console.error('FATAL: coluna event_id inválida em public.funnel_events');
+      throw new Error('funnel_events.event_id inválido');
+    }
+    console.log('DB_SANITY: funnel_events.event_id OK');
+
+    // Indexes
+    let { rows: indexes } = await client.query(indexesSql);
+    let ux = indexes.find(i => i.index_name === 'ux_funnel_events_event_id');
+    if (!ux || !(ux.indisunique && ux.indisvalid && ux.indisready)) {
+      try {
+        await client.query('CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ux_funnel_events_event_id ON public.funnel_events(event_id)');
+      } catch (err) {
+        console.warn('⚠️ Falha ao criar índice CONCURRENTLY:', err.message);
+        await client.query('CREATE UNIQUE INDEX IF NOT EXISTS ux_funnel_events_event_id ON public.funnel_events(event_id)');
+      }
+      ({ rows: indexes } = await client.query(indexesSql));
+      ux = indexes.find(i => i.index_name === 'ux_funnel_events_event_id');
+      if (!ux || !(ux.indisunique && ux.indisvalid && ux.indisready)) {
+        console.error('FATAL: índice único ux_funnel_events_event_id inválido');
+        throw new Error('ux_funnel_events_event_id inválido');
+      }
+    }
+    console.log(`DB_SANITY: ux_funnel_events_event_id { indisunique:${ux.indisunique}, indisvalid:${ux.indisvalid}, indisready:${ux.indisready} }`);
+
+    // Triggers
+    const { rows: trigRows } = await client.query(triggersSql);
+    const triggers = await analyzeTriggers(trigRows, colMap, client);
+    const bad = triggers.find(t => t.suspicious);
+    if (bad) {
+      console.error(`FATAL: trigger suspeito ${bad.trigger_name} (${bad.function_name}) oid ${bad.oid}\n${bad.src_first_lines.join('\n')}\nSugerido: DROP TRIGGER ${bad.trigger_name} ON public.funnel_events; DROP FUNCTION ${bad.function_name}();`);
+      throw new Error('trigger inválido detectado');
+    }
+
+    return { columns, indexes, triggers, ok: true };
+  } finally {
+    client.release();
+  }
+}
+
+async function inspectFunnelEvents(pool) {
+  const client = await pool.connect();
+  try {
+    const { rows: columns } = await client.query(columnsSql);
+    const colMap = Object.fromEntries(columns.map(c => [c.column_name, c]));
+    const { rows: indexes } = await client.query(indexesSql);
+    const { rows: trigRows } = await client.query(triggersSql);
+    const triggers = await analyzeTriggers(trigRows, colMap, client);
+    const ux = indexes.find(i => i.index_name === 'ux_funnel_events_event_id');
+    const ok = colMap.event_id && colMap.event_id.data_type === 'text' && colMap.event_id.is_nullable === 'NO' && ux && ux.indisunique && ux.indisvalid && ux.indisready && !triggers.some(t => t.suspicious);
+    return { columns, indexes, triggers, ok };
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = { ensureFunnelEventsReady, inspectFunnelEvents };

--- a/init-postgres.js
+++ b/init-postgres.js
@@ -1,7 +1,7 @@
-const { createPool } = require('./database/postgres');
+const { getPool } = require('./database/postgres');
 
 async function initPostgres() {
-  const pool = createPool();
+  const pool = getPool();
   await pool.query(`
     CREATE TABLE IF NOT EXISTS payload_tracking (
       payload_id TEXT PRIMARY KEY,

--- a/routes/track.js
+++ b/routes/track.js
@@ -2,6 +2,7 @@ const express = require('express');
 const uuid = require('crypto').randomUUID;
 const router = express.Router();
 const db = require('../database/postgres');
+const getPool = db.getPool;
 
 function parseUtmsFromQuery(search) {
   try {
@@ -53,7 +54,7 @@ router.post('/track/welcome', async (req, res) => {
 
     const eventId = sessionId ? `wel:${sessionId}` : `wel:${uuid()}`;
 
-    const pool = db.createPool();
+    const pool = getPool();
     const meta = { utm_source, utm_medium, utm_campaign, utm_term, utm_content };
     const result = await db.insertFunnelEvent(pool, {
       event_id: eventId,
@@ -97,7 +98,7 @@ router.post('/track/cta_click', async (req, res) => {
 
     const eventId = payloadId ? `cta:${payloadId}` : (sessionId ? `cta:${sessionId}` : `cta:${uuid()}`);
 
-    const pool = db.createPool();
+    const pool = getPool();
     const meta = { utm_source, utm_medium, utm_campaign, utm_term, utm_content };
     const result = await db.insertFunnelEvent(pool, {
       event_id: eventId,


### PR DESCRIPTION
## Summary
- add funnelEventsSanity to validate funnel_events schema and trigger anomalies
- defer bot launch and /track routes until database and migrations are ready
- provide /admin/db-check diagnostic endpoint
- reuse singleton Postgres pool in tracking routes and Telegram bot service

## Testing
- `npm test` *(fails: DATABASE_URL não definida)*

------
https://chatgpt.com/codex/tasks/task_e_68994ff2a68c832a9241f478c83dce97