### PR TITLE
Handle numeric purchase values in WhatsApp tracking

### DIFF
--- a/whatsapp/js/whatsapp-tracking.js
+++ b/whatsapp/js/whatsapp-tracking.js
@@ -2065,6 +2065,16 @@
       }
 
       mergeCandidate(valueArg);
+    } else if (typeof valueArg === 'number' && Number.isFinite(valueArg)) {
+      resolvedValue = valueArg;
+    } else if (typeof valueArg === 'string') {
+      const trimmedValue = valueArg.trim();
+      if (trimmedValue) {
+        const parsedValue = parsePurchaseValue(trimmedValue);
+        if (Number.isFinite(parsedValue)) {
+          resolvedValue = parsedValue;
+        }
+      }
     }
 
     mergeCandidate(customerArg);


### PR DESCRIPTION
## Summary
- ensure resolveTrackPurchaseContext assigns numeric purchase values when provided directly as numbers or numeric strings

## Testing
- npm test *(fails: Error: Cannot find module 'test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d084e8a4d0832a9a4ac33b02902960