### PR TITLE
Normalize CAPI event payload and user data handling

### DIFF
--- a/checkout/js/pixel-init.js
+++ b/checkout/js/pixel-init.js
@@ -169,26 +169,37 @@
   async function sendToCAPI(eventName, eventData) {
     try {
       // Coletar dados de contexto
-      const contextData = {
-        event_name: eventName,
-        event_time: Math.floor(Date.now() / 1000),
-        event_id: eventData.eventID,
-        event_source_url: window.location.href,
-        value: eventData.value,
-        currency: eventData.currency || 'BRL',
-        fbp: localStorage.getItem('fbp') || getCookie('_fbp'),
-        fbc: localStorage.getItem('fbc') || getCookie('_fbc'),
-        client_ip_address: localStorage.getItem('client_ip_address'),
-        client_user_agent: navigator.userAgent,
-        custom_data: eventData
-      };
+      const event_name = eventName;
+      const event_time = Math.floor(Date.now() / 1000);
+      const event_id = eventData.eventID;
+      const event_source_url = window.location.href;
+      const value = eventData.value;
+      const currency = eventData.currency || 'BRL';
+      const fbp = localStorage.getItem('fbp') || getCookie('_fbp');
+      const fbc = localStorage.getItem('fbc') || getCookie('_fbc');
+      const client_ip_address = localStorage.getItem('client_ip_address');
+      const client_user_agent = navigator.userAgent;
 
       const response = await fetch('/capi', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify(contextData)
+        body: JSON.stringify({
+          event_name,
+          event_time,
+          event_id,
+          event_source_url,
+          value,
+          currency,
+          user_data: {
+            fbp,
+            fbc,
+            ip_address: client_ip_address,
+            user_agent: client_user_agent
+          },
+          custom_data: eventData
+        })
       });
 
       if (response.ok) {

--- a/server.js
+++ b/server.js
@@ -1254,15 +1254,26 @@ app.post('/capi', async (req, res) => {
       });
     }
 
-    const { 
-      event_name, 
-      event_time, 
-      event_source_url, 
-      value, 
+    const {
+      event_name,
+      event_time,
+      event_source_url,
+      value,
       currency = 'BRL',
       event_id,
-      user_data 
+      user_data,
+      fbp,
+      fbc,
+      client_ip_address,
+      client_user_agent
     } = req.body;
+
+    const normalizedUserData = user_data || {
+      fbp,
+      fbc,
+      ip_address: client_ip_address,
+      user_agent: client_user_agent
+    };
 
     // Construir payload para Facebook CAPI
     const eventData = {
@@ -1272,10 +1283,10 @@ app.post('/capi', async (req, res) => {
       action_source: 'website',
       event_id,
       user_data: {
-        client_ip_address: user_data.ip_address || req.ip,
-        client_user_agent: user_data.user_agent || req.get('User-Agent'),
-        fbc: user_data.fbc,
-        fbp: user_data.fbp
+        client_ip_address: normalizedUserData.ip_address || req.ip,
+        client_user_agent: normalizedUserData.user_agent || req.get('User-Agent'),
+        fbc: normalizedUserData.fbc,
+        fbp: normalizedUserData.fbp
       }
     };
 


### PR DESCRIPTION
## Summary
- Nest user data into `sendToCAPI` payload with fbp/fbc and client info
- Build server-side user_data from loose fields when missing

## Testing
- `npm test` *(fails: Cannot find module 'test-database.js')*
- `FB_PIXEL_ID=123 FB_PIXEL_TOKEN=abc DATABASE_URL=postgres://user:pass@localhost/db node server.js` *(fails: credentials.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb81db136c832a9c0b459227d4a0a7