### PR TITLE
Debug bot1 media pre-loading issue

### DIFF
--- a/server.js
+++ b/server.js
@@ -2374,12 +2374,23 @@ function combinarMidiasEscaneadasComConfig(midiasEscaneadas, midiasConfig, baseD
   Object.keys(midiasConfig).forEach(configKey => {
     const configMidia = midiasConfig[configKey];
     
-    ['video', 'imagem', 'audio'].forEach(tipoMidia => {
-      if (configMidia[tipoMidia]) {
-        const caminhoCompleto = path.resolve(baseDir, configMidia[tipoMidia]);
+    // 🔥 CORREÇÃO: Processar TODAS as chaves de mídia, incluindo video2, video3, etc.
+    Object.keys(configMidia).forEach(chaveOriginal => {
+      if (configMidia[chaveOriginal]) {
+        const caminhoCompleto = path.resolve(baseDir, configMidia[chaveOriginal]);
         
         // Verificar se arquivo existe
         if (fs.existsSync(caminhoCompleto)) {
+          // 🎯 MAPEAR tipo de mídia baseado na chave
+          let tipoMidia = 'video'; // padrão
+          if (chaveOriginal.startsWith('video')) {
+            tipoMidia = 'video';
+          } else if (chaveOriginal === 'imagem' || chaveOriginal === 'foto') {
+            tipoMidia = 'imagem';
+          } else if (chaveOriginal === 'audio') {
+            tipoMidia = 'audio';
+          }
+          
           const tipo = configKey === 'inicial' || configKey === 'inicial_custom' ? 'inicial' : 
                       configKey.startsWith('ds') ? 'downsell' : 
                       configKey.startsWith('periodica_') ? 'periodica' : 'outro';
@@ -2388,20 +2399,26 @@ function combinarMidiasEscaneadasComConfig(midiasEscaneadas, midiasConfig, baseD
                      tipo === 'downsell' ? configKey : 
                      configKey;
           
-          const chave = `${tipo}_${key}_${tipoMidia}`;
+          // 🔥 CORREÇÃO: Incluir chave original para distinguir video, video2, etc.
+          const chave = `${tipo}_${key}_${chaveOriginal}`;
           
           if (!processados.has(chave)) {
             midiasFinais.push({
               tipo: tipo,
               key: key,
               tipoMidia: tipoMidia,
-              arquivo: path.basename(configMidia[tipoMidia]),
-              caminho: configMidia[tipoMidia],
+              chaveOriginal: chaveOriginal, // 🆕 Preservar chave original (video2, etc.)
+              arquivo: path.basename(configMidia[chaveOriginal]),
+              caminho: configMidia[chaveOriginal],
               caminhoCompleto: caminhoCompleto,
               origem: 'config'
             });
             processados.add(chave);
+            
+            console.log(`🔥 PRÉ-AQUECIMENTO: Mídia detectada - ${configKey}:${chaveOriginal} → ${path.basename(configMidia[chaveOriginal])}`);
           }
+        } else {
+          console.warn(`⚠️ PRÉ-AQUECIMENTO: Arquivo não encontrado - ${configKey}:${chaveOriginal} → ${configMidia[chaveOriginal]}`);
         }
       }
     });


### PR DESCRIPTION
Dynamically process all media keys in `combinarMidiasEscaneadasComConfig` to ensure all configured media, including those with keys like `video2`, are correctly pre-loaded.

Previously, the pre-loading system only iterated over hardcoded media types (`video`, `imagem`, `audio`). This caused media defined with non-standard keys (e.g., `video2` for `inicial_2.mp4`) to be entirely skipped during pre-warming, even though they were functional at runtime. This change modifies the logic to iterate over all keys present in the media configuration, dynamically mapping them to a generic media type for processing while retaining the original key for precise identification.

---
<a href="https://cursor.com/background-agent?bcId=bc-03cc9cb6-8346-45e6-a08f-4d3b1aea8848">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-03cc9cb6-8346-45e6-a08f-4d3b1aea8848">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

