### PR TITLE
Refactor funnel tracking client for simplified API

### DIFF
--- a/MODELO1/WEB/funnel-tracking.js
+++ b/MODELO1/WEB/funnel-tracking.js
@@ -1,36 +1,13 @@
 (function() {
     'use strict';
 
-    function generateUUID() {
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-            var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
-    }
-
-    // 1. Gera ou recupera um ID de sessão único para este visitante
-    let sessionId = sessionStorage.getItem('funnel_session_id');
-    if (!sessionId) {
-        sessionId = Date.now() + '-' + Math.random().toString(36).substring(2, 9);
-        sessionStorage.setItem('funnel_session_id', sessionId);
-    }
-
-    // 2. Função para enviar um evento para nosso endpoint de coleta
-    async function trackFunnelEvent(eventName, eventData = {}) {
-        const payload = {
-            session_id: sessionId,
-            event_name: eventName,
-            event_id: generateUUID(),
-            ...eventData
-        };
-
+    // Função simplificada para enviar apenas o nome do evento
+    async function trackFunnelEvent(eventName) {
         try {
-            // Usamos fetch com keepalive para garantir que a requisição seja enviada
-            // mesmo se o usuário navegar para outra página rapidamente.
             await fetch('/api/funnel/track', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
+                body: JSON.stringify({ event_name: eventName }),
                 keepalive: true
             });
         } catch (e) {
@@ -39,14 +16,11 @@
         }
     }
 
-    // 3. Expõe a função de rastreamento e a ID da sessão globalmente
-    window.funnelTracker = {
-        track: trackFunnelEvent,
-        getSessionId: () => sessionId
-    };
+    // Expõe a função de rastreamento globalmente
+    window.trackFunnelEvent = trackFunnelEvent;
+    window.funnelTracker = { track: trackFunnelEvent };
 
-    // 4. Rastreia o primeiro evento: a visita à página (welcome)
-    // Este evento é disparado assim que o script é carregado.
-    window.funnelTracker.track('welcome');
+    // Rastreia o primeiro evento: a visita à página (welcome)
+    trackFunnelEvent('welcome');
 
 })();


### PR DESCRIPTION
## Summary
- simplify funnel tracking to only send event name to `/api/funnel/track`
- expose `trackFunnelEvent` globally and alias via `funnelTracker`

## Testing
- `NODE_ENV=test npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a9d94835c832a8ca6eb4705099e03