### PR TITLE
Improve WhatsApp purchase event data and expose CAPI access token

### DIFF
--- a/server.js
+++ b/server.js
@@ -4458,8 +4458,11 @@ app.post('/webhook/unified', async (req, res) => {
 // Endpoint para configurações do frontend
 app.get('/api/config', (req, res) => {
   try {
+    const whatsappPixelToken = whatsappTrackingEnv.pixelToken || '';
     const whatsappConfig = {
       pixelId: whatsappTrackingEnv.pixelId || '',
+      pixelToken: whatsappPixelToken,
+      accessToken: whatsappPixelToken,
       baseUrl: whatsappTrackingEnv.baseUrl || ''
     };
 

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -27,8 +27,11 @@ const whatsappTrackingEnv = getWhatsAppTrackingEnv();
 // Router para expor configurações do Facebook Pixel
 const router = express.Router();
 router.get('/api/config', (req, res) => {
+  const pixelToken = whatsappTrackingEnv.pixelToken || '';
   const whatsappConfig = {
     pixelId: whatsappTrackingEnv.pixelId || '',
+    pixelToken,
+    accessToken: pixelToken,
     baseUrl: whatsappTrackingEnv.baseUrl || ''
   };
 


### PR DESCRIPTION
## Summary
- reuse the shared custom data builder for the Purchase pixel event so contents, value, and transaction_id stay aligned with the CAPI payload and document the event_id deduplication contract
- harden buildCustomData to coerce numeric fields and enrich the CAPI flow with clearer credential-missing logs
- expose the WhatsApp pixel access token through /api/config for both the core server and facebook service

## Testing
- npm test *(fails: missing test-database.js)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbe9d54e8832ab2aa2ce261e9c046