### PR TITLE
Include funnel session ID in payload tracking

### DIFF
--- a/server.js
+++ b/server.js
@@ -980,10 +980,15 @@ app.post('/api/payload', protegerContraFallbacks, async (req, res) => {
     const payloadId = crypto.randomBytes(4).toString('hex');
     const { chatId = null, trackingData, funnel_session_id } = req.body || {};
 
-    // Garante que trackingData seja um objeto e adiciona funnel_session_id
-    const finalTrackingData = trackingData || {};
+    // 1. Criamos um novo objeto 'finalTrackingData' para trabalhar de forma segura.
+    const finalTrackingData = { ...(trackingData || {}) };
+
+    // 2. Verificamos se o 'funnel_session_id' existe e o adicionamos ao nosso novo objeto.
     if (funnel_session_id) {
       finalTrackingData.funnel_session_id = funnel_session_id;
+      console.log(
+        `[PAYLOAD] funnel_session_id '${funnel_session_id}' adicionado ao tracking data.`
+      );
     }
 
     if (payloadManager && typeof payloadManager.savePayload === 'function') {


### PR DESCRIPTION
## Summary
- Safely merge `funnel_session_id` into payload tracking data and log its presence
- Store payloads with the enriched tracking information

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*


------
https://chatgpt.com/codex/tasks/task_e_689a8dd28a40832ab718891e62e1c0fe