### PR TITLE
Debug pix generation after page refresh

### DIFF
--- a/checkout/funil_completo/back1.html
+++ b/checkout/funil_completo/back1.html
@@ -1191,6 +1191,11 @@
                             pollingInterval = null;
                         }
                         
+                        // 🎯 NOVO: Disparar evento Purchase do Facebook Pixel
+                        if (window.trackBacksellPurchase) {
+                            window.trackBacksellPurchase(transactionId, 9.90, 'Vídeos Personalizados - ÚLTIMA CHANCE');
+                        }
+                        
                         // Fechar modal e redirecionar
                         Swal.close();
                         
@@ -1331,29 +1336,61 @@
         }, 4000);
         
         // 3. InitiateCheckout - Modificar função gerarPixPlano existente
-        const originalGerarPixPlano = window.gerarPixPlano;
-        window.gerarPixPlano = function(planoId, planoNome, planoValor) {
-            console.log('📊 [BACKSELL-1] Iniciando checkout - disparando InitiateCheckout');
-            
-            // Disparar evento InitiateCheckout antes de gerar o PIX
-            if (window.FacebookEvents) {
-                const result = window.FacebookEvents.trackInitiateCheckout(
-                    planoValor, 
-                    'BRL', 
-                    planoNome, 
-                    'Backsell'
-                );
-                
-                if (result.success) {
-                    console.log('📊 [BACKSELL-1] ✅ InitiateCheckout enviado com sucesso');
-                } else {
-                    console.error('📊 [BACKSELL-1] ❌ Erro no InitiateCheckout:', result.error);
-                }
+        // Aguardar a função gerarPixPlano estar disponível antes de capturá-la
+        function setupGerarPixPlanoWrapper() {
+            // Verificar se a função original existe
+            if (typeof window.gerarPixPlano !== 'function') {
+                console.warn('📊 [BACKSELL-1] Função gerarPixPlano ainda não está disponível, tentando novamente...');
+                // Tentar novamente após um pequeno delay
+                setTimeout(setupGerarPixPlanoWrapper, 100);
+                return;
             }
             
-            // Chamar função original
-            return originalGerarPixPlano.call(this, planoId, planoNome, planoValor);
-        };
+            const originalGerarPixPlano = window.gerarPixPlano;
+            window.gerarPixPlano = function(planoId, planoNome, planoValor) {
+                console.log('📊 [BACKSELL-1] Iniciando checkout - disparando InitiateCheckout');
+                
+                // Disparar evento InitiateCheckout antes de gerar o PIX
+                if (window.FacebookEvents) {
+                    const result = window.FacebookEvents.trackInitiateCheckout(
+                        planoValor, 
+                        'BRL', 
+                        planoNome, 
+                        'Backsell'
+                    );
+                    
+                    if (result.success) {
+                        console.log('📊 [BACKSELL-1] ✅ InitiateCheckout enviado com sucesso');
+                    } else {
+                        console.error('📊 [BACKSELL-1] ❌ Erro no InitiateCheckout:', result.error);
+                    }
+                }
+                
+                // Chamar função original com verificação de segurança
+                if (typeof originalGerarPixPlano === 'function') {
+                    return originalGerarPixPlano.call(this, planoId, planoNome, planoValor);
+                } else {
+                    console.error('📊 [BACKSELL-1] ❌ Função original gerarPixPlano não está disponível');
+                    // Fallback: tentar chamar diretamente se ainda existir
+                    if (typeof window.gerarPixPlano === 'function') {
+                        return window.gerarPixPlano.call(this, planoId, planoNome, planoValor);
+                    }
+                }
+            };
+            
+            console.log('📊 [BACKSELL-1] ✅ Wrapper do gerarPixPlano configurado com sucesso');
+        }
+        
+        // Iniciar o setup do wrapper
+        setupGerarPixPlanoWrapper();
+        
+        // Fallback: Se após 5 segundos o wrapper não foi configurado, configurar diretamente
+        setTimeout(() => {
+            if (typeof window.gerarPixPlano === 'function' && !window.gerarPixPlano.toString().includes('InitiateCheckout')) {
+                console.warn('📊 [BACKSELL-1] ⚠️ Wrapper não foi configurado automaticamente, configurando fallback...');
+                setupGerarPixPlanoWrapper();
+            }
+        }, 5000);
         
         // 4. Purchase - Será disparado quando pagamento for confirmado via polling
         // Integrar com sistema de polling existente


### PR DESCRIPTION
Fix `TypeError` in `gerarPixPlano` after page refresh by ensuring the function wrapper is set up only after the original function is defined.

The `TypeError: Cannot read properties of undefined (reading 'call')` occurred because the `originalGerarPixPlano` variable was assigned `undefined` if the tracking script executed before `window.gerarPixPlano` was defined. This PR introduces a retry mechanism to safely wrap the function and adds a fallback to ensure robustness against script loading order, preventing the error on subsequent calls. It also enhances purchase tracking integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b8b3d7e-40c0-4efe-9170-67f67642cbff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b8b3d7e-40c0-4efe-9170-67f67642cbff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

