### PR TITLE
fix: Adiciona event_id obrigatório para eventos do funil

### DIFF
--- a/MODELO1/WEB/funnel-tracking.js
+++ b/MODELO1/WEB/funnel-tracking.js
@@ -1,6 +1,13 @@
 (function() {
     'use strict';
 
+    function generateUUID() {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+            var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+            return v.toString(16);
+        });
+    }
+
     // 1. Gera ou recupera um ID de sessão único para este visitante
     let sessionId = sessionStorage.getItem('funnel_session_id');
     if (!sessionId) {
@@ -13,6 +20,7 @@
         const payload = {
             session_id: sessionId,
             event_name: eventName,
+            event_id: generateUUID(),
             ...eventData
         };
 

--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1281,6 +1281,7 @@ async _executarGerarCobranca(req, res) {
         axios.post(`${this.baseUrl}/api/funnel/track`, {
           session_id: sessionId,
           event_name: 'bot_start',
+          event_id: uuidv4(),
           bot: this.botId,
           telegram_id: String(chatId) // Envia o telegram_id junto
         }).catch(e => console.error('Falha ao rastrear bot_start:', e.message));


### PR DESCRIPTION
## Summary
- garante envio de `event_id` em todos os eventos do funil no frontend
- inclui `event_id` ao rastrear `bot_start` no serviço de Telegram

## Testing
- `npm test` *(falhou: DATABASE_URL não definida)*

------
https://chatgpt.com/codex/tasks/task_e_689a56bf3d6c832a9220528bbd4e61da