### PR TITLE
Fix Thumbmark import and logging for bundle

### DIFF
--- a/src/obrigado.js
+++ b/src/obrigado.js
@@ -1,5 +1,5 @@
 // ThumbmarkJS carregado via bundle NPM
-import { Thumbmark } from '@thumbmarkjs/thumbmarkjs';
+import Thumbmark from '@thumbmarkjs/thumbmarkjs';
 
 // Log imediato para confirmar carregamento do script
 console.log('🚀 [OBRIGADO] Script obrigado.js carregado!');
@@ -16,9 +16,9 @@ async function getThumbmarkId() {
         console.log('✅ Thumbmark ID via bundle:', id);
         return id;
     } catch (error) {
-        console.warn('⚠️ [THUMBMARK] Erro ao gerar ID via bundle, usando UUID fallback:', error);
+        console.error('❌ [THUMBMARK] Erro ao gerar ID via bundle:', error);
         const fallbackId = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : generateUUID();
-        console.log('✅ [THUMBMARK] ID gerado:', fallbackId);
+        console.warn('⚠️ [THUMBMARK] UUID fallback gerado:', fallbackId);
         return fallbackId;
     }
 }

--- a/src/redirect.js
+++ b/src/redirect.js
@@ -1,5 +1,5 @@
 // ThumbmarkJS carregado via bundle NPM
-import { Thumbmark } from '@thumbmarkjs/thumbmarkjs';
+import Thumbmark from '@thumbmarkjs/thumbmarkjs';
 
 // Log imediato para confirmar carregamento do script
 console.log('🚀 [REDIRECT] Script redirect.js carregado!');
@@ -16,9 +16,9 @@ async function getThumbmarkId() {
         console.log('✅ Thumbmark ID via bundle:', id);
         return id;
     } catch (error) {
-        console.warn('⚠️ [THUMBMARK] Erro ao gerar ID via bundle, usando UUID fallback:', error);
+        console.error('❌ [THUMBMARK] Erro ao gerar ID via bundle:', error);
         const fallbackId = (typeof crypto !== 'undefined' && crypto.randomUUID) ? crypto.randomUUID() : generateUUID();
-        console.log('✅ [THUMBMARK] ID gerado:', fallbackId);
+        console.warn('⚠️ [THUMBMARK] UUID fallback gerado:', fallbackId);
         return fallbackId;
     }
 }


### PR DESCRIPTION
## Summary
- switch ThumbmarkJS usage to the default export expected by the bundle
- update Thumbmark ID retrieval to log bundle success and fallback UUID usage consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64ec2e78c832a82aca09b0ec014a7