### PR TITLE
Add tipo support for tokens

### DIFF
--- a/MODELO1/WEB/tokens.js
+++ b/MODELO1/WEB/tokens.js
@@ -168,8 +168,8 @@ module.exports = (app, databasePool) => {
       const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get('host')}`;
       
       await databasePool.query(
-        'INSERT INTO tokens (token, valor) VALUES ($1, $2)',
-        [token, valor]
+        "INSERT INTO tokens (token, valor, tipo) VALUES ($1, $2, $3)",
+        [token, valor, 'principal']
       );
       
       cache.del('estatisticas');

--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -35,6 +35,7 @@ function initialize(path = './pagamentos.db') {
         fbc TEXT,
         ip_criacao TEXT,
         user_agent_criacao TEXT,
+        tipo TEXT DEFAULT 'principal',
         status TEXT DEFAULT 'pendente',
         criado_em DATETIME DEFAULT CURRENT_TIMESTAMP,
         event_time INTEGER,
@@ -141,6 +142,9 @@ function initialize(path = './pagamentos.db') {
     }
     if (!checkCol('user_agent_criacao')) {
       addColumnSafely('tokens', 'user_agent_criacao', 'TEXT');
+    }
+    if (!checkCol('tipo')) {
+      addColumnSafely('tokens', 'tipo', "TEXT DEFAULT 'principal'");
     }
     if (!checkCol('event_time')) {
       addColumnSafely('tokens', 'event_time', 'INTEGER');

--- a/migrations/20250921_add_tipo_to_tokens.sql
+++ b/migrations/20250921_add_tipo_to_tokens.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tokens ADD COLUMN IF NOT EXISTS tipo TEXT DEFAULT 'principal';

--- a/server.js
+++ b/server.js
@@ -3472,11 +3472,11 @@ app.post('/api/gerar-pix-checkout', async (req, res) => {
         }
         const insertQuery = `
           INSERT INTO tokens (
-            id_transacao, token, telegram_id, valor, status, usado, bot_id, 
-            utm_source, utm_medium, utm_campaign, utm_term, utm_content, 
-            fbp, fbc, ip_criacao, user_agent_criacao, nome_oferta, 
+            id_transacao, token, telegram_id, valor, status, tipo, usado, bot_id,
+            utm_source, utm_medium, utm_campaign, utm_term, utm_content,
+            fbp, fbc, ip_criacao, user_agent_criacao, nome_oferta,
             event_time, external_id_hash, kwai_click_id
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          ) VALUES (?, ?, ?, ?, ?, 'principal', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `;
         
         const externalId = `checkout_web_${apiId}`;
@@ -3840,11 +3840,11 @@ app.post('/api/pix/create', async (req, res) => {
 
           const insertQuery = `
             INSERT INTO tokens (
-              id_transacao, token, telegram_id, valor, status, usado, bot_id, 
-              utm_source, utm_medium, utm_campaign, utm_term, utm_content, 
-              fbp, fbc, ip_criacao, user_agent_criacao, nome_oferta, 
+              id_transacao, token, telegram_id, valor, status, tipo, usado, bot_id,
+              utm_source, utm_medium, utm_campaign, utm_term, utm_content,
+              fbp, fbc, ip_criacao, user_agent_criacao, nome_oferta,
               event_time, external_id_hash, kwai_click_id
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, 'principal', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           `;
           
           const externalId = `oasyfy_${result.transaction_id}`;
@@ -3885,14 +3885,15 @@ app.post('/api/pix/create', async (req, res) => {
           try {
             await pool.query(`
               INSERT INTO tokens (
-                id_transacao, token, telegram_id, valor, status, usado, bot_id, 
-                utm_source, utm_medium, utm_campaign, utm_term, utm_content, 
-                fbp, fbc, ip_criacao, user_agent_criacao, nome_oferta, 
+                id_transacao, token, telegram_id, valor, status, tipo, usado, bot_id,
+                utm_source, utm_medium, utm_campaign, utm_term, utm_content,
+                fbp, fbc, ip_criacao, user_agent_criacao, nome_oferta,
                 event_time, external_id_hash, kwai_click_id
-              ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
-              ON CONFLICT (id_transacao) DO UPDATE SET 
+              ) VALUES ($1, $2, $3, $4, $5, 'principal', $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+              ON CONFLICT (id_transacao) DO UPDATE SET
                 token = EXCLUDED.token,
                 status = EXCLUDED.status,
+                tipo = EXCLUDED.tipo,
                 usado = EXCLUDED.usado,
                 external_id_hash = EXCLUDED.external_id_hash,
                 kwai_click_id = EXCLUDED.kwai_click_id


### PR DESCRIPTION
## Summary
- add a migration to ensure the tokens table exposes a `tipo` column with a `principal` default
- persist the `tipo` value when generating tokens via the web module, Telegram service and checkout flows so WhatsApp tokens can be distinguished
- update the SQLite schema helper to include the new column during initialization and backfill

## Testing
- npm test *(fails: Cannot find module 'test-database.js')*


------
https://chatgpt.com/codex/tasks/task_e_68cf60c09db4832ab0e7a6bf4bbaeec3