### PR TITLE
feat: priorizar dados de tracking do backend ao enviar para a UTMify

### DIFF
--- a/whatsapp/obrigado.js
+++ b/whatsapp/obrigado.js
@@ -182,13 +182,19 @@ async function recuperarTrackingWhatsApp(token) {
             }
             
             // 🔥 NOVA FUNCIONALIDADE: Disponibilizar dados globalmente para whatsapp-tracking.js
+            const existingTrackingData = typeof window !== 'undefined' && window.trackingData
+                ? window.trackingData
+                : {};
+
             window.trackingData = {
-                fbp: data.fbp || trackingData.fbp,
-                fbc: data.fbc || trackingData.fbc,
-                utms: data.utms || trackingData.utms,
-                city: data.city || trackingData.city,
-                ip: data.ip || trackingData.ip,
-                userAgent: data.userAgent || trackingData.userAgent
+                ...existingTrackingData,
+                ...trackingData,
+                utms: data.utms || existingTrackingData.utms || trackingData.utms || null,
+                fbp: data.fbp || existingTrackingData.fbp || trackingData.fbp || null,
+                fbc: data.fbc || existingTrackingData.fbc || trackingData.fbc || null,
+                city: data.city || existingTrackingData.city || trackingData.city || null,
+                ip: data.ip || existingTrackingData.ip || trackingData.ip || null,
+                userAgent: data.userAgent || existingTrackingData.userAgent || trackingData.userAgent || null
             };
             
             console.log('🌍 [TRACKING] Dados disponibilizados globalmente:', window.trackingData);


### PR DESCRIPTION
## Summary
- garante que os dados recuperados do backend sejam mesclados em `window.trackingData` na página de obrigado
- ajusta o envio para a UTMify priorizando UTMs, fbp, fbc e cidade vindos do backend e registra a origem dos dados
- repassa os dados normalizados do cliente para o envio da UTMify para manter fallbacks consistentes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5de6b0840832a9506cc2158b4df3d