### PR TITLE
Ensure usado_em column created for backfill compatibility

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -257,6 +257,13 @@ async function createTables(pool) {
         ) THEN
           ALTER TABLE tokens ADD COLUMN data_uso TIMESTAMP;
         END IF;
+        -- Coluna usado_em (compatibilidade com versões antigas)
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='usado_em'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN usado_em TIMESTAMP;
+        END IF;
         IF NOT EXISTS (
           SELECT 1 FROM information_schema.columns
           WHERE table_name='tokens' AND column_name='ip_uso'


### PR DESCRIPTION
## Summary
- ensure the tokens table migration checks for the legacy `usado_em` column and creates it when missing before the backfill runs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf72bfa5e0832a96bcfbf7b2332fea