### PR TITLE
feat: include funnel session id in test panel charges

### DIFF
--- a/MODELO1/WEB/painel-funil.js
+++ b/MODELO1/WEB/painel-funil.js
@@ -109,3 +109,34 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 });
+
+// Função auxiliar utilizada no painel de testes para gerar uma cobrança
+// e associá-la a uma sessão única do funil. Essa função deve ser chamada
+// a partir dos botões da tabela de testes, enviando também os parâmetros
+// necessários para criar a cobrança.
+async function gerarCobranca(button, telegram_id, plano, valor, trackingData) {
+    // Pega a referência à linha (<tr>) onde o botão foi clicado
+    const row = button.closest('tr');
+
+    // Cria um identificador único baseado no timestamp atual
+    const funnel_session_id = 'funil_session_' + Date.now();
+
+    // Salva o identificador na linha da tabela para rastreamento posterior
+    row.dataset.sessionId = funnel_session_id;
+
+    // Envia a requisição para gerar a cobrança incluindo o novo campo
+    return fetch('/api/gerar-cobranca', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            telegram_id,
+            plano,
+            valor,
+            trackingData,
+            funnel_session_id
+        })
+    });
+}
+
+// Expõe a função globalmente para ser utilizada diretamente no HTML
+window.gerarCobranca = gerarCobranca;


### PR DESCRIPTION
## Summary
- add helper to generate `funnel_session_id` for each test row
- include session id in `/api/gerar-cobranca` payload and store it on row

## Testing
- `NODE_ENV=development npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a735ef148832a9a40d5903b5bb6c0