### PR TITLE
Track welcome event on CTA activation

### DIFF
--- a/MODELO1/WEB/boasvindas.html
+++ b/MODELO1/WEB/boasvindas.html
@@ -351,6 +351,16 @@
 
     const cta = document.getElementById("cta");
     cta.innerText = window.config.buttonText;
+    let welcomeEventFired = false;
+
+    function trackWelcomeEvent() {
+      if (!welcomeEventFired) {
+        welcomeEventFired = true;
+        fetch('/api/track-welcome', { method: 'POST' })
+          .then(() => console.log('Evento welcome enviado'))
+          .catch(err => console.error('Erro ao rastrear evento welcome:', err));
+      }
+    }
 
     // Base do bot
     const baseUrl = window.config.redirectLink;
@@ -443,13 +453,16 @@
         const data = await resp.json().catch(() => ({}));
         if (resp.ok && data.payload_id) {
           cta.href = `${baseUrl}?start=${data.payload_id}`;
+          trackWelcomeEvent();
           console.log('🔗 Payload gerado com cookies do Facebook:', { fbp: !!fbp, fbc: !!fbc });
         } else {
           cta.href = baseUrl;
+          trackWelcomeEvent();
         }
       } catch (e) {
         console.error('Erro ao gerar payload', e);
         cta.href = baseUrl;
+        trackWelcomeEvent();
       }
     }
 
@@ -475,13 +488,6 @@
     // Atualiza link final com payload gerado somente após o carregamento
     window.addEventListener('load', () => {
       setTimeout(gerarPayload, 500);
-    });
-  </script>
-
-  <script>
-    window.addEventListener('load', () => {
-      fetch('/api/track-welcome', { method: 'POST' })
-        .catch(err => console.error('Erro ao rastrear evento welcome:', err));
     });
   </script>
 


### PR DESCRIPTION
## Summary
- send POST `/api/track-welcome` when CTA link is set after payload generation
- ensure the welcome event fires only once using `welcomeEventFired`

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_689be892246c832aa2b4b3ef5e294122