### PR TITLE
Captura dados de tracking no redirect e envia no obrigado

### DIFF
--- a/whatsapp/redirect.js
+++ b/whatsapp/redirect.js
@@ -2,7 +2,7 @@
 async function detectCity() {
     const statusTextEl = document.getElementById('status-text');
     if (!statusTextEl) return;
-    
+
     try {
         // Usar a mesma API do index.html para consistência
         const response = await fetch("https://pro.ip-api.com/json/?key=R1a8D9VJfrqTqpY&fields=status,country,countryCode,region,city");
@@ -43,6 +43,53 @@ async function detectCity() {
     // Se não conseguir detectar a cidade, mantém apenas "ONLINE AGORA"
     statusTextEl.textContent = "ONLINE AGORA";
     console.log('Fallback: Cidade não detectada');
+}
+
+function getCookie(name) {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+    if (parts.length === 2) {
+        const cookieValue = parts.pop().split(';').shift();
+        return cookieValue ? decodeURIComponent(cookieValue) : null;
+    }
+    return null;
+}
+
+async function captureTrackingData() {
+    const trackingData = {
+        fbp: getCookie('_fbp') || null,
+        fbc: getCookie('_fbc') || null,
+        userAgent: navigator.userAgent || null,
+        ip: null,
+        city: null
+    };
+
+    console.log('🍪 Cookies capturados:', { fbp: trackingData.fbp, fbc: trackingData.fbc });
+    console.log('🧭 User Agent capturado:', trackingData.userAgent);
+
+    try {
+        const response = await fetch("https://pro.ip-api.com/json/?key=R1a8D9VJfrqTqpY&fields=status,country,countryCode,region,city,query");
+        const data = await response.json();
+
+        if (response.ok && data.status === "success") {
+            trackingData.ip = data.query || null;
+            trackingData.city = data.city || null;
+            console.log('🌍 Dados de geolocalização capturados:', { ip: trackingData.ip, city: trackingData.city });
+        } else {
+            console.warn('⚠️ Falha ao capturar dados de geolocalização:', data);
+        }
+    } catch (error) {
+        console.error('❌ Erro ao capturar dados de geolocalização:', error);
+    }
+
+    try {
+        localStorage.setItem('trackingData', JSON.stringify(trackingData));
+        console.log('💾 Tracking data salvo no localStorage:', trackingData);
+    } catch (error) {
+        console.error('❌ Erro ao salvar tracking data no localStorage:', error);
+    }
+
+    return trackingData;
 }
 
 // Função para pré-carregar imagens
@@ -92,13 +139,14 @@ document.addEventListener('DOMContentLoaded', async function() {
     
     // Chama a função de geolocalização imediatamente
     detectCity();
-    
+
     // Aguarda 5 segundos para mostrar a animação de carregamento
-    setTimeout(function() {
+    setTimeout(async function() {
         // Obtém o link do WhatsApp que foi injetado pelo servidor
         const zapLink = window.zapLink;
-        
+
         if (zapLink) {
+            await captureTrackingData();
             // Redireciona para o WhatsApp
             window.location.href = zapLink;
         } else {


### PR DESCRIPTION
## Summary
- captura cookies, user agent e dados de geolocalização no redirect e persiste no localStorage antes do redirecionamento
- carrega os dados de tracking na página de obrigado e envia no payload de verificação do token com logs de debug

## Testing
- Not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68d0a03690c4832abde03beb429134e3