### PR TITLE
Atualiza envio de conversões ao UTMify no webhook da Oasyfy

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1703,13 +1703,28 @@ async _executarGerarCobranca(req, res) {
 
         // UTMify
         if (trackingData.utm_source) {
-          await enviarConversaoParaUtmify({
-            transaction_id: transactionId,
-            valor: row.valor / 100,
-            gateway: 'oasyfy',
-            source: 'telegram_bot',
-            ...trackingData
-          });
+          const transactionValueRaw = typeof row.valor === 'number' ? row.valor : Number(row.valor);
+          const transactionValueCents = Number.isFinite(transactionValueRaw)
+            ? Math.round(transactionValueRaw)
+            : 0;
+
+          if (!Number.isFinite(transactionValueRaw)) {
+            console.warn(`[${this.botId}] ⚠️ Valor inválido para transactionValueCents ao enviar para UTMify`, {
+              valorOriginal: row.valor
+            });
+          }
+
+          const utmifyPayload = {
+            payer_name: transaction?.client?.name || null,
+            telegram_id: row.telegram_id,
+            transactionValueCents,
+            trackingData,
+            orderId: transactionId,
+            nomeOferta: row.nome_oferta || 'Oferta Desconhecida'
+          };
+
+          console.log(`[${this.botId}] 📨 Dados de conversão para UTMify`, utmifyPayload);
+          await enviarConversaoParaUtmify(utmifyPayload);
           console.log(`[${this.botId}] 📊 Conversão enviada para UTMify`);
         }
 


### PR DESCRIPTION
## Summary
- ajusta o webhook da Oasyfy para montar o payload do UTMify com os campos esperados
- garante que o valor enviado permaneça em centavos e registra os dados antes da chamada externa

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf45c24054832a833692e8de60b9fd