### PR TITLE
Add Google Drive scope to Google Sheets service

### DIFF
--- a/services/googleSheets.js
+++ b/services/googleSheets.js
@@ -22,7 +22,10 @@ async function appendDataToSheet(spreadsheetId, range, values) {
             process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL,
             null,
             formattedPrivateKey,
-            ['https://www.googleapis.com/auth/spreadsheets']
+            [
+                'https://www.googleapis.com/auth/spreadsheets',
+                'https://www.googleapis.com/auth/drive'
+            ]
         );
 
         // Instancia a API do Google Sheets


### PR DESCRIPTION
## Summary
- broaden Google Sheets auth scope to include Google Drive access

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_689bc8bd5600832a8d26b298a9729606