### PR TITLE
Track PIX checkout events in funnel pages

### DIFF
--- a/checkout/funil_completo/back1.html
+++ b/checkout/funil_completo/back1.html
@@ -769,7 +769,7 @@
                 </div>
             </div>
             
-            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('back1_videos', 'Vídeos Personalizados - ÚLTIMA CHANCE', 19.90); return false;">QUERO ESSA ÚLTIMA CHANCE!</a>
+            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('back1_videos', 'Vídeos Personalizados - ÚLTIMA CHANCE', 19.90);">QUERO ESSA ÚLTIMA CHANCE!</a>
             
             <!-- Botão para recusar e ir para back2 -->
             <div style="text-align: center; margin-top: 20px;">
@@ -857,6 +857,9 @@
         // Função para gerar PIX e mostrar pop-up
         async function gerarPixPlano(planoId, planoNome, planoValor) {
             try {
+                if (window.PixelTracker) {
+                    window.PixelTracker.trackInitiateCheckout(planoValor, planoNome);
+                }
                 // Mostrar loading
                 Swal.fire({
                     title: 'Gerando PIX...',

--- a/checkout/funil_completo/back2.html
+++ b/checkout/funil_completo/back2.html
@@ -769,7 +769,7 @@
                 </div>
             </div>
             
-            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('back2_videos', 'Vídeos Personalizados - SUPER DESCONTO', 9.90); return false;">SIM, QUERO POR R$ 9,90!</a>
+            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('back2_videos', 'Vídeos Personalizados - SUPER DESCONTO', 9.90);">SIM, QUERO POR R$ 9,90!</a>
             
             <!-- Botão para recusar e ir para back3 -->
             <div style="text-align: center; margin-top: 20px;">
@@ -857,6 +857,9 @@
         // Função para gerar PIX e mostrar pop-up
         async function gerarPixPlano(planoId, planoNome, planoValor) {
             try {
+                if (window.PixelTracker) {
+                    window.PixelTracker.trackInitiateCheckout(planoValor, planoNome);
+                }
                 // Mostrar loading
                 Swal.fire({
                     title: 'Gerando PIX...',

--- a/checkout/funil_completo/back3.html
+++ b/checkout/funil_completo/back3.html
@@ -769,7 +769,7 @@
                 </div>
             </div>
             
-            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('back3_videos', 'Vídeos Personalizados - PREÇO FINAL', 4.90); return false;">ACEITO! QUERO POR R$ 4,90!</a>
+            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('back3_videos', 'Vídeos Personalizados - PREÇO FINAL', 4.90);">ACEITO! QUERO POR R$ 4,90!</a>
             
             <!-- Botão para recusar e sair do funil -->
             <div style="text-align: center; margin-top: 20px;">
@@ -857,6 +857,9 @@
         // Função para gerar PIX e mostrar pop-up
         async function gerarPixPlano(planoId, planoNome, planoValor) {
             try {
+                if (window.PixelTracker) {
+                    window.PixelTracker.trackInitiateCheckout(planoValor, planoNome);
+                }
                 // Mostrar loading
                 Swal.fire({
                     title: 'Gerando PIX...',

--- a/checkout/funil_completo/up1.html
+++ b/checkout/funil_completo/up1.html
@@ -768,7 +768,7 @@
                 </div>
             </div>
             
-            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('upsell1_videos', 'Vídeos Personalizados', 27.00); return false;">QUERO O VÍDEO AGORA!</a>
+            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('upsell1_videos', 'Vídeos Personalizados', 27.00);">QUERO O VÍDEO AGORA!</a>
             
             <!-- Botão para recusar e ir para back1 -->
             <div style="text-align: center; margin-top: 20px;">
@@ -855,6 +855,9 @@
         // Função para gerar PIX e mostrar pop-up
         async function gerarPixPlano(planoId, planoNome, planoValor) {
             try {
+                if (window.PixelTracker) {
+                    window.PixelTracker.trackInitiateCheckout(planoValor, planoNome);
+                }
                 // Mostrar loading
                 Swal.fire({
                     title: 'Gerando PIX...',

--- a/checkout/funil_completo/up2.html
+++ b/checkout/funil_completo/up2.html
@@ -736,7 +736,7 @@
                 </div>
             </div>
             
-            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('upsell2_chat', 'Chat Exclusivo', 67.90); return false;">QUERO FALAR COM ELA AGORA!</a>
+            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('upsell2_chat', 'Chat Exclusivo', 67.90);">QUERO FALAR COM ELA AGORA!</a>
             
             <!-- Botão para recusar e ir para back1 -->
             <div style="text-align: center; margin-top: 20px;">
@@ -902,6 +902,9 @@
         // Função para gerar PIX e mostrar pop-up
         async function gerarPixPlano(planoId, planoNome, planoValor) {
             try {
+                if (window.PixelTracker) {
+                    window.PixelTracker.trackInitiateCheckout(planoValor, planoNome);
+                }
                 // Mostrar loading
                 Swal.fire({
                     title: 'Gerando PIX...',

--- a/checkout/funil_completo/up3.html
+++ b/checkout/funil_completo/up3.html
@@ -736,7 +736,7 @@
                 </div>
             </div>
             
-            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('upsell3_whatsapp', 'WhatsApp Exclusivo', 47.90); return false;">QUERO O WHATSAPP!</a>
+            <a id="buy-button" class="btn-upsell" href="#" onclick="gerarPixPlano('upsell3_whatsapp', 'WhatsApp Exclusivo', 47.90);">QUERO O WHATSAPP!</a>
             
             <!-- Botão para recusar e ir para back2 -->
             <div style="text-align: center; margin-top: 20px;">
@@ -902,6 +902,9 @@
         // Função para gerar PIX e mostrar pop-up
         async function gerarPixPlano(planoId, planoNome, planoValor) {
             try {
+                if (window.PixelTracker) {
+                    window.PixelTracker.trackInitiateCheckout(planoValor, planoNome);
+                }
                 // Mostrar loading
                 Swal.fire({
                     title: 'Gerando PIX...',


### PR DESCRIPTION
## Summary
- add PixelTracker `trackInitiateCheckout` calls before PIX modal generation
- allow funnel buttons to invoke `gerarPixPlano` without `return false`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/-HotBotWebV2/test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bb80a71420832aba11aa7e3fa90928