### PR TITLE
Emit checkoutIniciado WebSocket event

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -792,6 +792,19 @@ async _executarGerarCobranca(req, res) {
         .catch(e => console.error('Falha ao rastrear pix_generated:', e.message));
     }
 
+    if (this.io && funnelSessionId) {
+      this.io.emit('checkoutIniciado', {
+        funnel_session_id: funnelSessionId,
+        transaction_id: normalizedId,
+        valor: valorCentavos,
+        telegram_id: telegram_id,
+        bot_id: this.botId
+      });
+      console.log(
+        `[WebSocket] Evento 'checkoutIniciado' emitido para a sessão: ${funnelSessionId}`
+      );
+    }
+
     const tokenData = {
       id_transacao: normalizedId,
       token: normalizedId,


### PR DESCRIPTION
## Summary
- Emit checkoutIniciado WebSocket event after successful PIX charge creation
- Include funnel session, transaction, value, user, and bot identifiers in event payload for real-time dashboard updates

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_689a799078d8832a828bc443652be9e5