### PR TITLE
refactor: centralize initial media config

### DIFF
--- a/MODELO1/BOT/config1.js
+++ b/MODELO1/BOT/config1.js
@@ -3,17 +3,19 @@ const base = require('./config.default');
 module.exports = {
   ...base,
 
+  // 🎬 CONFIGURAÇÃO DE DOIS VÍDEOS INICIAIS
+  midias: {
+    ...base.midias,
+    inicial: {
+      video: './midia/inicial.mp4',
+      video2: './midia/inicial_2.mp4' // Segundo vídeo obrigatório
+    }
+  },
+
   inicio: {
     tipoMidia: 'video',
     // 🔥 NOVA CONFIGURAÇÃO: Forçar envio de múltiplas mídias
     enviarTodasMidias: true,
-    // 🎬 CONFIGURAÇÃO DE DOIS VÍDEOS INICIAIS
-    midias: {
-      inicial: { 
-        video: './midia/inicial.mp4',
-        video2: './midia/inicial_2.mp4' // Segundo vídeo obrigatório
-      }
-    },
     textoInicial: `💦 Aos 22 aninhos, virei a PUTINHA VIP mais desejada do Brasil 🇧🇷
 ✦━━━━━━━━━━━━✦
 

--- a/MODELO1/BOT/utils/midia.js
+++ b/MODELO1/BOT/utils/midia.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
-const { midias } = require('../config');
+// Utiliza a mesma configuração principal do bot (config1)
+const { midias } = require('../config1');
 
 /**
  * Classe para gerenciar mídias do bot


### PR DESCRIPTION
## Summary
- centralize initial media definition at top-level config with two videos
- ensure media utilities load config1 for consistent pre-warming

## Testing
- `NODE_ENV=test npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9b15e2664832ab0c8c27f80e09303