### PR TITLE
Add WhatsApp tracking environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# ID do pixel do Facebook usado no funil do WhatsApp
+WHATSAPP_FB_PIXEL_ID=
+
+# Token de acesso do pixel do Facebook exclusivo do funil WhatsApp (mantenha em segredo)
+WHATSAPP_FB_PIXEL_TOKEN=
+
+# Token da API da UTMify utilizado pelo funil WhatsApp (mantenha em segredo)
+WHATSAPP_UTMIFY_API_TOKEN=
+
+# URL base pública usada pelo funil WhatsApp para carregar recursos
+BASE_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ logs/
 # Env
 .env
 .env.*
+!.env.example
 
 # DB temporários
 *.db

--- a/config/env.js
+++ b/config/env.js
@@ -1,0 +1,39 @@
+function getWhatsAppTrackingEnv() {
+  const pixelId = process.env.WHATSAPP_FB_PIXEL_ID?.trim();
+  const pixelToken = process.env.WHATSAPP_FB_PIXEL_TOKEN?.trim();
+  const utmifyToken = process.env.WHATSAPP_UTMIFY_API_TOKEN?.trim();
+  const baseUrl = process.env.BASE_URL?.trim();
+
+  if (process.env.NODE_ENV === 'production') {
+    const missingVars = [];
+
+    if (!pixelId) {
+      missingVars.push('WHATSAPP_FB_PIXEL_ID');
+    }
+
+    if (!pixelToken) {
+      missingVars.push('WHATSAPP_FB_PIXEL_TOKEN');
+    }
+
+    if (!utmifyToken) {
+      missingVars.push('WHATSAPP_UTMIFY_API_TOKEN');
+    }
+
+    if (missingVars.length > 0) {
+      throw new Error(
+        `[WhatsApp Tracking] Variáveis obrigatórias ausentes em produção: ${missingVars.join(', ')}`
+      );
+    }
+  }
+
+  return Object.freeze({
+    pixelId,
+    pixelToken,
+    utmifyToken,
+    baseUrl
+  });
+}
+
+module.exports = {
+  getWhatsAppTrackingEnv
+};

--- a/server.js
+++ b/server.js
@@ -11,6 +11,16 @@ process.on('unhandledRejection', (reason, promise) => {
 
 console.log('Iniciando servidor...');
 
+const { getWhatsAppTrackingEnv } = require('./config/env');
+const whatsappTrackingEnv = getWhatsAppTrackingEnv();
+const whatsappPixelIdStatus = whatsappTrackingEnv.pixelId ? 'OK' : 'ausente';
+const whatsappPixelTokenStatus = whatsappTrackingEnv.pixelToken ? 'OK (mascarado)' : 'ausente';
+const whatsappUtmifyStatus = whatsappTrackingEnv.utmifyToken ? 'OK (mascarado)' : 'ausente';
+const whatsappBaseUrlLog = whatsappTrackingEnv.baseUrl || '(não definido)';
+console.log(
+  `[whatsapp-env] pixelId: ${whatsappPixelIdStatus} | pixelToken: ${whatsappPixelTokenStatus} | utmifyToken: ${whatsappUtmifyStatus} | baseUrl: ${whatsappBaseUrlLog}`
+);
+
 const fs = require('fs');
 const path = require('path');
 const express = require('express');
@@ -4423,6 +4433,11 @@ app.post('/webhook/unified', async (req, res) => {
 // Endpoint para configurações do frontend
 app.get('/api/config', (req, res) => {
   try {
+    const whatsappConfig = {
+      pixelId: whatsappTrackingEnv.pixelId || '',
+      baseUrl: whatsappTrackingEnv.baseUrl || ''
+    };
+
     const config = {
       FB_PIXEL_ID: process.env.FB_PIXEL_ID || '',
       KWAI_PIXEL_ID: process.env.KWAI_PIXEL_ID || '',
@@ -4438,9 +4453,10 @@ app.get('/api/config', (req, res) => {
         OASYFY_CONFIGURED: !!(process.env.OASYFY_PUBLIC_KEY && process.env.OASYFY_SECRET_KEY),
         OASYFY_PUBLIC_KEY: process.env.OASYFY_PUBLIC_KEY ? '***' : '',
         OASYFY_SECRET_KEY: process.env.OASYFY_SECRET_KEY ? '***' : ''
-      }
+      },
+      whatsapp: whatsappConfig
     };
-    
+
     res.json(config);
   } catch (error) {
     console.error('Erro ao obter configurações:', error);

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -3,6 +3,7 @@ const crypto = require('crypto');
 const express = require('express');
 const { getInstance: getSessionTracking } = require('./sessionTracking');
 const { formatForCAPI, validatePurchaseValue } = require('./purchaseValidation');
+const { getWhatsAppTrackingEnv } = require('../config/env');
 const {
   initialize: initPurchaseDedup,
   generatePurchaseEventId,
@@ -21,12 +22,20 @@ const {
 const PIXEL_ID = process.env.FB_PIXEL_ID;
 const ACCESS_TOKEN = process.env.FB_PIXEL_TOKEN;
 
+const whatsappTrackingEnv = getWhatsAppTrackingEnv();
+
 // Router para expor configurações do Facebook Pixel
 const router = express.Router();
 router.get('/api/config', (req, res) => {
+  const whatsappConfig = {
+    pixelId: whatsappTrackingEnv.pixelId || '',
+    baseUrl: whatsappTrackingEnv.baseUrl || ''
+  };
+
   res.json({
     FB_PIXEL_ID: process.env.FB_PIXEL_ID || '',
-    FORCE_FB_TEST_MODE: process.env.FORCE_FB_TEST_MODE === 'true' || false
+    FORCE_FB_TEST_MODE: process.env.FORCE_FB_TEST_MODE === 'true' || false,
+    whatsapp: whatsappConfig
   });
   console.debug('[FB CONFIG] Endpoint /api/config carregado');
 });


### PR DESCRIPTION
## Summary
- document the WhatsApp tracking environment variables in a new `.env.example`
- provide a configuration helper that validates required WhatsApp env vars and exposes them safely
- load the WhatsApp tracking configuration during boot, log a masked health summary, and return non-sensitive values from `/api/config`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf5ec95fcc832a8da1b5120e79c42b