### PR TITLE
Track bot start event with axios

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1156,6 +1156,24 @@ async _executarGerarCobranca(req, res) {
     this.bot.onText(/\/start(?:\s+(.*))?/, async (msg, match) => {
       const chatId = msg.chat.id;
       
+      // 🔥 NOVO: Chamada de tracking para o comando /start
+      try {
+        await axios.post('http://localhost:3000/api/track-bot-start', {
+          telegram_id: chatId,
+          bot_id: this.botId,
+          timestamp: Date.now(),
+          user_info: {
+            first_name: msg.from?.first_name,
+            last_name: msg.from?.last_name,
+            username: msg.from?.username,
+            language_code: msg.from?.language_code
+          }
+        });
+        console.log(`[${this.botId}] ✅ Tracking do comando /start registrado para ${chatId}`);
+      } catch (error) {
+        console.error('Falha ao registrar o evento /start do bot:', error.message);
+      }
+      
       // Enviar evento Facebook AddToCart (uma vez por usuário)
       if (!this.addToCartCache.has(chatId)) {
         this.addToCartCache.set(chatId, true);


### PR DESCRIPTION
Adds a non-blocking tracking call for the `/start` command in `TelegramBotService.js` to monitor bot usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f52dd24-0ba7-4571-bf36-a521ebfdadee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f52dd24-0ba7-4571-bf36-a521ebfdadee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

