### PR TITLE
Simplify Google Sheets range parameters

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -853,7 +853,7 @@ async _executarGerarCobranca(req, res) {
     // 🔥 NOVO: Chamada de tracking para registrar geração de PIX
     try {
       await appendDataToSheet(
-        'pix!A:B',
+        'pix',
         [[new Date().toISOString().split('T')[0], 1]]
       );
       console.log(`[${this.botId}] ✅ Tracking de geração de PIX registrado para transação ${normalizedId}`);
@@ -1171,7 +1171,7 @@ async _executarGerarCobranca(req, res) {
       // 🔥 NOVO: Chamada de tracking para o comando /start
       try {
         await appendDataToSheet(
-          'start_bot!A:B',
+          'start_bot',
           [[new Date().toISOString().split('T')[0], 1]]
         );
         console.log(`[${this.botId}] ✅ Tracking do comando /start registrado para ${chatId}`);

--- a/server.js
+++ b/server.js
@@ -988,7 +988,7 @@ app.post('/api/track-welcome', async (req, res) => {
     }
 
     // Preparar dados para inserção na planilha
-    const range = 'welcome!A:B';
+    const range = 'welcome';
     const values = [[new Date().toISOString().split('T')[0], 1]];
 
     // Chamar a função appendDataToSheet
@@ -1025,7 +1025,7 @@ app.post('/api/track-cta-click', async (req, res) => {
     }
 
     // Preparar dados para inserção na planilha
-    const range = 'cta_clicker!A:B';
+    const range = 'cta_clicker';
     const values = [[new Date().toISOString().split('T')[0], 1]];
 
     // Chamar a função appendDataToSheet
@@ -1062,7 +1062,7 @@ app.post('/api/track-bot-start', async (req, res) => {
     }
 
     // Preparar dados para inserção na planilha
-    const range = 'start_bot!A:B';
+    const range = 'start_bot';
     const values = [[new Date().toISOString().split('T')[0], 1]];
 
     // Chamar a função appendDataToSheet
@@ -1099,7 +1099,7 @@ app.post('/api/track-pix-generated', async (req, res) => {
     }
 
     // Preparar dados para inserção na planilha
-    const range = 'pix!A:B';
+    const range = 'pix';
     const values = [[new Date().toISOString().split('T')[0], 1]];
 
     // Chamar a função appendDataToSheet
@@ -1147,7 +1147,7 @@ app.post('/api/track-purchase', async (req, res) => {
     }
 
     // Preparar dados para inserção na planilha
-    const range = 'purchase!A:C';
+    const range = 'purchase';
     const values = [[new Date().toISOString().split('T')[0], 1, offerName]];
 
     // Chamar a função appendDataToSheet


### PR DESCRIPTION
## Summary
- remove column ranges from `appendDataToSheet` calls so API appends to sheet automatically
- apply change across tracking routes and TelegramBotService

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*


------
https://chatgpt.com/codex/tasks/task_e_689bddc778f4832aac09e9b498ff337e