### PR TITLE
fix: load checkout assets from static path

### DIFF
--- a/checkout/index.html
+++ b/checkout/index.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html><html class="v10" data-theme-lock="true"><head>
+    <base href="/checkout/">
    
     <script src="js/jquery.min.js" crossorigin="anonymous"></script>
     <!-- Required meta tags -->


### PR DESCRIPTION
## Summary
- ensure checkout images and icons load by setting base path

## Testing
- `npm test` *(fails: Cannot find module '/workspace/-HotBotWebV2/test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ba82acb534832aa3b50ab92b8f10c5