### PR TITLE
fix: remove stuck page loader

### DIFF
--- a/privacy---sync/public/index.html
+++ b/privacy---sync/public/index.html
@@ -1126,6 +1126,8 @@ setTimeout(() => {
 
       <!-- Proteções de inspeção (F12 e botão direito) -->
       <script src="/js/protection.js"></script>
+      <!-- Remover tela de carregamento quando a página estiver pronta -->
+      <script src="/js/page-loader.js"></script>
 
       <!-- Controle do Seletor de Gateway -->
       <script>

--- a/privacy---sync/public/js/page-loader.js
+++ b/privacy---sync/public/js/page-loader.js
@@ -1,0 +1,17 @@
+/**
+ * Simple helper to hide the page loader once the page is ready.
+ * Prevents the interface from remaining stuck on the loading screen.
+ */
+(function() {
+  function hideLoader() {
+    const loader = document.querySelector('.pageloader, .pageLoader');
+    if (loader) {
+      loader.classList.remove('is-active');
+      loader.style.display = 'none';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', hideLoader);
+  window.addEventListener('load', hideLoader);
+  setTimeout(hideLoader, 5000);
+})();


### PR DESCRIPTION
## Summary
- hide checkout page loader once DOM or load events fire to prevent stuck loading
- include new script in index.html to remove loader

## Testing
- `node --check privacy---sync/public/js/page-loader.js`
- `npm test` *(fails: DATABASE_URL não definida para ambiente 'production')*

------
https://chatgpt.com/codex/tasks/task_e_68b864a8915c832a9346e3cf5feb5de7