### PR TITLE
Add WhatsApp CAPI test event code TEST66065

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -21,6 +21,8 @@ const {
 
 const PIXEL_ID = process.env.FB_PIXEL_ID;
 const ACCESS_TOKEN = process.env.FB_PIXEL_TOKEN;
+const WHATSAPP_CAPI_TEST_EVENT_CODE =
+  process.env.WHATSAPP_FB_TEST_EVENT_CODE || 'TEST66065';
 
 const whatsappTrackingEnv = getWhatsAppTrackingEnv();
 
@@ -464,7 +466,7 @@ async function sendFacebookEvent(eventName, payload) {
 
   // 🔥 ADICIONAR test_event_code na raiz do payload SEMPRE para WhatsApp CAPI
   if (isWhatsAppCapiEvent) {
-    requestPayload.test_event_code = 'TEST33355';
+    requestPayload.test_event_code = WHATSAPP_CAPI_TEST_EVENT_CODE;
   }
 
   // 🔥 LOGS DE DEBUG EXCLUSIVOS PARA CAPI DO WHATSAPP

--- a/whatsapp/js/whatsapp-tracking.js
+++ b/whatsapp/js/whatsapp-tracking.js
@@ -192,6 +192,7 @@
     { url: 'https://ipv4.icanhazip.com/', parser: async response => (await response.text()).trim() },
     { url: 'https://ipinfo.io/json', parser: async response => (await response.json()).ip }
   ]);
+  const WHATSAPP_CAPI_TEST_EVENT_CODE = 'TEST66065';
 
   // ✅ CORREÇÃO: Função removida - test_event_code não usado no Pixel (browser)
 
@@ -1058,7 +1059,7 @@
       }
     }
 
-    return null;
+    return WHATSAPP_CAPI_TEST_EVENT_CODE;
   }
 
   function collectPurchaseCustomerData(rawData) {
@@ -1870,6 +1871,10 @@
     const requestBody = {
       data: [eventPayload]
     };
+    const testEventCode = resolveTestEventCode(customer.testEventCode);
+    if (testEventCode) {
+      requestBody.test_event_code = testEventCode;
+    }
 
     const encodedPixelId = encodeURIComponent(pixelId);
     const encodedToken = encodeURIComponent(accessToken);


### PR DESCRIPTION
## Summary
- default WhatsApp CAPI events to use the TEST66065 test event code on the server
- ensure the WhatsApp tracking script applies TEST66065 whenever constructing a CAPI payload, with environment overrides still supported

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5f0628178832aa08eecb9ce5c0e74