### PR TITLE
Adjust WhatsApp UTMify commission to use gross value

### DIFF
--- a/Exemplo de Payload UTMify (1).json
+++ b/Exemplo de Payload UTMify (1).json
@@ -22,9 +22,9 @@
   ],
   "createdAt": "2025-08-03T19:08:00Z",
   "commission": {
-    "gatewayFeeInCents": 1000,
+    "gatewayFeeInCents": 0,
     "totalPriceInCents": 99900,
-    "userCommissionInCents": 98900
+    "userCommissionInCents": 99900
   },
   "refundedAt": null,
   "approvedDate": "2025-08-03T19:08:00Z",

--- a/GUIA_TRACKING_WHATSAPP.md
+++ b/GUIA_TRACKING_WHATSAPP.md
@@ -370,8 +370,8 @@ async function sendToUtmify(token, value, utms) {
   try {
     const now = new Date().toISOString();
     const priceInCents = Math.round(parseFloat(value) * 100);
-    const gatewayFee = Math.round(priceInCents * 0.03); // 3% taxa gateway
-    const userCommission = priceInCents - gatewayFee;
+    const gatewayFee = 0;
+    const userCommission = priceInCents;
     
     const payload = {
       isTest: false,
@@ -426,6 +426,8 @@ async function sendToUtmify(token, value, utms) {
   }
 }
 ```
+
+> 💡 **Importante:** a comissão enviada para a UTMify deve representar o valor bruto da venda, sem descontos ou taxas subtraídas. Por isso o campo `userCommissionInCents` precisa ser igual ao `priceInCents`, e o `gatewayFeeInCents` deve permanecer zerado.
 
 ## Configurações de Ambiente
 
@@ -618,9 +620,9 @@ Body: { telegram_id, tracking_data }
   "approvedDate": "2025-01-01T00:00:00Z",
   "refundedAt": null,
   "commission": {
-    "gatewayFeeInCents": 30,
+    "gatewayFeeInCents": 0,
     "totalPriceInCents": 9900,
-    "userCommissionInCents": 9870
+    "userCommissionInCents": 9900
   },
   "paymentMethod": "whatsapp",
   "trackingParameters": {

--- a/services/utmify.js
+++ b/services/utmify.js
@@ -162,10 +162,11 @@ async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionV
       // 🔥 CORREÇÃO: Usar utm_campaign no formato nome|id
       utm_campaign: utmCampaignProcessed.formatted
     },
+    // A UTMify espera os valores brutos (sem taxas) para a comissão.
     commission: {
       totalPriceInCents: transactionValueCents,
-      gatewayFeeInCents: 30,
-      userCommissionInCents: transactionValueCents - 30
+      gatewayFeeInCents: 0,
+      userCommissionInCents: transactionValueCents
     },
     isTest: false
   };

--- a/whatsapp/js/whatsapp-tracking.js
+++ b/whatsapp/js/whatsapp-tracking.js
@@ -629,8 +629,8 @@
     }
 
     const priceInCents = Math.max(Math.round(parsedValue * 100), 0);
-    const gatewayFeeInCents = Math.round(priceInCents * 0.03);
-    const userCommissionInCents = Math.max(priceInCents - gatewayFeeInCents, 0);
+    const gatewayFeeInCents = 0;
+    const userCommissionInCents = priceInCents;
     const normalizedUtms = normalizeUtms(utms);
     const timestamp = new Date().toISOString();
 


### PR DESCRIPTION
## Summary
- ensure the WhatsApp tracking script sends the full gross amount as commission to the UTMify endpoint
- align the backend UTMify service and documentation/sample payloads with the zero gateway fee requirement

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf9b92edc0832aa1f36323f9b52500