### PR TITLE
Fix zap controle schema to allow lead rotation

### DIFF
--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -94,6 +94,8 @@ function initialize(path = './pagamentos.db') {
         leads_zap2 INTEGER DEFAULT 0,
         zap1_numero TEXT DEFAULT '5511999999999',
         zap2_numero TEXT DEFAULT '5511888888888',
+        ativo_zap1 INTEGER DEFAULT 1,
+        ativo_zap2 INTEGER DEFAULT 1,
         historico TEXT DEFAULT '[]',
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
@@ -220,6 +222,12 @@ function initialize(path = './pagamentos.db') {
     }
     if (!checkCol('phone')) {
       addColumnSafely('tokens', 'phone', 'TEXT');
+    }
+    if (!checkZapControleCol('ativo_zap1')) {
+      addColumnSafely('zap_controle', 'ativo_zap1', 'INTEGER DEFAULT 1');
+    }
+    if (!checkZapControleCol('ativo_zap2')) {
+      addColumnSafely('zap_controle', 'ativo_zap2', 'INTEGER DEFAULT 1');
     }
     if (!checkZapControleCol('historico')) {
       addColumnSafely('zap_controle', 'historico', 'TEXT DEFAULT "[]"');


### PR DESCRIPTION
## Summary
- add the ativo_zap1 and ativo_zap2 columns to the zap_controle table definition so the WhatsApp toggles persist in SQLite
- backfill the same columns when the database already exists to avoid write errors and keep lead alternation working

## Testing
- `npm test` *(fails: test script test-database.js is missing in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f1c16420832ab3c178a38579f82c