### PR TITLE
Add WhatsApp tracking persistence endpoint

### DIFF
--- a/database/postgres.js
+++ b/database/postgres.js
@@ -316,6 +316,12 @@ async function createTables(pool) {
         END IF;
         IF NOT EXISTS (
           SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='city'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN city TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
           WHERE table_name='tokens' AND column_name='user_agent_criacao'
         ) THEN
           ALTER TABLE tokens ADD COLUMN user_agent_criacao TEXT;


### PR DESCRIPTION
## Summary
- add the /api/whatsapp/salvar-tracking endpoint to persist tracking data tied to WhatsApp tokens
- ensure WhatsApp column verification and database bootstrap add the city column used by the new endpoint

## Testing
- npm run test *(fails: Error: Cannot find module 'test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68d0a5a112fc832ab369317ac1111533