### PR TITLE
Fix WhatsApp commission payload

### DIFF
--- a/whatsapp/js/whatsapp-tracking.js
+++ b/whatsapp/js/whatsapp-tracking.js
@@ -2471,7 +2471,7 @@
       commission: {
         totalPriceInCents: priceInCents,
         gatewayFeeInCents: 0,
-        userCommissionInCents: 0
+        userCommissionInCents: priceInCents
       },
       customer: {
         name: ensureString(normalizedCustomerData.name) || DEFAULT_CUSTOMER.name,


### PR DESCRIPTION
## Summary
- update the WhatsApp tracking payload so the user commission matches the sale value when no fees are applied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d612199104832a9dc4431e43031d21