### PR TITLE
Propagate webhook URLs for PushinPay PIX flows

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1060,6 +1060,7 @@ async _executarGerarCobranca(req, res) {
         document: finalTrackingData.document || '00000000000'
       },
       description: nomeOferta,
+      callbackUrl: webhookUrl,
       metadata: {
         ...metadata,
         telegram_id: telegram_id,

--- a/server.js
+++ b/server.js
@@ -3543,16 +3543,30 @@ app.post('/api/pix/create', async (req, res) => {
 
     switch (type) {
       case 'bot':
-        const { telegram_id, plano, valor, tracking_data, bot_id } = paymentData;
+        const {
+          telegram_id,
+          plano,
+          valor,
+          tracking_data,
+          bot_id,
+          callback_url,
+          callbackUrl: camelCallbackUrl
+        } = paymentData;
         console.log('🤖 [API PIX] Processando PIX para BOT:', {
           telegram_id,
           plano,
           valor,
           bot_id,
-          tracking_data_keys: Object.keys(tracking_data || {})
+          tracking_data_keys: Object.keys(tracking_data || {}),
+          callback_url: camelCallbackUrl || callback_url || null
         });
         result = await unifiedPixService.createBotPixPayment(
-          telegram_id, plano, valor, tracking_data, bot_id
+          telegram_id,
+          plano,
+          valor,
+          tracking_data,
+          bot_id,
+          { callbackUrl: camelCallbackUrl || callback_url }
         );
         console.log('🤖 [API PIX] Resultado do PIX para BOT:', {
           success: result.success,

--- a/services/pushinpay.js
+++ b/services/pushinpay.js
@@ -133,9 +133,11 @@ class PushinPayService {
         split_rules: []
       };
 
+      const effectiveWebhookUrl = callbackUrl || metadata?.webhook_url;
+
       // Adicionar webhook URL se fornecida (conforme documentação)
-      if (callbackUrl) {
-        payload.webhook_url = callbackUrl;
+      if (effectiveWebhookUrl) {
+        payload.webhook_url = effectiveWebhookUrl;
       }
 
       // NOTA: Dados do cliente e produtos não são suportados no payload do PushinPay
@@ -151,7 +153,8 @@ class PushinPayService {
           amount_centavos: valorCentavos,
           is_amount_in_cents: isAmountInCents,
           products_count: products.length,
-          has_callback: !!callbackUrl,
+          has_callback: !!effectiveWebhookUrl,
+          callback_url_source: callbackUrl ? 'callbackUrl' : (metadata?.webhook_url ? 'metadata.webhook_url' : null),
           client_name: client?.name || 'N/A',
           client_email: client?.email || 'N/A'
         },


### PR DESCRIPTION
## Summary
- derive the PushinPay webhook URL from either `callbackUrl` or `metadata.webhook_url` and log its source
- forward the bot webhook URL into `callbackUrl` plus metadata when creating PIX charges through the unified service and API
- ensure web and special PIX creators also mirror their callback URL into metadata for PushinPay fallback handling

## Testing
- node - <<'NODE' ... (PushinPay payload capture)
- node - <<'NODE' ... (Unified callback propagation)

------
https://chatgpt.com/codex/tasks/task_e_68ccf79f4c6c832aaf70fefe9a788c36