### PR TITLE
fix: load SweetAlert and remove invalid skeleton css

### DIFF
--- a/checkout/index.html
+++ b/checkout/index.html
@@ -60,9 +60,10 @@
 
     <link href="css/checkout.css" rel="stylesheet">
 
-    <link rel="stylesheet" href="/assets/css/privacy.components.skeleton.css">
-    <link rel="stylesheet" href="css/shadow-styles.css"> 
-    
+    <link rel="stylesheet" href="css/shadow-styles.css">
+
+
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
 
 
 


### PR DESCRIPTION
## Summary
- remove unused skeleton CSS link causing MIME errors
- load SweetAlert2 from CDN so Swal is defined

## Testing
- `npm test` *(fails: Cannot find module 'test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ba84590ac0832aa222a74a254f7912