### PR TITLE
Ensure initPostgres returns the connection pool

### DIFF
--- a/init-postgres.js
+++ b/init-postgres.js
@@ -34,6 +34,7 @@ async function initPostgres() {
   `);
   console.log('✅ Tabela payloads verificada no PostgreSQL');
   console.log('✅ Tabela payload_tracking verificada no PostgreSQL');
+  return pool;
 }
 
 module.exports = initPostgres;


### PR DESCRIPTION
## Summary
- return the PostgreSQL connection pool from `initPostgres` so callers receive the initialized instance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce4a055150832a894c50d09b652ae4