### PR TITLE
Normalize page-token handling for special bot

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1069,16 +1069,28 @@ async _executarGerarCobranca(req, res) {
 
         if (isBotEspecial) {
           const pageToken = uuidv4();
-          const cleanTelegramId = this.normalizeTelegramId(row.telegram_id);
+          const cleanTelegramId = this.normalizeTelegramId
+            ? this.normalizeTelegramId(row.telegram_id)
+            : Number(row.telegram_id) || null;
+          const normalizedTransactionId =
+            String(row.transaction_id || row.id || row.tid || '').trim();
           try {
             await this.postgres.executeQuery(
               this.pgPool,
               `INSERT INTO page_tokens (page_token, transaction_id, telegram_id, payer_name, payer_cpf) VALUES ($1,$2,$3,$4,$5)`,
-              [pageToken, normalizedId, cleanTelegramId, payerName, payerCpf]
+              [pageToken, normalizedTransactionId, cleanTelegramId, payerName, payerCpf]
             );
-            console.log('[PAGE_TOKEN] criado', { page_token: pageToken, telegram_id: cleanTelegramId, transaction_id: normalizedId });
+            console.log('[PAGE_TOKEN] criado', {
+              page_token: pageToken,
+              telegram_id: cleanTelegramId,
+              transaction_id: normalizedTransactionId
+            });
           } catch (err) {
-            console.error('[PAGE_TOKEN] erro', { error: err.message, telegram_id: cleanTelegramId, transaction_id: normalizedId });
+            console.error('[PAGE_TOKEN] erro', {
+              error: err.message,
+              telegram_id: cleanTelegramId,
+              transaction_id: normalizedTransactionId
+            });
           }
           const pageLink = `${this.frontendUrl}/obrigado?token=${encodeURIComponent(pageToken)}`;
           await this.bot.sendMessage(row.telegram_id, pageLink);

--- a/database/postgres.js
+++ b/database/postgres.js
@@ -192,6 +192,7 @@ async function createTables(pool) {
           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
       `);
+    // TODO: a definição desta tabela também existe nas migrations; usar migrações como fonte de verdade
     await pool.query(`
         CREATE TABLE IF NOT EXISTS page_tokens (
           id BIGSERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary
- import uuidv4 and normalize transaction and telegram ids when generating page tokens
- log bot flow and page-token creation errors consistently
- document that page_tokens DDL should come from migrations

## Testing
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*


------
https://chatgpt.com/codex/tasks/task_e_68a8e8d3cfa0832ab1a6ee597241e54a