### PR TITLE
Track purchase event with offer name

### DIFF
--- a/server.js
+++ b/server.js
@@ -1127,6 +1127,55 @@ app.post('/api/track-pix-generated', async (req, res) => {
   }
 });
 
+// 🔥 NOVA ROTA: Rastrear evento 'purchase' quando usuário realiza uma compra
+app.post('/api/track-purchase', async (req, res) => {
+  try {
+    // Extrair offerName do corpo da requisição
+    const { offerName } = req.body;
+
+    // Validar se offerName foi fornecido
+    if (!offerName) {
+      return res.status(400).json({ 
+        success: false, 
+        message: 'Offer name is required.' 
+      });
+    }
+
+    // Verificar se a variável de ambiente SPREADSHEET_ID está definida
+    if (!process.env.SPREADSHEET_ID) {
+      console.error('SPREADSHEET_ID não definido nas variáveis de ambiente');
+      return res.status(500).json({ 
+        success: false, 
+        message: 'Configuração de planilha não encontrada' 
+      });
+    }
+
+    // Preparar dados para inserção na planilha
+    const spreadsheetId = process.env.SPREADSHEET_ID;
+    const range = 'purchase!A:C';
+    const values = [[new Date().toISOString().split('T')[0], 1, offerName]];
+
+    // Chamar a função appendDataToSheet
+    await appendDataToSheet(spreadsheetId, range, values);
+
+    // Retornar sucesso
+    return res.status(200).json({ 
+      success: true, 
+      message: 'Purchase event tracked successfully.' 
+    });
+
+  } catch (error) {
+    // Log do erro no console
+    console.error('Erro ao rastrear evento purchase:', error);
+    
+    // Retornar erro
+    return res.status(500).json({ 
+      success: false, 
+      message: 'Failed to track purchase event.' 
+    });
+  }
+});
+
 
 // Servir arquivos estáticos
 const publicPath = path.join(__dirname, 'public');


### PR DESCRIPTION
Adds a new POST `/api/track-purchase` route to log purchase events to a Google Sheet.

---
<a href="https://cursor.com/background-agent?bcId=bc-47216a52-5bd9-47c5-ab41-8223c140bccd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47216a52-5bd9-47c5-ab41-8223c140bccd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

