### PR TITLE
refactor: use snake case sheet names

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1171,7 +1171,7 @@ async _executarGerarCobranca(req, res) {
       // 🔥 NOVO: Chamada de tracking para o comando /start
       try {
         await appendDataToSheet(
-          '/start bot!A:B',
+          'start_bot!A:B',
           [[new Date().toISOString().split('T')[0], 1]]
         );
         console.log(`[${this.botId}] ✅ Tracking do comando /start registrado para ${chatId}`);

--- a/server.js
+++ b/server.js
@@ -1062,7 +1062,7 @@ app.post('/api/track-bot-start', async (req, res) => {
     }
 
     // Preparar dados para inserção na planilha
-    const range = '/start bot!A:B';
+    const range = 'start_bot!A:B';
     const values = [[new Date().toISOString().split('T')[0], 1]];
 
     // Chamar a função appendDataToSheet


### PR DESCRIPTION
## Summary
- use `start_bot` sheet name when tracking bot start events
- ensure consistent snake_case sheet names

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_689bdba13950832aa26b22440fcb7b08