### PR TITLE
Fix tracking data reference in WhatsApp redirect

### DIFF
--- a/whatsapp/redirect.js
+++ b/whatsapp/redirect.js
@@ -377,11 +377,11 @@ document.addEventListener('DOMContentLoaded', async function() {
 
         if (zapLink) {
             console.log('✅ [REDIRECT] Executando captureTrackingData...');
-            await captureTrackingData();
+            const trackingData = await captureTrackingData();
             console.log('✅ [REDIRECT] captureTrackingData concluído, salvando sessão...');
-            
+
             // Salvar sessão com fingerprint antes de redirecionar
-            await salvarSessaoWhatsApp(dataToPersist);
+            await salvarSessaoWhatsApp(trackingData);
             
             console.log('✅ [REDIRECT] Sessão salva, redirecionando...');
             // Redireciona para o WhatsApp


### PR DESCRIPTION
## Summary
- capture the tracking data returned by `captureTrackingData` before redirecting
- pass the collected tracking data object into `salvarSessaoWhatsApp`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5e46027e4832aa53a41b56833128d