### PR TITLE
Allow configuring Facebook test event code

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# Example environment configuration
+# Facebook test event code
+FB_TEST_EVENT_CODE=TEST12345
+

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -347,7 +347,7 @@ async function sendFacebookEvent({
 
   const payload = {
     data: [eventPayload],
-    test_event_code: 'TEST11543'
+    ...(process.env.FORCE_FB_TEST_MODE === 'true' && { test_event_code: process.env.FB_TEST_EVENT_CODE })
   };
 
   // 🔥 MELHORIA 3: Implementar Logs de Comparação Detalhados para Auditoria


### PR DESCRIPTION
## Summary
- Make Facebook CAPI test event code configurable through env vars
- Document FB_TEST_EVENT_CODE in example environment file

## Testing
- `npm test` *(fails: Cannot find module '/workspace/-HotBotWebV2/test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bb82ca265c832ab3793f557ae5c549