### PR TITLE
Centralize funnel redirects and fix BACK1 decline bug

### DIFF
--- a/checkout/funil_completo/back1.html
+++ b/checkout/funil_completo/back1.html
@@ -7,6 +7,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Oferta Especial</title>
+    <script src="flow.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
     <style>
@@ -736,7 +737,7 @@
             
             <!-- Botão para recusar e ir para obrigado -->
             <div style="text-align: center; margin-top: 20px;">
-                <a href="../obrigado.html" class="btn-decline" onclick="preserveTrackingParams(this); console.log('Botão recusar clicado, redirecionando para obrigado.html');">Recusar essa oferta</a>
+                <a href="#" class="btn-decline" onclick="goToNextOnDecline('back1', 'btnDeclineClick'); return false;">Recusar essa oferta</a>
             </div>
             
             <div class="guarantee-section">
@@ -898,7 +899,7 @@ console.log('🔧 [GLOBAL] Função gerarPixPlano temporária registrada');
             clearInterval(countdownInterval); // Para o contador
             // Preservar parâmetros de tracking
             const urlParams = new URLSearchParams(window.location.search);
-            window.location.href = '../obrigado.html?' + urlParams.toString(); // Redireciona para obrigado
+            goToNextOnDecline('back1', 'timeout');
             return; // Sai da função
         }
 
@@ -1305,7 +1306,7 @@ console.log('🔧 [GLOBAL] Função gerarPixPlano temporária registrada');
                         }).then(() => {
                             // Redirecionar para up2.html após compra
                             const urlParams = new URLSearchParams(window.location.search);
-                            window.location.href = 'up2.html?' + urlParams.toString();
+                            goToNextOnPurchase('back1', 'pollingApproved');
                         });
                         
                         return;

--- a/checkout/funil_completo/back2.html
+++ b/checkout/funil_completo/back2.html
@@ -7,6 +7,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Oferta Especial</title>
+    <script src="flow.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
     <style>
@@ -740,7 +741,7 @@
             
             <!-- Botão para recusar e ir para obrigado -->  
             <div style="text-align: center; margin-top: 20px;">
-                <a href="../obrigado.html" class="btn-decline" onclick="preserveTrackingParams(this)">Recusar essa oferta</a>
+                <a href="#" class="btn-decline" onclick="goToNextOnDecline('back2', 'btnDeclineClick'); return false;">Recusar essa oferta</a>
             </div>
             
             <div class="guarantee-section">
@@ -845,7 +846,7 @@ console.log('🔧 [GLOBAL] Função gerarPixPlano temporária registrada');
             clearInterval(countdownInterval); // Para o contador
             // Preservar parâmetros de tracking
             const urlParams = new URLSearchParams(window.location.search);
-            window.location.href = '../obrigado.html?' + urlParams.toString(); // Redireciona para obrigado
+            goToNextOnDecline('back2', 'timeout');
             return; // Sai da função
         }
 
@@ -1247,7 +1248,7 @@ console.log('🔧 [GLOBAL] Função gerarPixPlano temporária registrada');
                         }).then(() => {
                             // Redirecionar para up3.html após compra
                             const urlParams = new URLSearchParams(window.location.search);
-                            window.location.href = 'up3.html?' + urlParams.toString();
+                            goToNextOnPurchase('back2', 'pollingApproved');
                         });
                         
                         return;

--- a/checkout/funil_completo/back3.html
+++ b/checkout/funil_completo/back3.html
@@ -7,6 +7,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Oferta Especial</title>
+    <script src="flow.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
     <style>
@@ -740,7 +741,7 @@
             
             <!-- Botão para recusar e ir para obrigado -->
             <div style="text-align: center; margin-top: 20px;">
-                <a href="../obrigado.html" class="btn-decline" onclick="preserveTrackingParams(this)">Recusar essa oferta</a>
+                <a href="#" class="btn-decline" onclick="goToNextOnDecline('back3', 'btnDeclineClick'); return false;">Recusar essa oferta</a>
             </div>
             
             <div class="guarantee-section">
@@ -845,7 +846,7 @@ console.log('🔧 [GLOBAL] Função gerarPixPlano temporária registrada');
             clearInterval(countdownInterval); // Para o contador
             // Preservar parâmetros de tracking
             const urlParams = new URLSearchParams(window.location.search);
-            window.location.href = '../obrigado.html?' + urlParams.toString(); // Redireciona para obrigado
+            goToNextOnDecline('back3', 'timeout');
             return; // Sai da função
         }
 
@@ -1247,7 +1248,7 @@ console.log('🔧 [GLOBAL] Função gerarPixPlano temporária registrada');
                         }).then(() => {
                             // Redirecionar para página de agradecimento
                             const urlParams = new URLSearchParams(window.location.search);
-                            window.location.href = '../obrigado.html?' + urlParams.toString();
+                            goToNextOnPurchase('back3', 'pollingApproved');
                         });
                         
                         return;

--- a/checkout/funil_completo/flow.js
+++ b/checkout/funil_completo/flow.js
@@ -1,0 +1,30 @@
+// Centralized flow control for upsell/back pages
+const FLOW_MAP = {
+  up1: { decline: 'back1.html', purchase: 'up2.html' },
+  up2: { decline: 'back2.html', purchase: 'up3.html' },
+  up3: { decline: 'back3.html', purchase: '../obrigado.html' },
+  back1: { decline: '../obrigado.html', purchase: 'up2.html' },
+  back2: { decline: '../obrigado.html', purchase: 'up3.html' },
+  back3: { decline: '../obrigado.html', purchase: '../obrigado.html' }
+};
+
+function withTracking(url) {
+  const params = new URLSearchParams(window.location.search);
+  const query = params.toString();
+  const sep = url.includes('?') ? '&' : '?';
+  return query ? url + sep + query : url;
+}
+
+function goToNextOnDecline(page, origin) {
+  const target = FLOW_MAP[page]?.decline;
+  if (!target) return;
+  console.info(`[FLOW] ${page} decline -> redirect to ${target}`, { origin });
+  window.location.href = withTracking(target);
+}
+
+function goToNextOnPurchase(page, origin) {
+  const target = FLOW_MAP[page]?.purchase;
+  if (!target) return;
+  console.info(`[FLOW] ${page} purchase_confirmed -> redirect to ${target}`, { origin });
+  window.location.href = withTracking(target);
+}

--- a/checkout/funil_completo/up1.html
+++ b/checkout/funil_completo/up1.html
@@ -7,6 +7,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Oferta Especial</title>
+    <script src="flow.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
@@ -747,7 +748,7 @@
             
             <!-- Botão para recusar e ir para back1 -->
             <div style="text-align: center; margin-top: 20px;">
-                <a href="back1.html" class="btn-decline" onclick="preserveTrackingParams(this)">Recusar essa oferta</a>
+                <a href="#" class="btn-decline" onclick="goToNextOnDecline('up1', 'btnDeclineClick'); return false;">Recusar essa oferta</a>
             </div>
             
             <!-- Rodapé -->
@@ -784,7 +785,7 @@
             clearInterval(countdownInterval); // Para o contador
             // Preservar parâmetros de tracking
             const urlParams = new URLSearchParams(window.location.search);
-            window.location.href = 'back1.html?' + urlParams.toString(); // Redireciona para back1
+            goToNextOnDecline('up1', 'timeout');
             return; // Sai da função
         }
 
@@ -906,7 +907,7 @@
                                     }).then(() => {
                                         // Redirecionar para up2 preservando parâmetros
                                         const urlParams = new URLSearchParams(window.location.search);
-                                        window.location.href = 'up2.html?' + urlParams.toString();
+                                        goToNextOnPurchase('up1', 'pollingApproved');
                                     });
                                     
                                     return;
@@ -1248,7 +1249,7 @@
                     clearInterval(countdownInterval); // Para o contador
                     // Preservar parâmetros de tracking
                     const urlParams = new URLSearchParams(window.location.search);
-                    window.location.href = 'back1.html?' + urlParams.toString(); // Redireciona para back1
+                    goToNextOnDecline('up1', 'timeout');
                     return; // Sai da função
                 }
                 
@@ -1358,7 +1359,7 @@
                                     }).then(() => {
                                         // Redirecionar para up2 preservando parâmetros
                                     const urlParams = new URLSearchParams(window.location.search);
-                                    window.location.href = 'up2.html?' + urlParams.toString();
+                                    goToNextOnPurchase('up1', 'pollingApproved');
                                     });
                                     
                                     return;

--- a/checkout/funil_completo/up2.html
+++ b/checkout/funil_completo/up2.html
@@ -7,6 +7,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Oferta Especial</title>
+    <script src="flow.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
     <style>
@@ -747,7 +748,7 @@
             
             <!-- Botão para recusar e ir para back2 -->
             <div style="text-align: center; margin-top: 20px;">
-                <a href="back2.html" class="btn-decline" onclick="preserveTrackingParams(this)">Recusar essa oferta</a>
+                <a href="#" class="btn-decline" onclick="goToNextOnDecline('up2', 'btnDeclineClick'); return false;">Recusar essa oferta</a>
             </div>
             
             <div class="guarantee-section">
@@ -874,7 +875,7 @@
         if (hours === 0 && minutes === 0 && seconds === 0) {
             clearInterval(countdownInterval); // Para o contador
             const urlParams = new URLSearchParams(window.location.search);
-            window.location.href = 'back2.html?' + urlParams.toString(); // Redireciona para back2
+            goToNextOnDecline('up2', 'timeout');
             return; // Sai da função
         }
 
@@ -1240,7 +1241,7 @@
                         }).then(() => {
                             // Redirecionar para up3 preservando parâmetros
                             const urlParams = new URLSearchParams(window.location.search);
-                            window.location.href = 'up3.html?' + urlParams.toString();
+                            goToNextOnPurchase('up2', 'pollingApproved');
                         });
                         
                         return;

--- a/checkout/funil_completo/up3.html
+++ b/checkout/funil_completo/up3.html
@@ -7,6 +7,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Oferta Especial</title>
+    <script src="flow.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
     <style>
@@ -747,7 +748,7 @@
             
             <!-- Botão para recusar e ir para back3 -->
             <div style="text-align: center; margin-top: 20px;">
-                <a href="back3.html" class="btn-decline" onclick="preserveTrackingParams(this)">Recusar essa oferta</a>
+                <a href="#" class="btn-decline" onclick="goToNextOnDecline('up3', 'btnDeclineClick'); return false;">Recusar essa oferta</a>
             </div>
             
             <div class="guarantee-section">
@@ -876,7 +877,7 @@
         if (hours === 0 && minutes === 0 && seconds === 0) {
             clearInterval(countdownInterval); // Para o contador
             const urlParams = new URLSearchParams(window.location.search);
-            window.location.href = 'back3.html?' + urlParams.toString(); // Redireciona para back3
+            goToNextOnDecline('up3', 'timeout');
             return; // Sai da função
         }
 
@@ -1270,7 +1271,7 @@
                         }).then(() => {
                             // Redirecionar para página de obrigado preservando parâmetros
                             const urlParams = new URLSearchParams(window.location.search);
-                            window.location.href = '../obrigado.html?' + urlParams.toString();
+                            goToNextOnPurchase('up3', 'pollingApproved');
                         });
                         
                         return;


### PR DESCRIPTION
## Summary
- add shared `flow.js` to map funnel redirects and add `[FLOW]` logging
- update upsell/back pages to use central redirect helpers
- ensure BACK1 decline leads to `/checkout/obrigado`

## Testing
- `npm test` *(fails: Cannot find module '/workspace/-HotBotWebV2/test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68c0805a9530832aa9ae39059e738315