### PR TITLE
Format Google Sheets private key for authentication

### DIFF
--- a/services/googleSheets.js
+++ b/services/googleSheets.js
@@ -10,11 +10,14 @@ const { google } = require('googleapis');
  */
 async function appendDataToSheet(spreadsheetId, range, values) {
     try {
+        // Formata a chave privada, substituindo \n por quebras de linha reais
+        const formattedPrivateKey = process.env.GOOGLE_PRIVATE_KEY.replace(/\\n/g, '\n');
+
         // Cria um cliente JWT com as credenciais da conta de serviço
         const auth = new google.auth.JWT(
             process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
             null,
-            process.env.GOOGLE_PRIVATE_KEY,
+            formattedPrivateKey,
             ['https://www.googleapis.com/auth/spreadsheets']
         );
 


### PR DESCRIPTION
## Summary
- ensure GOOGLE_PRIVATE_KEY is formatted by replacing `\n` escape sequences with real newlines before creating JWT auth

## Testing
- `NODE_ENV=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bbe50ec68832abdd4e106f015122c