### PR TITLE
Add WhatsApp token list with name and phone details

### DIFF
--- a/whatsapp/dashboard.html
+++ b/whatsapp/dashboard.html
@@ -430,15 +430,155 @@
         }
 
         .token-stats {
-            background: #e9ecef;
-            padding: 20px;
-            border-radius: 10px;
+            background: #f8f9fa;
+            padding: 25px;
+            border-radius: 12px;
             margin-bottom: 20px;
+            border-left: 5px solid #667eea;
         }
 
         .token-stats h3 {
-            margin-bottom: 15px;
+            margin-bottom: 20px;
             color: #333;
+        }
+
+        .token-details-card {
+            margin-top: 25px;
+            background: white;
+            border-radius: 12px;
+            padding: 20px;
+            box-shadow: 0 10px 25px rgba(102, 126, 234, 0.15);
+            border: 1px solid #e2e8f0;
+        }
+
+        .token-details-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+
+        .token-details-header h4 {
+            font-size: 1.1rem;
+            color: #333;
+        }
+
+        .token-details-updated {
+            font-size: 0.85rem;
+            color: #6c757d;
+        }
+
+        .token-details-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 16px;
+            margin-top: 18px;
+        }
+
+        .token-details-item {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+            background: #f8fafc;
+            border-radius: 12px;
+            padding: 12px 14px;
+            border: 1px solid #e2e8f0;
+        }
+
+        .token-details-label {
+            font-size: 0.8rem;
+            font-weight: 600;
+            color: #64748b;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .token-details-value {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: #1e293b;
+            word-break: break-all;
+        }
+
+        .token-list {
+            margin-top: 25px;
+            background: #f8f9fa;
+            border-radius: 12px;
+            padding: 25px;
+            border-left: 5px solid #25D366;
+        }
+
+        .token-list h4 {
+            color: #333;
+            margin-bottom: 18px;
+            font-size: 1.2rem;
+        }
+
+        .token-table-wrapper {
+            overflow-x: auto;
+        }
+
+        .token-table {
+            width: 100%;
+            border-collapse: collapse;
+            min-width: 520px;
+        }
+
+        .token-table th,
+        .token-table td {
+            padding: 12px;
+            border-bottom: 1px solid #e2e8f0;
+            text-align: left;
+            font-size: 0.95rem;
+        }
+
+        .token-table th {
+            background: #ffffff;
+            color: #334155;
+            font-weight: 600;
+        }
+
+        .token-table tbody tr:hover {
+            background: #eef2ff;
+        }
+
+        .token-table td.token-code {
+            font-family: 'Fira Code', 'SFMono-Regular', Consolas, monospace;
+            font-size: 0.85rem;
+        }
+
+        .token-table .status-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .status-pill.usado {
+            background: rgba(34, 197, 94, 0.15);
+            color: #15803d;
+        }
+
+        .status-pill.pendente {
+            background: rgba(37, 211, 102, 0.18);
+            color: #047857;
+        }
+
+        .status-pill.expirado,
+        .status-pill.cancelado {
+            background: rgba(248, 113, 113, 0.18);
+            color: #b91c1c;
+        }
+
+        .token-table-empty {
+            text-align: center;
+            padding: 24px 12px;
+            color: #6b7280;
         }
 
         .stats-grid {
@@ -548,17 +688,37 @@
                 margin: 10px;
                 border-radius: 10px;
             }
-            
+
             .content {
                 padding: 20px;
             }
-            
+
             .header h1 {
                 font-size: 2rem;
             }
-            
+
             .form-grid {
                 grid-template-columns: 1fr;
+            }
+
+            .token-details-grid {
+                grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            }
+
+            .token-details-header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 6px;
+            }
+
+            .token-table {
+                min-width: 100%;
+            }
+
+            .token-table th,
+            .token-table td {
+                font-size: 0.85rem;
+                padding: 10px 8px;
             }
 
             .historico-table th,
@@ -704,6 +864,57 @@
                             <div class="stat-value" id="tokensHoje">0</div>
                             <div class="stat-label">Tokens Hoje</div>
                         </div>
+                    </div>
+
+                    <div class="token-details-card" id="latestTokenCard">
+                        <div class="token-details-header">
+                            <h4>Último token gerado</h4>
+                            <span class="token-details-updated" id="latestTokenUpdatedAt">Sem registros</span>
+                        </div>
+                        <div class="token-details-grid">
+                            <div class="token-details-item">
+                                <span class="token-details-label">Valor</span>
+                                <span class="token-details-value" id="latestTokenValue">-</span>
+                            </div>
+                            <div class="token-details-item">
+                                <span class="token-details-label">Nome</span>
+                                <span class="token-details-value" id="latestTokenName">-</span>
+                            </div>
+                            <div class="token-details-item">
+                                <span class="token-details-label">Telefone</span>
+                                <span class="token-details-value" id="latestTokenPhone">-</span>
+                            </div>
+                            <div class="token-details-item">
+                                <span class="token-details-label">Token</span>
+                                <span class="token-details-value token-code" id="latestTokenCode">-</span>
+                            </div>
+                            <div class="token-details-item">
+                                <span class="token-details-label">Status</span>
+                                <span class="token-details-value" id="latestTokenStatus">-</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="token-list" id="tokenList">
+                    <h4>Histórico de Tokens</h4>
+                    <div class="token-table-wrapper">
+                        <table class="token-table">
+                            <thead>
+                                <tr>
+                                    <th>Valor</th>
+                                    <th>Nome</th>
+                                    <th>Telefone</th>
+                                    <th>Token</th>
+                                    <th>Status</th>
+                                </tr>
+                            </thead>
+                            <tbody id="tokenListBody">
+                                <tr>
+                                    <td colspan="5" class="token-table-empty">Carregando tokens...</td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
- include name and phone on the WhatsApp tokens API response and expose the latest token from statistics
- update the dashboard layout to show value, name, phone, token and status in the stats card and token history
- extend the frontend logic to format and render the new token metadata while keeping the generated token view in sync

## Testing
- npm test *(fails: test-database.js ausente no repositório)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa2ee61b4832aa2c487817b11df0c