### PR TITLE
Ensure init-postgres runs full database initializer

### DIFF
--- a/init-postgres.js
+++ b/init-postgres.js
@@ -1,7 +1,7 @@
-const { createPool } = require('./database/postgres');
+const { initializeDatabase } = require('./database/postgres');
 
 async function initPostgres() {
-  const pool = createPool();
+  const pool = await initializeDatabase();
   await pool.query(`
     CREATE TABLE IF NOT EXISTS payload_tracking (
       payload_id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- invoke `initializeDatabase` when creating the PostgreSQL pool so the tokens table schema (descricao, tipo and timestamps) is enforced before use.

## Testing
- curl -s -X POST http://localhost:3000/api/whatsapp/gerar-token -H 'Content-Type: application/json' -d '{"valor":"123.45","descricao":"Teste"}' -w '\nHTTP %{http_code}\n'
- curl -s http://localhost:3000/api/whatsapp/estatisticas -w '\nHTTP %{http_code}\n'

------
https://chatgpt.com/codex/tasks/task_e_68ce4cafab78832aa682b352aa416711