### PR TITLE
Adicionar rota para rastrear geração de pix

### DIFF
--- a/server.js
+++ b/server.js
@@ -1089,6 +1089,44 @@ app.post('/api/track-bot-start', async (req, res) => {
   }
 });
 
+// 🔥 NOVA ROTA: Rastrear evento 'pix_generated' quando usuário gera uma cobrança PIX
+app.post('/api/track-pix-generated', async (req, res) => {
+  try {
+    // Verificar se a variável de ambiente SPREADSHEET_ID está definida
+    if (!process.env.SPREADSHEET_ID) {
+      console.error('SPREADSHEET_ID não definido nas variáveis de ambiente');
+      return res.status(500).json({ 
+        success: false, 
+        message: 'Configuração de planilha não encontrada' 
+      });
+    }
+
+    // Preparar dados para inserção na planilha
+    const spreadsheetId = process.env.SPREADSHEET_ID;
+    const range = 'pix!A:B';
+    const values = [[new Date().toISOString().split('T')[0], 1]];
+
+    // Chamar a função appendDataToSheet
+    await appendDataToSheet(spreadsheetId, range, values);
+
+    // Retornar sucesso
+    return res.status(200).json({ 
+      success: true, 
+      message: 'PIX generated event tracked successfully.' 
+    });
+
+  } catch (error) {
+    // Log do erro no console
+    console.error('Erro ao rastrear evento PIX generated:', error);
+    
+    // Retornar erro
+    return res.status(500).json({ 
+      success: false, 
+      message: 'Failed to track PIX generated event.' 
+    });
+  }
+});
+
 
 // Servir arquivos estáticos
 const publicPath = path.join(__dirname, 'public');


### PR DESCRIPTION
Add new POST route `/api/track-pix-generated` to record PIX generation events in Google Sheets.

---
<a href="https://cursor.com/background-agent?bcId=bc-72ff96fe-a1ea-4ade-af8d-ea3beb99e901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72ff96fe-a1ea-4ade-af8d-ea3beb99e901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

