### PR TITLE
Handle explicit amount units for PushinPay

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -1124,6 +1124,7 @@ async _executarGerarCobranca(req, res) {
     const paymentData = {
       identifier: `telegram_${telegram_id}_${Date.now()}`,
       amount: valorCentavos / 100, // Converter centavos para reais
+      amount_unit: 'reais',
       client: {
         name: finalTrackingData.name || `Telegram User ${telegram_id}`,
         email: finalTrackingData.email || `${telegram_id}@telegram.local`,

--- a/exemplo_uso_gateway_pix.js
+++ b/exemplo_uso_gateway_pix.js
@@ -1,8 +1,12 @@
 /**
  * EXEMPLO DE USO DO SISTEMA DE GATEWAY PIX
- * 
+ *
  * Este arquivo demonstra como usar o sistema unificado de PIX
  * para alternar entre PushinPay e Oasyfy
+ *
+ * IMPORTANTE: quando precisar enviar o campo `amount` diretamente em centavos
+ * (por exemplo, `amount: 1990`), inclua também `amount_unit: 'cents'`
+ * para informar explicitamente a unidade do valor ao backend.
  */
 
 const axios = require('axios');
@@ -97,6 +101,7 @@ async function criarPixBot() {
         nome: 'Plano 1 Mês'
       },
       valor: 19.90,
+      amount_unit: 'reais',
       tracking_data: {
         utm_source: 'telegram',
         utm_campaign: 'lancamento',
@@ -132,6 +137,7 @@ async function criarPixWeb() {
       type: 'web',
       plano_id: 'plano_3_meses',
       valor: 41.90,
+      amount_unit: 'reais',
       client_data: {
         name: 'João Silva',
         email: 'joao@email.com',
@@ -170,6 +176,7 @@ async function criarPixEspecial() {
     const response = await axios.post(`${API_BASE}/api/pix/create`, {
       type: 'special',
       valor: 100,
+      amount_unit: 'reais',
       metadata: {
         source: 'obrigado_especial',
         test: true

--- a/server.js
+++ b/server.js
@@ -3698,6 +3698,13 @@ app.post('/api/pix/create', async (req, res) => {
           callback_url,
           callbackUrl: camelCallbackUrl
         } = paymentData;
+
+        const amountUnit = paymentData.amount_unit || paymentData.amountUnit || null;
+        const amountInCentsFlag = [
+          paymentData.isAmountInCents,
+          paymentData.amountInCents,
+          paymentData.amount_is_in_cents
+        ].find(value => typeof value === 'boolean');
         console.log('🤖 [API PIX] Processando PIX para BOT:', {
           telegram_id,
           plano,
@@ -3712,7 +3719,12 @@ app.post('/api/pix/create', async (req, res) => {
           valor,
           tracking_data,
           bot_id,
-          { callbackUrl: camelCallbackUrl || callback_url }
+          {
+            callbackUrl: camelCallbackUrl || callback_url,
+            amountUnit,
+            amount_unit: amountUnit,
+            isAmountInCents: amountInCentsFlag
+          }
         );
         console.log('🤖 [API PIX] Resultado do PIX para BOT:', {
           success: result.success,
@@ -3724,6 +3736,12 @@ app.post('/api/pix/create', async (req, res) => {
         
       case 'web':
         const { plano_id, valor: webValor, client_data, tracking_data: webTracking } = paymentData;
+        const webAmountUnit = paymentData.amount_unit || paymentData.amountUnit || null;
+        const webAmountInCentsFlag = [
+          paymentData.isAmountInCents,
+          paymentData.amountInCents,
+          paymentData.amount_is_in_cents
+        ].find(value => typeof value === 'boolean');
         console.log('🌐 [API PIX] Processando PIX para WEB:', {
           plano_id,
           valor: webValor,
@@ -3731,7 +3749,15 @@ app.post('/api/pix/create', async (req, res) => {
           tracking_data_keys: Object.keys(webTracking || {})
         });
         result = await unifiedPixService.createWebPixPayment(
-          plano_id, webValor, client_data, webTracking
+          plano_id,
+          webValor,
+          client_data,
+          webTracking,
+          {
+            amountUnit: webAmountUnit,
+            amount_unit: webAmountUnit,
+            isAmountInCents: webAmountInCentsFlag
+          }
         );
         console.log('🌐 [API PIX] Resultado do PIX para WEB:', {
           success: result.success,
@@ -3743,7 +3769,17 @@ app.post('/api/pix/create', async (req, res) => {
         
       case 'special':
         const { valor: specialValor = 100, metadata } = paymentData;
-        result = await unifiedPixService.createSpecialPixPayment(specialValor, metadata);
+        const specialAmountUnit = paymentData.amount_unit || paymentData.amountUnit || null;
+        const specialAmountFlag = [
+          paymentData.isAmountInCents,
+          paymentData.amountInCents,
+          paymentData.amount_is_in_cents
+        ].find(value => typeof value === 'boolean');
+        result = await unifiedPixService.createSpecialPixPayment(specialValor, metadata, {
+          amountUnit: specialAmountUnit,
+          amount_unit: specialAmountUnit,
+          isAmountInCents: specialAmountFlag
+        });
         break;
         
       default:

--- a/services/oasyfy.js
+++ b/services/oasyfy.js
@@ -36,25 +36,78 @@ class CurrencyUtils {
    * @param {number} amount - Valor a ser analisado
    * @returns {boolean} True se provavelmente está em centavos
    */
-  static isLikelyInCents(amount) {
-    // Heurística melhorada:
-    // 1. Valores >= 5000 (R$ 50,00) provavelmente em centavos
-    // 2. Valores com casas decimais > 2 provavelmente em reais
-    // 3. Valores entre 100-4999 são ambíguos, assumir reais por segurança
-    
-    if (amount >= 5000) {
-      return true; // Provavelmente centavos (R$ 50+)
+  static isLikelyInCents(amount, options = {}) {
+    const { explicitHint } = options || {};
+
+    if (typeof explicitHint === 'boolean') {
+      return explicitHint;
     }
-    
-    // Verificar casas decimais
-    const decimalPlaces = (amount.toString().split('.')[1] || '').length;
+
+    const normalizedAmount =
+      typeof amount === 'string' && amount.trim() !== ''
+        ? Number(amount)
+        : amount;
+
+    if (typeof normalizedAmount !== 'number' || Number.isNaN(normalizedAmount) || !Number.isFinite(normalizedAmount)) {
+      return false;
+    }
+
+    if (Math.abs(normalizedAmount) >= 5000) {
+      return true;
+    }
+
+    const decimalPlaces = (normalizedAmount.toString().split('.')[1] || '').length;
     if (decimalPlaces > 2) {
-      return false; // Mais de 2 decimais = provavelmente reais
+      return false;
     }
-    
-    // Valores baixos assumir como reais por segurança
+
     return false;
   }
+}
+
+/**
+ * Resolve sinalizações explícitas sobre a unidade do valor
+ *
+ * @param {Object} paymentData
+ * @returns {{ explicitHint: boolean | undefined, source: string | null, normalizedUnit: string | null }}
+ */
+function resolveAmountHint(paymentData = {}) {
+  if (!paymentData || typeof paymentData !== 'object') {
+    return { explicitHint: undefined, source: null, normalizedUnit: null };
+  }
+
+  const booleanKeys = ['isAmountInCents', 'amountInCents', 'amount_is_in_cents'];
+  for (const key of booleanKeys) {
+    if (typeof paymentData[key] === 'boolean') {
+      return { explicitHint: paymentData[key], source: key, normalizedUnit: null };
+    }
+  }
+
+  const unitCandidates = [
+    paymentData.amount_unit,
+    paymentData.amountUnit,
+    paymentData.amount_format,
+    paymentData.amountFormat,
+    paymentData.unit,
+    paymentData.metadata?.amount_unit,
+    paymentData.metadata?.amountUnit
+  ].filter(value => typeof value === 'string' && value.trim().length > 0);
+
+  if (unitCandidates.length > 0) {
+    const normalizedUnit = unitCandidates[0].trim().toLowerCase();
+
+    if (['cent', 'cents', 'centavo', 'centavos'].includes(normalizedUnit)) {
+      return { explicitHint: true, source: 'amount_unit', normalizedUnit };
+    }
+
+    if (['real', 'reais', 'brl', 'r$'].includes(normalizedUnit)) {
+      return { explicitHint: false, source: 'amount_unit', normalizedUnit };
+    }
+
+    return { explicitHint: undefined, source: 'amount_unit', normalizedUnit };
+  }
+
+  return { explicitHint: undefined, source: null, normalizedUnit: null };
 }
 
 /**
@@ -385,8 +438,11 @@ class OasyfyService {
       const normalizedClient = validateClientData(client);
 
       // Oasyfy sempre trabalha com reais conforme documentação oficial
-      // Detectar se o valor já está em centavos usando heurística
-      const isAmountInCents = CurrencyUtils.isLikelyInCents(amount);
+      // Detectar se o valor já está em centavos usando sinalização explícita ou heurística
+      const amountHint = resolveAmountHint(paymentData);
+      const isAmountInCents = CurrencyUtils.isLikelyInCents(amount, {
+        explicitHint: amountHint.explicitHint
+      });
       const amountInReais = CurrencyUtils.toReais(amount, isAmountInCents);
       const shippingFeeInReais = CurrencyUtils.toReais(shippingFee || 0, isAmountInCents);
       const extraFeeInReais = CurrencyUtils.toReais(extraFee || 0, isAmountInCents);
@@ -456,6 +512,9 @@ class OasyfyService {
           amount_centavos: amount,
           amount_reais: amountInReais,
           is_amount_in_cents: isAmountInCents,
+          amount_hint_source: amountHint.source,
+          amount_hint_unit: amountHint.normalizedUnit,
+          amount_hint_applied: typeof amountHint.explicitHint === 'boolean',
           products_count: products.length,
           has_callback: !!callbackUrl,
           client_name: normalizedClient.name,

--- a/tests/pushinpay-regression.test.js
+++ b/tests/pushinpay-regression.test.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const axios = require('axios');
+const PushinPayService = require('../services/pushinpay');
+
+(async () => {
+  const originalToken = process.env.PUSHINPAY_TOKEN;
+  process.env.PUSHINPAY_TOKEN = 'test-token';
+
+  const originalPost = axios.post;
+  const captured = { url: null, payload: null };
+
+  axios.post = async (url, payload) => {
+    captured.url = url;
+    captured.payload = payload;
+    return {
+      data: {
+        id: 'test-transaction',
+        qr_code_base64: null,
+        qr_code: '000201010212...',
+        qr_code_image: null
+      }
+    };
+  };
+
+  try {
+    const service = new PushinPayService();
+
+    const result = await service.createPixPayment({
+      identifier: 'order_regression_1990',
+      amount: 1990,
+      amount_unit: 'cents',
+      client: {
+        name: 'Test Regression',
+        email: 'regression@example.com'
+      },
+      metadata: {
+        reason: 'regression-test'
+      }
+    });
+
+    assert.strictEqual(result.success, true, 'createPixPayment should return success');
+    assert.ok(captured.payload, 'Payload should have been captured');
+    assert.strictEqual(
+      captured.payload.value,
+      1990,
+      'PushinPay payload.value must respect cent-based inputs'
+    );
+
+    console.log('✅ Regression check: payload.value =', captured.payload.value);
+  } catch (error) {
+    console.error('❌ Regression check failed:', error);
+    process.exitCode = 1;
+  } finally {
+    axios.post = originalPost;
+    if (originalToken === undefined) {
+      delete process.env.PUSHINPAY_TOKEN;
+    } else {
+      process.env.PUSHINPAY_TOKEN = originalToken;
+    }
+  }
+})();


### PR DESCRIPTION
## Summary
- honor explicit amount unit hints when normalizing amounts in the PushinPay and Oasyfy services so cent-denominated integers remain stable
- propagate the amount_unit flag through the unified PIX service, API handler, and Telegram bot integration while documenting the flag in the example script
- add a regression script that stubs PushinPay to confirm amount: 1990 keeps payload.value at 1990

## Testing
- node tests/pushinpay-regression.test.js

------
https://chatgpt.com/codex/tasks/task_e_68cf5332b498832aa7566f65746dcd1a