### PR TITLE
feat: add funnel stats endpoint and simplify panel

### DIFF
--- a/MODELO1/WEB/painel-funil.js
+++ b/MODELO1/WEB/painel-funil.js
@@ -1,113 +1,47 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('carregar-funil');
-    const tokenInput = document.getElementById('token-acesso');
-    const inicioInput = document.getElementById('data-inicio');
-    const fimInput = document.getElementById('data-fim');
-    let chart = null;
+  async function carregarDados() {
+    try {
+      const response = await fetch('/api/funnel/stats');
+      if (!response.ok) {
+        throw new Error(`Erro ${response.status}: ${await response.text()}`);
+      }
+      const data = await response.json();
+      const counts = {
+        welcome: data.welcome || 0,
+        cta_click: data.cta_click || 0,
+        pix_generated: data.pix_generated || 0,
+        purchase: data.pix_paid || data.purchase || 0
+      };
 
-    // Define datas padrão (últimos 7 dias)
-    const hoje = new Date();
-    const seteDiasAtras = new Date();
-    seteDiasAtras.setDate(hoje.getDate() - 7);
-    inicioInput.value = seteDiasAtras.toISOString().split('T')[0];
-    fimInput.value = hoje.toISOString().split('T')[0];
-    tokenInput.value = localStorage.getItem('dashboard_token_funil') || '';
-
-    btn.addEventListener('click', carregarDados);
-
-    async function carregarDados() {
-        const token = tokenInput.value;
-        if (!token) { alert('Por favor, insira o token de acesso.'); return; }
-        localStorage.setItem('dashboard_token_funil', token);
-
-        document.getElementById('loading').style.display = 'block';
-        document.getElementById('dashboard-content').style.display = 'none';
-
-        const params = new URLSearchParams({
-            token: token,
-            inicio: inicioInput.value,
-            fim: fimInput.value,
-            agrupamento: document.getElementById('agrupamento').value
-        });
-
-        try {
-            const response = await fetch(`/api/funnel/data?${params}`);
-            if (!response.ok) throw new Error(`Erro ${response.status}: ${await response.text()}`);
-            
-            const data = await response.json();
-            
-            atualizarContadores(data.counts);
-            atualizarTaxas(data.counts);
-            atualizarGrafico(data.series);
-
-            document.getElementById('loading').style.display = 'none';
-            document.getElementById('dashboard-content').style.display = 'block';
-        } catch (error) {
-            console.error('Erro ao carregar dados do funil:', error);
-            alert('Falha ao carregar dados: ' + error.message);
-            document.getElementById('loading').style.display = 'none';
-        }
+      atualizarContadores(counts);
+      atualizarTaxas(counts);
+    } catch (error) {
+      console.error('Erro ao carregar dados do funil:', error);
     }
+  }
 
-    function atualizarContadores(counts) {
-        document.getElementById('welcome').textContent = counts.welcome || 0;
-        document.getElementById('cta-click').textContent = counts.cta_click || 0;
-        document.getElementById('bot-start').textContent = counts.bot_start || 0;
-        document.getElementById('pix-generated').textContent = counts.pix_generated || 0;
-        document.getElementById('purchase').textContent = counts.purchase || 0;
-    }
+  function atualizarContadores(c) {
+    document.getElementById('welcome').textContent = c.welcome;
+    document.getElementById('cta_click').textContent = c.cta_click;
+    document.getElementById('pix_generated').textContent = c.pix_generated;
+    document.getElementById('purchase').textContent = c.purchase;
+  }
 
-    function calcularTaxa(numerador, denominador) {
-        numerador = parseInt(numerador) || 0;
-        denominador = parseInt(denominador) || 0;
-        if (denominador === 0) return '0.00%';
-        return ((numerador / denominador) * 100).toFixed(2) + '%';
-    }
+  function calcularTaxa(numerador, denominador) {
+    numerador = parseInt(numerador) || 0;
+    denominador = parseInt(denominador) || 0;
+    if (denominador === 0) return '0.00%';
+    return ((numerador / denominador) * 100).toFixed(2) + '%';
+  }
 
-    function atualizarTaxas(c) {
-        document.getElementById('rate-welcome-click').textContent = calcularTaxa(c.cta_click, c.welcome);
-        document.getElementById('rate-click-bot').textContent = calcularTaxa(c.bot_start, c.cta_click);
-        document.getElementById('rate-bot-pix').textContent = calcularTaxa(c.pix_generated, c.bot_start);
-        document.getElementById('rate-pix-compra').textContent = calcularTaxa(c.purchase, c.pix_generated);
-        document.getElementById('rate-welcome-compra').textContent = calcularTaxa(c.purchase, c.welcome);
-    }
-    
-    function atualizarGrafico(series) {
-        const ctx = document.getElementById('funil-chart').getContext('2d');
-        if (chart) chart.destroy();
+  function atualizarTaxas(c) {
+    document.getElementById('rate-welcome-click').textContent = calcularTaxa(c.cta_click, c.welcome);
+    document.getElementById('rate-click-pix').textContent = calcularTaxa(c.pix_generated, c.cta_click);
+    document.getElementById('rate-pix-compra').textContent = calcularTaxa(c.purchase, c.pix_generated);
+    document.getElementById('rate-welcome-compra').textContent = calcularTaxa(c.purchase, c.welcome);
+  }
 
-        const labels = [...new Set(series.map(item => item.time_bucket.split('T')[0]))].sort();
-        
-        const datasets = {
-            welcome: { label: 'Welcome', data: [], borderColor: '#4e9af1', tension: 0.1 },
-            cta_click: { label: 'CTA Click', data: [], borderColor: '#f1c40f', tension: 0.1 },
-            bot_start: { label: 'Entraram no Bot', data: [], borderColor: '#e67e22', tension: 0.1 },
-            pix_generated: { label: 'PIX Gerado', data: [], borderColor: '#e74c3c', tension: 0.1 },
-            purchase: { label: 'Compraram', data: [], borderColor: '#2ecc71', tension: 0.1 }
-        };
-
-        labels.forEach(label => {
-            for (const key in datasets) {
-                const item = series.find(s => s.time_bucket.startsWith(label) && s.event_name === key);
-                datasets[key].data.push(item ? parseInt(item.count) : 0);
-            }
-        });
-
-        chart = new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: labels,
-                datasets: Object.values(datasets)
-            },
-            options: {
-                scales: {
-                    x: { ticks: { color: '#e0e0e0' }, grid: { color: '#444' } },
-                    y: { beginAtZero: true, ticks: { color: '#e0e0e0' }, grid: { color: '#444' } }
-                },
-                plugins: { legend: { labels: { color: '#e0e0e0' } } }
-            }
-        });
-    }
+  carregarDados();
 });
 
 // Função auxiliar utilizada no painel de testes para gerar uma cobrança
@@ -115,28 +49,29 @@ document.addEventListener('DOMContentLoaded', () => {
 // a partir dos botões da tabela de testes, enviando também os parâmetros
 // necessários para criar a cobrança.
 async function gerarCobranca(button, telegram_id, plano, valor, trackingData) {
-    // Pega a referência à linha (<tr>) onde o botão foi clicado
-    const row = button.closest('tr');
+  // Pega a referência à linha (<tr>) onde o botão foi clicado
+  const row = button.closest('tr');
 
-    // Cria um identificador único baseado no timestamp atual
-    const funnel_session_id = 'funil_session_' + Date.now();
+  // Cria um identificador único baseado no timestamp atual
+  const funnel_session_id = 'funil_session_' + Date.now();
 
-    // Salva o identificador na linha da tabela para rastreamento posterior
-    row.dataset.sessionId = funnel_session_id;
+  // Salva o identificador na linha da tabela para rastreamento posterior
+  row.dataset.sessionId = funnel_session_id;
 
-    // Envia a requisição para gerar a cobrança incluindo o novo campo
-    return fetch('/api/gerar-cobranca', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-            telegram_id,
-            plano,
-            valor,
-            trackingData,
-            funnel_session_id
-        })
-    });
+  // Envia a requisição para gerar a cobrança incluindo o novo campo
+  return fetch('/api/gerar-cobranca', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      telegram_id,
+      plano,
+      valor,
+      trackingData,
+      funnel_session_id
+    })
+  });
 }
 
 // Expõe a função globalmente para ser utilizada diretamente no HTML
 window.gerarCobranca = gerarCobranca;
+

--- a/server.js
+++ b/server.js
@@ -427,6 +427,29 @@ app.post('/api/funnel/track', async (req, res) => {
   }
 });
 
+// 🔥 Novo: retorna contadores agregados do funil
+app.get('/api/funnel/stats', async (req, res) => {
+  try {
+    if (!pool) {
+      return res.status(500).json({ error: 'Banco não disponível' });
+    }
+
+    const result = await pool.query(
+      'SELECT event_name, event_count FROM funnel_analytics'
+    );
+
+    const stats = {};
+    for (const row of result.rows) {
+      stats[row.event_name] = Number(row.event_count);
+    }
+
+    res.json(stats);
+  } catch (error) {
+    console.error('Erro ao buscar estatísticas do funil:', error);
+    res.status(500).json({ error: 'Falha ao buscar dados do funil' });
+  }
+});
+
 // Endpoint que fornece os dados para o Painel de Funil
 app.get('/api/funnel/data', async (req, res) => {
     // Reutiliza a segurança do seu outro painel


### PR DESCRIPTION
## Summary
- add API endpoint `/api/funnel/stats` to return aggregated event counts
- simplify funnel dashboard script to fetch new endpoint and render totals

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_689aa701d3b4832abdd51a337ce3b0e6