### PR TITLE
fix: adiciona coluna funnel_session_id à tabela tokens do sqlite

### DIFF
--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -125,6 +125,9 @@ function initialize(path = './pagamentos.db') {
     if (!checkCol('external_id_hash')) {
       database.prepare('ALTER TABLE tokens ADD COLUMN external_id_hash TEXT').run();
     }
+    if (!checkCol('funnel_session_id')) {
+      database.prepare('ALTER TABLE tokens ADD COLUMN funnel_session_id TEXT').run();
+    }
     if (!checkPayloadCol('telegram_id')) {
       database.prepare('ALTER TABLE payload_tracking ADD COLUMN telegram_id TEXT').run();
     }


### PR DESCRIPTION
## Summary
- ensure SQLite tokens table contains `funnel_session_id`

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_689a6af6f9a8832aa8775d047914e103