### PR TITLE
feat: attach funnel session id to payload tracking

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -469,6 +469,23 @@
         eventID: generateEventID('ViewContent')
       };
       fbq('track', 'ViewContent', viewContentData);
+
+      // Recupera o ID da sessão atual do funil
+      const funnelSessionId = window.funnelTracker.getSessionId();
+      const telegramId = window.telegramId || null;
+      const trackingData = typeof window.getTrackingData === 'function'
+        ? window.getTrackingData()
+        : {};
+
+      fetch('/api/payload', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          chatId: telegramId,
+          trackingData,
+          funnel_session_id: funnelSessionId
+        })
+      });
     });
 
     // Aplica imagem de fundo


### PR DESCRIPTION
## Summary
- include funnel session id when posting payload from boasvindas.html
- persist funnel session id and chat association in `/api/payload`

## Testing
- `NODE_ENV=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a7cdaf994832a8eaeccff6abd2c3a