### PR TITLE
Fix SQLite boolean binding error when inserting token

### DIFF
--- a/server.js
+++ b/server.js
@@ -2736,7 +2736,7 @@ app.post('/api/gerar-pix-checkout', async (req, res) => {
           'checkout_web', // telegram_id (identificador para checkout web)
           valorFinal, // valor
           'pendente', // status
-          false, // usado
+          0, // usado
           'checkout_web', // bot_id
           trackingData.utm_source,
           trackingData.utm_medium,


### PR DESCRIPTION
## Summary
- ensure tokens insertion uses numeric flag instead of boolean

## Testing
- `npm test` *(fails: Cannot find module '/workspace/-HotBotWebV2/test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bcc4234d54832a83e93cfb08e04447