### PR TITLE
Sanitize tracking data before partner emissions

### DIFF
--- a/server.js
+++ b/server.js
@@ -1107,17 +1107,25 @@ app.post('/api/gerar-payload', protegerContraFallbacks, async (req, res) => {
     const normalize = (val) => {
       if (typeof val === 'string') {
         const cleaned = val.toLowerCase().trim();
-        return cleaned || 'unknown';
+        return cleaned || null;
       }
-      return 'unknown';
+      if (val === null || val === undefined) {
+        return null;
+      }
+      const coerced = String(val).trim().toLowerCase();
+      return coerced || null;
     };
 
     const normalizePreservingCase = (val) => {
       if (typeof val === 'string') {
         const cleaned = val.trim();
-        return cleaned || 'unknown';
+        return cleaned || null;
       }
-      return 'unknown';
+      if (val === null || val === undefined) {
+        return null;
+      }
+      const coerced = String(val).trim();
+      return coerced || null;
     };
 
     const payloadId = crypto.randomBytes(4).toString('hex');


### PR DESCRIPTION
## Summary
- update payload normalization so blank tracking values persist as NULL
- add tracking sanitization helpers to skip `unknown` placeholders when replaying payloads and emitting events
- clean outbound partner payloads to avoid overriding real UTMs with empty values

## Testing
- npm test *(fails: cannot find test-database.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cf406fecc4832ab2353e8dcc1f1fbc