### PR TITLE
Corrigir bot para exibir dados do comprador e tela de obrigado

### DIFF
--- a/MODELO1/WEB/obrigado_especial.html
+++ b/MODELO1/WEB/obrigado_especial.html
@@ -152,9 +152,9 @@
         </div>
       </div>
       
-      <p>Você será redirecionado automaticamente para o canal VIP Premium.</p>
-      <a href="https://t.me/+0iLdVzcJsq9kOWQ5" class="botao" onclick="redirecionarSePronto(); return false;">Ou clique aqui para entrar agora</a>
-      <div id="contador" class="contador"></div>
+      <p>Seu acesso premium foi liberado com sucesso!</p>
+      <p>Clique no botão abaixo para acessar o canal VIP Premium quando desejar.</p>
+      <a href="https://t.me/+0iLdVzcJsq9kOWQ5" class="botao" target="_blank">🚀 Acessar Canal VIP Premium</a>
     </div>
     
     <div id="erro" class="hidden">
@@ -233,9 +233,6 @@
     const token = urlParams.get('token');
     const valor = urlParams.get('valor');
     let tokenValido = false;
-    let redirectUrl = '';
-    let redirectDelay = 5000;
-    let redirectTimer;
 
     // Função para buscar dados do comprador
     async function carregarDadosComprador(token) {
@@ -267,7 +264,6 @@
 
         if (data.sucesso) {
           tokenValido = true;
-          redirectUrl = data.redirectUrl;
           
           // Marcar token como usado
           try {
@@ -281,8 +277,6 @@
           
           document.getElementById('loading').classList.add('hidden');
           document.getElementById('conteudo').classList.remove('hidden');
-          
-          iniciarContador();
           
           // Enviar evento Purchase para Facebook
           await enviarEventoPurchase();
@@ -358,29 +352,7 @@
       }, 3000);
     }
 
-    function iniciarContador() {
-      let segundos = Math.floor(redirectDelay / 1000);
-      const contadorEl = document.getElementById('contador');
-      
-      const updateContador = () => {
-        contadorEl.textContent = `Redirecionando em ${segundos} segundos...`;
-        segundos--;
-        
-        if (segundos < 0) {
-          redirecionarSePronto();
-        }
-      };
-      
-      updateContador();
-      redirectTimer = setInterval(updateContador, 1000);
-    }
 
-    function redirecionarSePronto() {
-      if (tokenValido && redirectUrl) {
-        clearInterval(redirectTimer);
-        window.location.href = redirectUrl;
-      }
-    }
 
     // Iniciar verificação
     verificarToken();

--- a/add-columns.js
+++ b/add-columns.js
@@ -1,0 +1,23 @@
+const postgres = require('./database/postgres');
+
+async function addColumns() {
+  try {
+    console.log('Adicionando colunas temporárias para bot especial...');
+    
+    const pool = postgres.createPool();
+    
+    await pool.query('ALTER TABLE tokens ADD COLUMN IF NOT EXISTS payer_name_temp TEXT');
+    console.log('✅ Coluna payer_name_temp adicionada');
+    
+    await pool.query('ALTER TABLE tokens ADD COLUMN IF NOT EXISTS payer_cpf_temp TEXT');
+    console.log('✅ Coluna payer_cpf_temp adicionada');
+    
+    await pool.end();
+    console.log('✅ Colunas adicionadas com sucesso!');
+    
+  } catch (error) {
+    console.error('❌ Erro ao adicionar colunas:', error.message);
+  }
+}
+
+addColumns();


### PR DESCRIPTION
Remove automatic redirection from the thank you page and display the buyer's name and masked CPF for `bot_especial`.

The user requested that the `bot_especial` thank you page should no longer redirect to a group and instead remain visible. Additionally, the buyer's name and CPF, provided by PushinPay, needed to be displayed on this page. This PR implements these changes by storing the buyer's details temporarily and updating the frontend and API to show them.

---
<a href="https://cursor.com/background-agent?bcId=bc-be38d069-0d1e-4fd2-adb5-585f164e8b60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be38d069-0d1e-4fd2-adb5-585f164e8b60">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

