### PR TITLE
Normalize UTM medium/content before sending conversions to UTMify

### DIFF
--- a/services/utmify.js
+++ b/services/utmify.js
@@ -44,16 +44,22 @@ function processUTMForUtmify(utmValue) {
     if (parts.length >= 2) {
       const name = parts[0].trim();
       const id = parts[1].trim();
-      
+
       // Validar se o ID é numérico
       if (name && id && /^\d+$/.test(id)) {
         const formatted = `${name}|${id}`;
         console.log(`✅ UTM processado para UTMify: "${utmValue}" → nome: "${name}", id: "${id}", formatado: "${formatted}"`);
         return { name, id, formatted };
       }
+
+      const fallbackName = name || decoded;
+      console.log(
+        `ℹ️ UTM sem ID numérico válido para UTMify: "${utmValue}" → usando fallback "${fallbackName}"`
+      );
+      return { name: fallbackName, id: null, formatted: fallbackName };
     }
-    
-    // Se não tem formato nome|id, retorna apenas o nome
+
+    // Se não tem formato nome|id, retorna apenas o nome/valor decodificado
     console.log(`ℹ️ UTM sem formato nome|id para UTMify: "${utmValue}"`);
     return { name: decoded, id: null, formatted: decoded };
     
@@ -119,8 +125,10 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
       src,
       sck,
       utm_source,
-      utm_medium: utm_medium, // Manter original
-      utm_content: utm_content, // Manter original
+      utm_medium:
+        utmMediumProcessed.formatted ?? utm_medium ?? utmMediumProcessed.name,
+      utm_content:
+        utmContentProcessed.formatted ?? utm_content ?? utmContentProcessed.name,
       utm_term,
       // 🔥 CORREÇÃO: Usar utm_campaign no formato nome|id
       utm_campaign: utmCampaignProcessed.formatted


### PR DESCRIPTION
## Summary
- send UTM medium and content to UTMify using the normalized name|id format produced by the existing parser, falling back to the original value when no numeric ID exists
- improve the UTM parsing helper so that the formatted value preserves a human-readable fallback whenever the ID portion is missing or invalid

## Testing
- node - <<'NODE' ... NODE

------
https://chatgpt.com/codex/tasks/task_e_68cf3df48480832a8b912c0541bb30db