### PR TITLE
Corrigir erro de geração de PIX após refresh em back1

### DIFF
--- a/checkout/funil_completo/back1.html
+++ b/checkout/funil_completo/back1.html
@@ -889,7 +889,7 @@
         const maxPollingAttempts = 60; // 5 minutos (5s * 60)
         
         // Função para gerar PIX e mostrar pop-up
-        window.gerarPixPlano = async function(planoId, planoNome, planoValor) {
+        async function gerarPixPlano(planoId, planoNome, planoValor) {
             try {
                 // Mostrar loading
                 Swal.fire({
@@ -1151,6 +1151,81 @@
             }
         }
 
+        // Atribuir função ao window para compatibilidade com onclick
+        window.gerarPixPlano = gerarPixPlano;
+
+        // 📊 FACEBOOK PIXEL EVENTS - BACKSELL 1
+        
+        // 1. PageView - Disparado quando a página carrega completamente
+        window.addEventListener('load', function() {
+            console.log('📊 [BACKSELL-1] Página carregada - disparando PageView');
+            if (window.FacebookEvents) {
+                window.FacebookEvents.trackPageView();
+            }
+        });
+        
+        // 2. ViewContent - Disparado após 4 segundos na página
+        setTimeout(function() {
+            console.log('📊 [BACKSELL-1] 4 segundos na página - disparando ViewContent');
+            if (window.FacebookEvents) {
+                // Valor do backsell 1: R$ 9,90
+                const valorViewContent = 9.90;
+                window.FacebookEvents.trackViewContent(valorViewContent, 'Backsell 1 - Última Chance', 'Backsell');
+            }
+        }, 4000);
+        
+        // 3. InitiateCheckout - Modificar função gerarPixPlano existente
+        const originalGerarPixPlano = window.gerarPixPlano;
+        window.gerarPixPlano = function(planoId, planoNome, planoValor) {
+            console.log('📊 [BACKSELL-1] Iniciando checkout - disparando InitiateCheckout');
+            
+            // Disparar evento InitiateCheckout antes de gerar o PIX
+            if (window.FacebookEvents) {
+                const result = window.FacebookEvents.trackInitiateCheckout(
+                    planoValor, 
+                    'BRL', 
+                    planoNome, 
+                    'Backsell'
+                );
+                
+                if (result.success) {
+                    console.log('📊 [BACKSELL-1] ✅ InitiateCheckout enviado com sucesso');
+                } else {
+                    console.error('📊 [BACKSELL-1] ❌ Erro no InitiateCheckout:', result.error);
+                }
+            }
+            
+            // Chamar função original
+            return originalGerarPixPlano.call(this, planoId, planoNome, planoValor);
+        };
+        
+        // 4. Purchase - Será disparado quando pagamento for confirmado via polling
+        // Integrar com sistema de polling existente
+        window.trackBacksellPurchase = function(transactionId, valor, nomeProduto) {
+            console.log('📊 [BACKSELL-1] Pagamento confirmado - disparando Purchase');
+            
+            if (window.FacebookEvents) {
+                const result = window.FacebookEvents.trackPurchase(
+                    transactionId,
+                    valor,
+                    'BRL',
+                    nomeProduto
+                );
+                
+                if (result.success) {
+                    console.log('📊 [BACKSELL-1] ✅ Purchase enviado com sucesso');
+                } else {
+                    console.error('📊 [BACKSELL-1] ❌ Erro no Purchase:', result.error);
+                }
+                
+                return result;
+            }
+            
+            return { success: false, error: 'FacebookEvents não disponível' };
+        };
+        
+        console.log('📊 [BACKSELL-1] Sistema de eventos Facebook Pixel configurado');
+
         // Função para copiar código PIX
         window.copiarPixCola = function(codigo) {
             navigator.clipboard.writeText(codigo).then(function() {
@@ -1309,79 +1384,6 @@
     <!-- 📊 Facebook Pixel Events -->
     <script src="../js/facebook-events.js"></script>
     
-    <script>
-        // 📊 FACEBOOK PIXEL EVENTS - BACKSELL 1
-        
-        // 1. PageView - Disparado quando a página carrega completamente
-        window.addEventListener('load', function() {
-            console.log('📊 [BACKSELL-1] Página carregada - disparando PageView');
-            if (window.FacebookEvents) {
-                window.FacebookEvents.trackPageView();
-            }
-        });
-        
-        // 2. ViewContent - Disparado após 4 segundos na página
-        setTimeout(function() {
-            console.log('📊 [BACKSELL-1] 4 segundos na página - disparando ViewContent');
-            if (window.FacebookEvents) {
-                // Valor do backsell 1: R$ 9,90
-                const valorViewContent = 9.90;
-                window.FacebookEvents.trackViewContent(valorViewContent, 'Backsell 1 - Última Chance', 'Backsell');
-            }
-        }, 4000);
-        
-        // 3. InitiateCheckout - Modificar função gerarPixPlano existente
-        const originalGerarPixPlano = window.gerarPixPlano;
-        window.gerarPixPlano = function(planoId, planoNome, planoValor) {
-            console.log('📊 [BACKSELL-1] Iniciando checkout - disparando InitiateCheckout');
-            
-            // Disparar evento InitiateCheckout antes de gerar o PIX
-            if (window.FacebookEvents) {
-                const result = window.FacebookEvents.trackInitiateCheckout(
-                    planoValor, 
-                    'BRL', 
-                    planoNome, 
-                    'Backsell'
-                );
-                
-                if (result.success) {
-                    console.log('📊 [BACKSELL-1] ✅ InitiateCheckout enviado com sucesso');
-                } else {
-                    console.error('📊 [BACKSELL-1] ❌ Erro no InitiateCheckout:', result.error);
-                }
-            }
-            
-            // Chamar função original
-            return originalGerarPixPlano.call(this, planoId, planoNome, planoValor);
-        };
-        
-        // 4. Purchase - Será disparado quando pagamento for confirmado via polling
-        // Integrar com sistema de polling existente
-        window.trackBacksellPurchase = function(transactionId, valor, nomeProduto) {
-            console.log('📊 [BACKSELL-1] Pagamento confirmado - disparando Purchase');
-            
-            if (window.FacebookEvents) {
-                const result = window.FacebookEvents.trackPurchase(
-                    transactionId,
-                    valor,
-                    'BRL',
-                    nomeProduto
-                );
-                
-                if (result.success) {
-                    console.log('📊 [BACKSELL-1] ✅ Purchase enviado com sucesso');
-                } else {
-                    console.error('📊 [BACKSELL-1] ❌ Erro no Purchase:', result.error);
-                }
-                
-                return result;
-            }
-            
-            return { success: false, error: 'FacebookEvents não disponível' };
-        };
-        
-        console.log('📊 [BACKSELL-1] Sistema de eventos Facebook Pixel configurado');
-    </script>
 </body>
 
 <!-- Mirrored from privasimaria.site/app/up1.html by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 21 Mar 2025 23:19:22 GMT -->


### PR DESCRIPTION
Fix `gerarPixPlano` undefined error on `back1.html` after refresh by reordering function definition and Facebook Pixel script.

The `TypeError` occurred because `window.gerarPixPlano` was being captured as `undefined` by the Facebook Pixel script after a page refresh. The changes ensure the base `gerarPixPlano` function is fully defined and assigned to `window` before the Facebook Pixel script attempts to wrap it, resolving the error on page reloads.

---
<a href="https://cursor.com/background-agent?bcId=bc-8de61330-c657-4fa0-8244-644f79f638df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8de61330-c657-4fa0-8244-644f79f638df">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

