### PR TITLE
Analyze and fix privacy endpoint for pix creation

### DIFF
--- a/FIX_PIX_PRIVACY.md
+++ b/FIX_PIX_PRIVACY.md
@@ -1,0 +1,137 @@
+# 🔧 Correção do Erro PIX no Endpoint /privacy
+
+## 📋 Problema Identificado
+O endpoint `/privacy` estava com erro ao criar pagamentos PIX. O problema principal era:
+1. **Incompatibilidade de campos**: O frontend enviava `amount` mas o backend esperava `value`
+2. **Resposta incompleta**: O backend não retornava todos os campos necessários para o frontend
+
+## ✅ Correções Implementadas
+
+### 1. **Compatibilidade de Campos (server.js)**
+```javascript
+// ANTES: Só aceitava 'value'
+const { value, split_rules = [], metadata = {} } = req.body;
+
+// DEPOIS: Aceita tanto 'value' quanto 'amount'
+const { value, amount, split_rules = [], metadata = {} } = req.body;
+const finalAmount = value || amount;
+```
+
+### 2. **Resposta Completa do Endpoint**
+```javascript
+// Agora retorna todos os campos necessários
+res.json({
+  success: true,
+  message: 'Pagamento PIX criado com sucesso',
+  gateway: gateway,
+  data: {
+    id: result.payment_id,
+    qr_code_base64: result.qr_code_image,
+    qr_code: result.pix_code,
+    pix_code: result.pix_code,
+    pix_copia_cola: result.pix_code,
+    transacao_id: result.payment_id,
+    payment_id: result.payment_id,
+    valor: finalAmount,
+    amount: finalAmount
+  }
+});
+```
+
+### 3. **Melhorias no Debug**
+- Adicionados logs detalhados para rastrear o fluxo
+- Validação aprimorada dos dados recebidos
+- Mensagens de erro mais descritivas
+
+## 🧪 Como Testar
+
+### 1. Via Interface Web (/privacy)
+1. Acesse: `https://seu-dominio.com/privacy`
+2. Clique em um dos botões de plano (1 mês, 3 meses, 6 meses)
+3. O PIX deve ser gerado com sucesso
+
+### 2. Via Script de Teste
+```bash
+# Execute o script de teste criado
+node test-pix-endpoint.js
+```
+
+### 3. Via cURL
+```bash
+curl -X POST https://seu-dominio.com/api/payments/pix/create \
+  -H "Content-Type: application/json" \
+  -d '{
+    "amount": 19.90,
+    "description": "Teste PIX",
+    "customer_name": "Cliente Teste"
+  }'
+```
+
+## 📝 Logs Esperados (Sucesso)
+```
+💰 [DEBUG] Criando pagamento PIX...
+📋 [DEBUG] Dados recebidos: { amount: 19.90, ... }
+💰 [DEBUG] Valor final a ser processado: 19.90
+🚀 Usando implementação PushinPay do bot via privacy
+✅ Pagamento PIX criado com sucesso
+```
+
+## ⚠️ Possíveis Problemas Restantes
+
+### 1. Token PushinPay
+Verifique se o token está configurado corretamente no `.env`:
+```env
+PUSHINPAY_TOKEN=seu_token_aqui
+```
+
+### 2. URL Base
+Certifique-se de que a BASE_URL está configurada:
+```env
+BASE_URL=https://seu-dominio.com
+```
+
+### 3. Webhook URL
+O webhook é gerado automaticamente como:
+```
+${BASE_URL}/webhook/pushinpay
+```
+
+## 🚀 Deploy no Render
+
+Após fazer o commit das mudanças:
+```bash
+git add .
+git commit -m "Fix: Corrigido erro de criação PIX no endpoint /privacy"
+git push origin main
+```
+
+O Render fará o deploy automático.
+
+## 📊 Monitoramento
+
+Para monitorar os logs em tempo real no Render:
+1. Acesse o dashboard do Render
+2. Vá para seu serviço
+3. Clique em "Logs"
+4. Filtre por: `[DEBUG]` ou `PIX`
+
+## ✨ Melhorias Futuras Sugeridas
+
+1. **Cache de Transações**: Implementar cache Redis para consultas frequentes
+2. **Retry Logic**: Adicionar tentativas automáticas em caso de falha
+3. **Rate Limiting**: Implementar limite de requisições por IP
+4. **Webhook Resilience**: Adicionar fila de processamento para webhooks
+
+## 🤝 Integração Bot vs Privacy
+
+O sistema agora usa uma arquitetura unificada:
+- **Bot Telegram**: Usa `TelegramBotService._executarGerarCobranca`
+- **Privacy Web**: Usa `UnifiedPaymentGateway` que internamente chama o mesmo serviço do bot
+- **Benefício**: Código único, manutenção simplificada
+
+## 📞 Suporte
+
+Se o erro persistir após essas correções:
+1. Verifique os logs detalhados no Render
+2. Confirme que as variáveis de ambiente estão corretas
+3. Teste diretamente a API da PushinPay com o token configurado

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "luxon": "^3.4.4",
         "node-cache": "^5.1.2",
         "node-cron": "^3.0.2",
+        "node-fetch": "^2.6.7",
         "node-telegram-bot-api": "^0.61.0",
         "pg": "^8.11.3",
         "uuid": "^9.0.1"
@@ -1409,6 +1410,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/gcp-metadata": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
@@ -2480,21 +2499,23 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
+        "whatwg-url": "^5.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": "4.x || >=6.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-telegram-bot-api": {
@@ -3764,6 +3785,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -3975,6 +4002,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which-boxed-primitive": {

--- a/test-pix-endpoint.js
+++ b/test-pix-endpoint.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+// Script de teste para o endpoint PIX
+const axios = require('axios');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
+
+async function testPixEndpoint() {
+  console.log('🧪 Testando endpoint PIX...');
+  console.log('📍 URL:', `${BASE_URL}/api/payments/pix/create`);
+  
+  const testData = {
+    amount: 19.90,
+    description: 'Teste de pagamento PIX',
+    customer_name: 'Cliente Teste',
+    customer_email: 'teste@exemplo.com',
+    customer_document: '12345678901',
+    customer_phone: '11999999999'
+  };
+  
+  console.log('📤 Dados enviados:', JSON.stringify(testData, null, 2));
+  
+  try {
+    const response = await axios.post(
+      `${BASE_URL}/api/payments/pix/create`,
+      testData,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        }
+      }
+    );
+    
+    console.log('✅ Resposta recebida:');
+    console.log('Status:', response.status);
+    console.log('Data:', JSON.stringify(response.data, null, 2));
+    
+    if (response.data.success) {
+      console.log('✅ PIX criado com sucesso!');
+      console.log('Gateway usado:', response.data.gateway);
+      console.log('ID da transação:', response.data.data.id);
+      console.log('QR Code disponível:', !!response.data.data.qr_code);
+    }
+  } catch (error) {
+    console.error('❌ Erro ao testar endpoint:');
+    if (error.response) {
+      console.error('Status:', error.response.status);
+      console.error('Data:', JSON.stringify(error.response.data, null, 2));
+    } else {
+      console.error('Erro:', error.message);
+    }
+  }
+}
+
+// Executar teste
+testPixEndpoint();


### PR DESCRIPTION
Fix PIX creation on `/privacy` endpoint by ensuring compatibility with `amount` and `value` fields and providing a complete response.

The previous implementation expected `value` for PIX creation, while the frontend was sending `amount`. This PR updates the endpoint to accept both `value` and `amount` for flexibility and ensures the response includes all necessary PIX details for the frontend.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc375700-42e2-4848-87a3-a3036e64b0e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc375700-42e2-4848-87a3-a3036e64b0e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

