### PR TITLE
Allow null dedup values and add migration

### DIFF
--- a/create-purchase-dedup-table.js
+++ b/create-purchase-dedup-table.js
@@ -21,7 +21,7 @@ async function createPurchaseDedupTable() {
         event_id VARCHAR(64) UNIQUE NOT NULL,
         transaction_id VARCHAR(255) NOT NULL,
         event_name VARCHAR(50) NOT NULL DEFAULT 'Purchase',
-        value DECIMAL(10,2) NOT NULL,
+        value DECIMAL(10,2),
         currency VARCHAR(3) NOT NULL DEFAULT 'BRL',
         source VARCHAR(20) NOT NULL, -- 'pixel' ou 'capi'
         fbp VARCHAR(255),

--- a/init-postgres.js
+++ b/init-postgres.js
@@ -1,7 +1,9 @@
 const { initializeDatabase } = require('./database/postgres');
+const { makeValueColumnNullable } = require('./make-purchase-dedup-value-nullable');
 
 async function initPostgres() {
   const pool = await initializeDatabase();
+  await makeValueColumnNullable(pool);
   await pool.query(`
     CREATE TABLE IF NOT EXISTS payload_tracking (
       payload_id TEXT PRIMARY KEY,

--- a/make-purchase-dedup-value-nullable.js
+++ b/make-purchase-dedup-value-nullable.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * Migration script to allow NULL values in purchase_event_dedup.value
+ *
+ * Usage: node make-purchase-dedup-value-nullable.js
+ */
+
+const { Pool } = require('pg');
+require('dotenv').config();
+
+function createPool() {
+  return new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+  });
+}
+
+async function makeValueColumnNullable(externalPool = null) {
+  const pool = externalPool || createPool();
+  console.log('🔄 Ajustando coluna value em purchase_event_dedup para aceitar NULL...');
+
+  const checkQuery = `
+    SELECT is_nullable
+    FROM information_schema.columns
+    WHERE table_name = 'purchase_event_dedup' AND column_name = 'value'
+  `;
+
+  try {
+    const result = await pool.query(checkQuery);
+
+    if (result.rowCount === 0) {
+      console.log('ℹ️ Tabela purchase_event_dedup ou coluna value não encontrada. Nenhuma alteração realizada.');
+      return;
+    }
+
+    const isNullable = result.rows[0].is_nullable === 'YES';
+    if (isNullable) {
+      console.log('✅ Coluna value já aceita NULL. Nada a fazer.');
+      return;
+    }
+
+    await pool.query('ALTER TABLE purchase_event_dedup ALTER COLUMN value DROP NOT NULL;');
+    console.log('✅ Coluna value agora aceita valores NULL.');
+  } catch (error) {
+    console.error('❌ Erro ao atualizar coluna value:', error);
+    throw error;
+  } finally {
+    if (!externalPool) {
+      await pool.end();
+    }
+  }
+}
+
+if (require.main === module) {
+  makeValueColumnNullable()
+    .then(() => {
+      console.log('🎉 Migração concluída com sucesso!');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('❌ Migração falhou:', error.message);
+      process.exit(1);
+    });
+}
+
+module.exports = { makeValueColumnNullable };

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -431,12 +431,14 @@ async function sendFacebookEvent({
     console.log(`✅ Evento ${event_name} enviado com sucesso via ${source.toUpperCase()}:`, res.data);
 
     // 🔥 REGISTRAR TODOS OS EVENTOS NO SISTEMA DE DEDUPLICAÇÃO ROBUSTO
+    const dedupValueForDatabase = finalValue ?? null;
+
     try {
       await markEventAsSent({
         event_id: finalEventId,
         transaction_id: token || 'unknown',
         event_name: event_name,
-        value: finalValue,
+        value: dedupValueForDatabase,
         currency: currency,
         source: source,
         fbp: finalFbp,

--- a/services/purchaseDedup.js
+++ b/services/purchaseDedup.js
@@ -167,11 +167,16 @@ async function registerEventInDatabase(eventData) {
       RETURNING id
     `;
     
+    const sanitizedValue =
+      value === null || value === undefined || (typeof value === 'number' && Number.isNaN(value))
+        ? null
+        : value;
+
     const values = [
       event_id,
       transaction_id,
       event_name,
-      value,
+      sanitizedValue,
       currency,
       source,
       fbp,


### PR DESCRIPTION
## Summary
- allow the purchase_event_dedup.value column to be nullable when creating the table
- add a reusable migration that drops the NOT NULL constraint during production startup
- sanitize dedup value handling so null amounts propagate through purchaseDedup and facebook services

## Testing
- npm test *(fails: test-database.js is missing in the repository)*
- curl -X POST http://localhost:3100/api/capi/viewcontent ... *(with axios mocked to bypass external calls; confirmed dedup insert without constraint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68cf4e669ca8832abea3f38914a88be9