### PR TITLE
Ajusta roteamento do CAPI do WhatsApp para pixel dedicado

### DIFF
--- a/server.js
+++ b/server.js
@@ -545,6 +545,7 @@ async function processarCapiWhatsApp({ pool, token, dadosToken: providedDadosTok
           telegram_id: dadosToken.telegram_id,
           user_data_hash: userDataHash,
           source: 'capi',
+          origin: 'whatsapp',
           client_timestamp: dadosToken.event_time,
           custom_data: {
             utm_source: utmSource.name,

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -177,30 +177,32 @@ function generateExternalId(telegram_id, fbp, ip) {
   return crypto.createHash('sha256').update(base).digest('hex');
 }
 
-async function sendFacebookEvent({
-  event_name,
-  event_time = Math.floor(Date.now() / 1000),
-  event_id,
-  event_source_url,
-  value,
-  currency = 'BRL',
-  fbp,
-  fbc,
-  client_ip_address,
-  client_ip,
-  client_user_agent,
-  ip,
-  userAgent,
-  custom_data = {},
+async function sendFacebookEvent(event = {}) {
+  const {
+    event_name,
+    event_time = Math.floor(Date.now() / 1000),
+    event_id,
+    event_source_url,
+    value,
+    currency = 'BRL',
+    fbp,
+    fbc,
+    client_ip_address,
+    client_ip,
+    client_user_agent,
+    ip,
+    userAgent,
+    custom_data = {},
 
-  user_data_hash = null, // Novos dados pessoais hasheados
-  source = 'unknown', // Origem do evento: 'pixel', 'capi', 'cron'
-  token = null, // Token para atualizar flags no banco
-  pool = null, // Pool de conexão do banco
-  telegram_id = null, // 🔥 NOVO: ID do Telegram para buscar cookies automaticamente
-  client_timestamp = null // 🔥 NOVO: Timestamp do cliente para sincronização
-}) {
-  const isWhatsAppCapiEvent = source === 'capi' && event_name === 'Purchase';
+    user_data_hash = null, // Novos dados pessoais hasheados
+    source = 'unknown', // Origem do evento: 'pixel', 'capi', 'cron'
+    token = null, // Token para atualizar flags no banco
+    pool = null, // Pool de conexão do banco
+    telegram_id = null, // 🔥 NOVO: ID do Telegram para buscar cookies automaticamente
+    client_timestamp = null // 🔥 NOVO: Timestamp do cliente para sincronização
+  } = event;
+
+  const isWhatsAppCapiEvent = source === 'capi' && event.origin === 'whatsapp';
   const pixelId = isWhatsAppCapiEvent
     ? process.env.WHATSAPP_FB_PIXEL_ID
     : PIXEL_ID;


### PR DESCRIPTION
## Summary
- marca os eventos do fluxo de WhatsApp com origin: 'whatsapp'
- atualiza o sendFacebookEvent para usar o pixel e token dedicados quando a origem é WhatsApp
- mantém os logs [CAPI-DEBUG] restritos aos eventos de WhatsApp

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d095fab0ec832abeae088ba23fee8c