### PR TITLE
Improve Thumbmark loading resilience

### DIFF
--- a/whatsapp/obrigado.html
+++ b/whatsapp/obrigado.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Obrigado pela Confiança!</title>
-    <!-- ThumbmarkJS CDN -->
-    <script src="https://cdn.jsdelivr.net/npm/@thumbmarkjs/thumbmarkjs@latest/dist/thumbmark.umd.js"></script>
+    <!-- ThumbmarkJS CDN (backup para quando o import NPM não estiver disponível) -->
+    <script async src="https://cdn.jsdelivr.net/npm/@thumbmarkjs/thumbmarkjs@1.3.0/dist/thumbmark.min.js"></script>
     <style>
         * {
             margin: 0;

--- a/whatsapp/redirect.html
+++ b/whatsapp/redirect.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Redirecionando para WhatsApp</title>
-    <!-- ThumbmarkJS CDN -->
-    <script src="https://cdn.jsdelivr.net/npm/@thumbmarkjs/thumbmarkjs@latest/dist/thumbmark.umd.js"></script>
+    <!-- ThumbmarkJS CDN (backup para quando o import NPM não estiver disponível) -->
+    <script async src="https://cdn.jsdelivr.net/npm/@thumbmarkjs/thumbmarkjs@1.3.0/dist/thumbmark.min.js"></script>
     <style>
         * {
             margin: 0;


### PR DESCRIPTION
## Summary
- add an async Thumbmark loader with retry and UUID fallback for redirect and obrigado tracking flows
- prefer the npm Thumbmark package while logging availability and waiting longer for CDN readiness
- pin the Thumbmark CDN script to v1.3.0 and load it asynchronously as a backup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64485fed8832ab494068210e700c4