### PR TITLE
feat: cria painel de visualização do funil de vendas

### DIFF
--- a/MODELO1/WEB/painel-funil.html
+++ b/MODELO1/WEB/painel-funil.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Painel de Funil - SiteHot</title>
+    <meta name="robots" content="noindex, nofollow">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #121212; color: #e0e0e0; margin: 0; padding: 20px; }
+        .container { max-width: 1600px; margin: auto; }
+        .header, .card { background-color: #1e1e1e; border-radius: 12px; padding: 20px; margin-bottom: 20px; box-shadow: 0 4px 8px rgba(0,0,0,0.3); }
+        h1, h2 { color: #ffffff; border-bottom: 2px solid #333; padding-bottom: 10px; margin-bottom: 20px; }
+        .filters { display: flex; flex-wrap: wrap; gap: 20px; align-items: flex-end; }
+        .filter-group { display: flex; flex-direction: column; }
+        label { margin-bottom: 8px; font-size: 14px; color: #aaa; }
+        input, select, button { background-color: #333; color: #e0e0e0; border: 1px solid #555; border-radius: 6px; padding: 10px; font-size: 14px; }
+        button { background-color: #007bff; cursor: pointer; transition: background-color 0.2s; }
+        button:hover { background-color: #0056b3; }
+        .metrics-grid, .rates-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; }
+        .metric-card, .rate-card { background-color: #2a2a2a; text-align: center; padding: 20px; border-radius: 8px; }
+        .metric-card .value { font-size: 2.5em; font-weight: bold; color: #4e9af1; }
+        .metric-card .label, .rate-card .label { margin-top: 10px; font-size: 1em; color: #bbb; }
+        .rate-card .value { font-size: 1.8em; font-weight: bold; color: #50c878; }
+        .rate-card .arrow { color: #555; margin: 0 10px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1><i class="fas fa-filter"></i> Painel de Funil</h1>
+        <div class="header">
+            <div class="filters">
+                <div class="filter-group">
+                    <label for="token">Token de Acesso</label>
+                    <input type="password" id="token-acesso" placeholder="••••••••">
+                </div>
+                <div class="filter-group">
+                    <label for="data-inicio">Data Início</label>
+                    <input type="date" id="data-inicio">
+                </div>
+                <div class="filter-group">
+                    <label for="data-fim">Data Fim</label>
+                    <input type="date" id="data-fim">
+                </div>
+                <div class="filter-group">
+                    <label for="agrupamento">Agrupamento</label>
+                    <select id="agrupamento">
+                        <option>Diário</option>
+                        <option>Horário</option>
+                    </select>
+                </div>
+                <button id="carregar-funil"><i class="fas fa-sync-alt"></i> Carregar Funil</button>
+            </div>
+        </div>
+
+        <div id="dashboard-content" style="display: none;">
+            <h2><i class="fas fa-users"></i> Resumo do Funil</h2>
+            <div class="card metrics-grid">
+                <div class="metric-card"><div id="welcome" class="value">0</div><div class="label">Welcome</div></div>
+                <div class="metric-card"><div id="cta-click" class="value">0</div><div class="label">CTA Click</div></div>
+                <div class="metric-card"><div id="bot-start" class="value">0</div><div class="label">Entraram no Bot</div></div>
+                <div class="metric-card"><div id="pix-generated" class="value">0</div><div class="label">PIX Gerado</div></div>
+                <div class="metric-card"><div id="purchase" class="value">0</div><div class="label">Compraram</div></div>
+            </div>
+
+            <h2><i class="fas fa-chart-line"></i> Taxas de Conversão</h2>
+            <div class="card rates-grid">
+                <div class="rate-card"><div class="label">Welcome <span class="arrow">&rarr;</span> Click</div><div id="rate-welcome-click" class="value">-</div></div>
+                <div class="rate-card"><div class="label">Click <span class="arrow">&rarr;</span> Bot</div><div id="rate-click-bot" class="value">-</div></div>
+                <div class="rate-card"><div class="label">Bot <span class="arrow">&rarr;</span> PIX</div><div id="rate-bot-pix" class="value">-</div></div>
+                <div class="rate-card"><div class="label">PIX <span class="arrow">&rarr;</span> Compra</div><div id="rate-pix-compra" class="value">-</div></div>
+                <div class="rate-card"><div class="label">Welcome <span class="arrow">&rarr;</span> Compra</div><div id="rate-welcome-compra" class="value">-</div></div>
+            </div>
+
+            <h2><i class="fas fa-wave-square"></i> Gráfico de Funil</h2>
+            <div class="card">
+                <canvas id="funil-chart"></canvas>
+            </div>
+        </div>
+        <div id="loading" style="text-align: center; padding: 40px; display: none;">Carregando...</div>
+    </div>
+    <script src="painel-funil.js"></script>
+</body>
+</html>

--- a/MODELO1/WEB/painel-funil.js
+++ b/MODELO1/WEB/painel-funil.js
@@ -1,0 +1,111 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('carregar-funil');
+    const tokenInput = document.getElementById('token-acesso');
+    const inicioInput = document.getElementById('data-inicio');
+    const fimInput = document.getElementById('data-fim');
+    let chart = null;
+
+    // Define datas padrão (últimos 7 dias)
+    const hoje = new Date();
+    const seteDiasAtras = new Date();
+    seteDiasAtras.setDate(hoje.getDate() - 7);
+    inicioInput.value = seteDiasAtras.toISOString().split('T')[0];
+    fimInput.value = hoje.toISOString().split('T')[0];
+    tokenInput.value = localStorage.getItem('dashboard_token_funil') || '';
+
+    btn.addEventListener('click', carregarDados);
+
+    async function carregarDados() {
+        const token = tokenInput.value;
+        if (!token) { alert('Por favor, insira o token de acesso.'); return; }
+        localStorage.setItem('dashboard_token_funil', token);
+
+        document.getElementById('loading').style.display = 'block';
+        document.getElementById('dashboard-content').style.display = 'none';
+
+        const params = new URLSearchParams({
+            token: token,
+            inicio: inicioInput.value,
+            fim: fimInput.value,
+            agrupamento: document.getElementById('agrupamento').value
+        });
+
+        try {
+            const response = await fetch(`/api/funnel/data?${params}`);
+            if (!response.ok) throw new Error(`Erro ${response.status}: ${await response.text()}`);
+            
+            const data = await response.json();
+            
+            atualizarContadores(data.counts);
+            atualizarTaxas(data.counts);
+            atualizarGrafico(data.series);
+
+            document.getElementById('loading').style.display = 'none';
+            document.getElementById('dashboard-content').style.display = 'block';
+        } catch (error) {
+            console.error('Erro ao carregar dados do funil:', error);
+            alert('Falha ao carregar dados: ' + error.message);
+            document.getElementById('loading').style.display = 'none';
+        }
+    }
+
+    function atualizarContadores(counts) {
+        document.getElementById('welcome').textContent = counts.welcome || 0;
+        document.getElementById('cta-click').textContent = counts.cta_click || 0;
+        document.getElementById('bot-start').textContent = counts.bot_start || 0;
+        document.getElementById('pix-generated').textContent = counts.pix_generated || 0;
+        document.getElementById('purchase').textContent = counts.purchase || 0;
+    }
+
+    function calcularTaxa(numerador, denominador) {
+        numerador = parseInt(numerador) || 0;
+        denominador = parseInt(denominador) || 0;
+        if (denominador === 0) return '0.00%';
+        return ((numerador / denominador) * 100).toFixed(2) + '%';
+    }
+
+    function atualizarTaxas(c) {
+        document.getElementById('rate-welcome-click').textContent = calcularTaxa(c.cta_click, c.welcome);
+        document.getElementById('rate-click-bot').textContent = calcularTaxa(c.bot_start, c.cta_click);
+        document.getElementById('rate-bot-pix').textContent = calcularTaxa(c.pix_generated, c.bot_start);
+        document.getElementById('rate-pix-compra').textContent = calcularTaxa(c.purchase, c.pix_generated);
+        document.getElementById('rate-welcome-compra').textContent = calcularTaxa(c.purchase, c.welcome);
+    }
+    
+    function atualizarGrafico(series) {
+        const ctx = document.getElementById('funil-chart').getContext('2d');
+        if (chart) chart.destroy();
+
+        const labels = [...new Set(series.map(item => item.time_bucket.split('T')[0]))].sort();
+        
+        const datasets = {
+            welcome: { label: 'Welcome', data: [], borderColor: '#4e9af1', tension: 0.1 },
+            cta_click: { label: 'CTA Click', data: [], borderColor: '#f1c40f', tension: 0.1 },
+            bot_start: { label: 'Entraram no Bot', data: [], borderColor: '#e67e22', tension: 0.1 },
+            pix_generated: { label: 'PIX Gerado', data: [], borderColor: '#e74c3c', tension: 0.1 },
+            purchase: { label: 'Compraram', data: [], borderColor: '#2ecc71', tension: 0.1 }
+        };
+
+        labels.forEach(label => {
+            for (const key in datasets) {
+                const item = series.find(s => s.time_bucket.startsWith(label) && s.event_name === key);
+                datasets[key].data.push(item ? parseInt(item.count) : 0);
+            }
+        });
+
+        chart = new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: Object.values(datasets)
+            },
+            options: {
+                scales: {
+                    x: { ticks: { color: '#e0e0e0' }, grid: { color: '#444' } },
+                    y: { beginAtZero: true, ticks: { color: '#e0e0e0' }, grid: { color: '#444' } }
+                },
+                plugins: { legend: { labels: { color: '#e0e0e0' } } }
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Summary
- adiciona pagina de painel com filtros e gráficos para visualizar o funil de vendas
- implementa script para carregar dados do funil e montar métricas e gráfico

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*


------
https://chatgpt.com/codex/tasks/task_e_689a52cd66c0832a94e9950731d42962