### PR TITLE
Load FingerprintJS via module import

### DIFF
--- a/whatsapp/redirect.html
+++ b/whatsapp/redirect.html
@@ -4,13 +4,22 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Redirecionando para WhatsApp</title>
-    <script async src="https://openfpcdn.io/fingerprintjs/v4" onload="initFingerprintJS()"></script>
-    <script>
+    <script type="module">
         // Função global para inicializar FingerprintJS
         function initFingerprintJS() {
             console.log('🔍 [FINGERPRINT] FingerprintJS carregado e disponível');
             window.FingerprintJSLoaded = true;
         }
+
+        window.initFingerprintJS = initFingerprintJS;
+
+        import('https://openfpcdn.io/fingerprintjs/v4')
+            .then(() => {
+                initFingerprintJS();
+            })
+            .catch((error) => {
+                console.error('⚠️ [FINGERPRINT] Falha ao carregar FingerprintJS', error);
+            });
     </script>
     <style>
         * {


### PR DESCRIPTION
## Summary
- replace the async FingerprintJS loader with an ES module script
- dynamically import FingerprintJS and mark the global flag after the module loads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5e343cc1c832ab71587de8ebb5bd2