### PR TITLE
feat: add funnel analytics table

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -192,6 +192,14 @@ async function createTables(pool) {
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
       `);
+
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS funnel_analytics (
+            event_name TEXT PRIMARY KEY,
+            event_count INTEGER NOT NULL DEFAULT 0
+        )
+      `);
+    console.log('✅ Tabela funnel_analytics verificada');
     // tabela payload_tracking movida para init-postgres
     } catch (err) {
       console.error('❌ Erro ao criar tabela tokens:', err.message);


### PR DESCRIPTION
## Summary
- create `funnel_analytics` table in Postgres initialization
- log confirmation when table is ensured

## Testing
- `DATABASE_URL=postgresql://localhost:5432/test npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a996448c4832a9104d562cf4f0281