### PR TITLE
fix: serve privacy static assets

### DIFF
--- a/server.js
+++ b/server.js
@@ -1861,11 +1861,17 @@ if (fs.existsSync(webPath)) {
 
 // 🔥 NOVO: SERVIR ARQUIVOS ESTÁTICOS DO PRIVACY---SYNC (APÓS AS ROTAS ESPECÍFICAS)
 if (fs.existsSync(privacyPath)) {
+  // Servir assets do checkout (/privacy)
+  app.use(express.static(path.join(privacyPath, 'public')));
+
   // Servir arquivos estáticos específicos
   app.use('/images', express.static(path.join(privacyPath, 'links/images')));
   app.use('/icons', express.static(path.join(privacyPath, 'links/icons')));
-  app.use('/compra-aprovada/images', express.static(path.join(privacyPath, 'compra-aprovada/images')));
-  
+  app.use(
+    '/compra-aprovada/images',
+    express.static(path.join(privacyPath, 'compra-aprovada/images'))
+  );
+
   console.log('✅ Arquivos estáticos do privacy---sync configurados');
 }
 


### PR DESCRIPTION
## Summary
- serve privacy checkout assets from `privacy---sync/public` so CSS and JS load

## Testing
- `npm test`
- `DATABASE_URL=postgresql://localhost/test npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85b892f54832a8f2c1d9ba35eead7