### PR TITLE
Add WhatsApp token cleanup action in dashboard

### DIFF
--- a/server.js
+++ b/server.js
@@ -214,6 +214,7 @@ const TELEGRAM_TOKEN_BOT2 = process.env.TELEGRAM_TOKEN_BOT2;
 const TELEGRAM_TOKEN_ESPECIAL = process.env.TELEGRAM_TOKEN_ESPECIAL;
 const BASE_URL = process.env.BASE_URL;
 const PORT = process.env.PORT || 3000;
+const ADMIN_SECRET = process.env.ADMIN_SECRET;
 const URL_ENVIO_1 = process.env.URL_ENVIO_1;
 const URL_ENVIO_2 = process.env.URL_ENVIO_2;
 const URL_ENVIO_3 = process.env.URL_ENVIO_3;
@@ -5051,6 +5052,34 @@ app.get('/api/whatsapp/estatisticas', async (req, res) => {
       sucesso: false, 
       erro: 'Erro interno do servidor' 
     });
+  }
+});
+
+app.delete('/api/whatsapp/limpar-tokens', async (req, res) => {
+  try {
+    if (ADMIN_SECRET) {
+      const authHeader = req.headers.authorization || '';
+      const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+
+      if (!token || token !== ADMIN_SECRET) {
+        return res.status(403).json({ sucesso: false, erro: 'Não autorizado' });
+      }
+    }
+
+    const pool = postgres ? postgres.getPool() : null;
+    if (!pool) {
+      return res.status(500).json({
+        sucesso: false,
+        erro: 'Erro de conexão com banco de dados'
+      });
+    }
+
+    await pool.query("DELETE FROM tokens WHERE tipo = 'whatsapp'");
+
+    res.json({ sucesso: true, mensagem: 'Tokens de WhatsApp apagados com sucesso' });
+  } catch (err) {
+    console.error('Erro ao apagar tokens de WhatsApp:', err);
+    res.status(500).json({ sucesso: false, erro: 'Erro ao apagar tokens de WhatsApp' });
   }
 });
 

--- a/whatsapp/dashboard.html
+++ b/whatsapp/dashboard.html
@@ -387,6 +387,40 @@
             transform: none;
         }
 
+        .btn-clear-tokens {
+            background: linear-gradient(135deg, #f87171, #dc2626);
+            color: #fff;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 8px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+            margin: 20px auto 10px;
+            box-shadow: 0 6px 16px rgba(220, 38, 38, 0.3);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            width: 100%;
+            max-width: 320px;
+        }
+
+        .btn-clear-tokens:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 10px 22px rgba(220, 38, 38, 0.4);
+        }
+
+        .btn-clear-tokens:active {
+            transform: translateY(0);
+        }
+
+        .btn-clear-tokens:focus {
+            outline: none;
+            box-shadow: 0 0 0 4px rgba(248, 113, 113, 0.35);
+        }
+
         .test-section {
             background: #f8f9fa;
             padding: 25px;
@@ -865,6 +899,11 @@
                             <div class="stat-label">Tokens Hoje</div>
                         </div>
                     </div>
+
+                    <button type="button" class="btn-clear-tokens" id="clearWhatsAppTokensBtn">
+                        🗑️ Apagar todos os tokens
+                    </button>
+                    <div class="message" id="clearTokensMessage"></div>
 
                     <div class="token-details-card" id="latestTokenCard">
                         <div class="token-details-header">


### PR DESCRIPTION
## Summary
- add a highlighted "Apagar todos os tokens" action and message area to the WhatsApp dashboard stats card
- handle token cleanup confirmation, admin secret storage, API call, and UI refresh in the dashboard script
- provide a DELETE /api/whatsapp/limpar-tokens endpoint that removes WhatsApp tokens with optional ADMIN_SECRET protection

## Testing
- npm test *(fails: Cannot find module '/workspace/-HotBotWebV2/test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68cfa8042cd8832ab8996f9e9fed8a37