### PR TITLE
Add WhatsApp purchase tracking and UTMify forwarding

### DIFF
--- a/whatsapp/obrigado.html
+++ b/whatsapp/obrigado.html
@@ -327,6 +327,25 @@
     </div>
 
     <script src="js/whatsapp-tracking.js"></script>
+    <script>
+      (async function() {
+        try {
+          const params = new URLSearchParams(window.location.search);
+          const token = params.get('token');
+          const value = params.get('value');
+
+          if (!token || !value) {
+            console.warn('[WhatsApp Tracking] Token ou valor ausente, Purchase não será enviado.');
+            return;
+          }
+
+          await window.whatsappTracking.init();
+          await window.whatsappTracking.trackPurchase(token, value);
+        } catch (err) {
+          console.error('[WhatsApp Tracking] Erro no Purchase:', err);
+        }
+      })();
+    </script>
     <script src="obrigado.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a purchase tracking flow to the WhatsApp tracking helper, including robust UTM recovery and UTMify payload delivery
- normalize and forward purchase details (including commission math and customer/product fallbacks) to `/api/whatsapp/utmify`
- trigger the new tracking routine from `whatsapp/obrigado.html` when token and value query params are present

## Testing
- npm test *(fails: Cannot find module '/workspace/-HotBotWebV2/test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68cf69fbceb8832a9ec384a2b7932ca1