### PR TITLE
feat: track welcome and CTA click events on frontend

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -455,6 +455,10 @@
 
     // Evento de clique com redirecionamento direto
     cta.addEventListener("click", function () {
+      // Rastrear clique do CTA no backend
+      fetch('/api/track-cta-click', { method: 'POST' })
+        .catch(err => console.error('Erro ao rastrear clique do CTA:', err));
+
       const viewContentData = {
         value: parseFloat((Math.random() * (19.90 - 9.90) + 9.90).toFixed(2)),
         currency: 'BRL',
@@ -471,6 +475,13 @@
     // Atualiza link final com payload gerado somente após o carregamento
     window.addEventListener('load', () => {
       setTimeout(gerarPayload, 500);
+    });
+  </script>
+
+  <script>
+    window.addEventListener('load', () => {
+      fetch('/api/track-welcome', { method: 'POST' })
+        .catch(err => console.error('Erro ao rastrear evento welcome:', err));
     });
   </script>
 

--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -477,7 +477,11 @@
     try {
       // 🔥 DISPARAR FLUXO DE EVENTOS ADD TO CART + INITIATE CHECKOUT
       console.log('🎯 CTA clicado - iniciando fluxo de eventos');
-      
+
+      // Rastrear clique do CTA no backend
+      fetch('/api/track-cta-click', { method: 'POST' })
+        .catch(err => console.error('Erro ao rastrear clique do CTA:', err));
+
       // Disparar eventos de conversão
       const flowResult = window.EventTracking.triggerInitiateFlowEvents();
       


### PR DESCRIPTION
## Summary
- add POST call to /api/track-cta-click when CTA button is pressed
- trigger /api/track-welcome on welcome page load

## Testing
- `npm test` (fails: DATABASE_URL não definida para ambiente 'production')

------
https://chatgpt.com/codex/tasks/task_e_689be5711bf4832aa7db88d5e6823cc8