### PR TITLE
Add WhatsApp CAPI test event code

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -463,7 +463,9 @@ async function sendFacebookEvent(eventName, payload) {
   };
 
   // 🔥 ADICIONAR test_event_code na raiz do payload SEMPRE para WhatsApp CAPI
-  // Código de teste removido - pronto para produção
+  if (isWhatsAppCapiEvent) {
+    requestPayload.test_event_code = 'TEST33355';
+  }
 
   // 🔥 LOGS DE DEBUG EXCLUSIVOS PARA CAPI DO WHATSAPP
   // Verificar se é um evento do CAPI do WhatsApp (source === 'capi' e event_name === 'Purchase')


### PR DESCRIPTION
## Summary
- append the TEST33355 test event code to all WhatsApp CAPI payloads before sending to Facebook

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ed719020832aaae4dfd5cc23102f