### PR TITLE
Map webhook source to capi flag

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -479,8 +479,9 @@ async function updateEventFlags(pool, token, source) {
     // WHITELIST DE COLUNAS VÁLIDAS PARA PREVENIR SQL INJECTION
     const validFlagColumns = {
       'pixel': 'pixel_sent',
-      'capi': 'capi_sent', 
-      'cron': 'cron_sent'
+      'capi': 'capi_sent',
+      'cron': 'cron_sent',
+      'webhook': 'capi_sent'
     };
 
     // Validar se a fonte é permitida
@@ -503,7 +504,7 @@ async function updateEventFlags(pool, token, source) {
     
     await pool.query(query, [token, now]);
     
-    console.log(`🏷️ Flag ${flagColumn} atualizada para token ${token}`);
+    console.log(`🏷️ Flag ${flagColumn} (${source}) atualizada para token ${token}`);
   } catch (error) {
     console.error('Erro ao atualizar flags de evento:', error);
   }


### PR DESCRIPTION
## Summary
- allow webhook-sourced purchases to reuse the capi_sent flag in the safe column whitelist
- extend logging to include the event source for clearer auditing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf514e0eac832a8be1d8fe16bd3a7c