### PR TITLE
Track cta click event to sheet

### DIFF
--- a/server.js
+++ b/server.js
@@ -1013,6 +1013,44 @@ app.post('/api/track-welcome', async (req, res) => {
   }
 });
 
+// 🔥 NOVA ROTA: Rastrear evento 'cta_clicker' quando usuário clica no botão
+app.post('/api/track-cta-click', async (req, res) => {
+  try {
+    // Verificar se a variável de ambiente SPREADSHEET_ID está definida
+    if (!process.env.SPREADSHEET_ID) {
+      console.error('SPREADSHEET_ID não definido nas variáveis de ambiente');
+      return res.status(500).json({ 
+        success: false, 
+        message: 'Configuração de planilha não encontrada' 
+      });
+    }
+
+    // Preparar dados para inserção na planilha
+    const spreadsheetId = process.env.SPREADSHEET_ID;
+    const range = 'cta_clicker!A:B';
+    const values = [[new Date().toISOString().split('T')[0], 1]];
+
+    // Chamar a função appendDataToSheet
+    await appendDataToSheet(spreadsheetId, range, values);
+
+    // Retornar sucesso
+    return res.status(200).json({ 
+      success: true, 
+      message: 'CTA click event tracked successfully.' 
+    });
+
+  } catch (error) {
+    // Log do erro no console
+    console.error('Erro ao rastrear evento cta_clicker:', error);
+    
+    // Retornar erro
+    return res.status(500).json({ 
+      success: false, 
+      message: 'Failed to track CTA click event.' 
+    });
+  }
+});
+
 
 // Servir arquivos estáticos
 const publicPath = path.join(__dirname, 'public');


### PR DESCRIPTION
Adds a new POST route `/api/track-cta-click` to track CTA click events in a Google Sheet.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c55a5ef-33fc-4883-9918-f55600a64956">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c55a5ef-33fc-4883-9918-f55600a64956">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

