### PR TITLE
Add Telegram VIP redirect landing page

### DIFF
--- a/MODELO1/WEB/telegram/app.js
+++ b/MODELO1/WEB/telegram/app.js
@@ -1,0 +1,51 @@
+(function () {
+  const DEFAULT_LINK = 'https://t.me/bot1';
+
+  function buildTargetUrl(baseLink, searchParams) {
+    const params = new URLSearchParams(searchParams);
+    let startValue = '';
+
+    if (params.has('payload_id')) {
+      startValue = params.get('payload_id') || '';
+    } else if (params.has('start')) {
+      startValue = params.get('start') || '';
+    }
+
+    let target = baseLink || DEFAULT_LINK;
+
+    if (startValue) {
+      const separator = target.includes('?') ? '&' : '?';
+      target += `${separator}start=${encodeURIComponent(startValue)}`;
+    }
+
+    return target;
+  }
+
+  function updateCountdown(element, seconds) {
+    if (!element) return;
+    element.textContent = `Redirecionando em ${seconds} segundos…`;
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const baseLink = window.BOT1_LINK_FROM_SERVER || DEFAULT_LINK;
+    const countdownEl = document.getElementById('countdown');
+    const targetUrl = buildTargetUrl(baseLink, window.location.search);
+
+    let remainingSeconds = 3;
+    updateCountdown(countdownEl, remainingSeconds);
+
+    const countdownInterval = setInterval(() => {
+      remainingSeconds -= 1;
+      if (remainingSeconds >= 0) {
+        updateCountdown(countdownEl, remainingSeconds);
+      }
+      if (remainingSeconds < 0) {
+        clearInterval(countdownInterval);
+      }
+    }, 1000);
+
+    setTimeout(() => {
+      window.location.href = targetUrl;
+    }, 3000);
+  });
+})();

--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Acesso VIP - Telegram</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/telegram/styles.css" />
+  </head>
+  <body>
+    <div class="page-wrapper">
+      <div class="vip-card">
+        <div class="card-header">
+          <div class="avatar-wrapper">
+            <img src="/assets/avatar.jpg" alt="Avatar" class="avatar" />
+            <img src="/assets/telegram.png" alt="Telegram" class="telegram-icon" />
+          </div>
+          <p class="header-text">Estamos preparando seu acesso VIP…</p>
+        </div>
+
+        <h1 class="title">
+          Seu acesso <span class="highlight">VIP</span> está quase liberado!
+        </h1>
+
+        <p class="subtitle">
+          Aguarde só alguns segundos enquanto conectamos você ao grupo exclusivo no
+          Telegram.
+        </p>
+
+        <div class="badge">
+          <span class="fire">🔥</span>
+          <span>92% das vagas já foram preenchidas</span>
+        </div>
+
+        <div class="progress-bar">
+          <div class="progress-fill"></div>
+        </div>
+
+        <p id="countdown" class="countdown">Redirecionando em 3 segundos…</p>
+      </div>
+    </div>
+
+    <script>
+      window.BOT1_LINK_FROM_SERVER = "<%= process.env.BOT1_TELEGRAM_LINK || 'https://t.me/bot1' %>";
+    </script>
+    <script src="/telegram/app.js" defer></script>
+  </body>
+</html>

--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -1,0 +1,197 @@
+:root {
+  --bg-gradient-start: #2d0b66;
+  --bg-gradient-end: #1b2a6b;
+  --card-bg: rgba(18, 21, 43, 0.85);
+  --card-border: rgba(255, 47, 141, 0.7);
+  --glow-color: rgba(255, 47, 141, 0.45);
+  --text-color: #f4f6ff;
+  --subtitle-color: rgba(244, 246, 255, 0.7);
+  --badge-bg: rgba(255, 255, 255, 0.08);
+  --progress-bg: rgba(255, 255, 255, 0.15);
+  --progress-fill-start: #ff6ac1;
+  --progress-fill-end: #8a7dff;
+  --highlight-gradient: linear-gradient(90deg, #ff72d1, #8a7dff);
+  --card-radius: 24px;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  font-family: 'Poppins', sans-serif;
+  background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-color);
+  padding: 24px;
+}
+
+.page-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 520px;
+}
+
+.vip-card {
+  position: relative;
+  background: var(--card-bg);
+  border-radius: var(--card-radius);
+  padding: 42px 36px 48px;
+  border: 2px solid transparent;
+  overflow: hidden;
+}
+
+.vip-card::before {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(255, 114, 209, 0.9), rgba(138, 125, 255, 0.9));
+  z-index: -2;
+}
+
+.vip-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: calc(var(--card-radius) - 2px);
+  background: var(--card-bg);
+  box-shadow: 0 0 35px var(--glow-color);
+  z-index: -1;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 28px;
+}
+
+.avatar-wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  border: 3px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+  object-fit: cover;
+}
+
+.telegram-icon {
+  width: 42px;
+  height: 42px;
+  filter: drop-shadow(0 6px 16px rgba(74, 144, 226, 0.35));
+}
+
+.header-text {
+  font-size: 0.95rem;
+  color: var(--subtitle-color);
+  max-width: 180px;
+  text-align: right;
+  line-height: 1.4;
+}
+
+.title {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.2;
+  margin-bottom: 18px;
+}
+
+.title .highlight {
+  background-image: var(--highlight-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.subtitle {
+  font-size: 1rem;
+  color: var(--subtitle-color);
+  line-height: 1.6;
+  margin-bottom: 26px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  background: var(--badge-bg);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  padding: 10px 18px;
+  margin-bottom: 30px;
+  backdrop-filter: blur(6px);
+}
+
+.fire {
+  font-size: 1.15rem;
+}
+
+.progress-bar {
+  width: 100%;
+  height: 12px;
+  background: var(--progress-bg);
+  border-radius: 999px;
+  overflow: hidden;
+  margin-bottom: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.progress-fill {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, var(--progress-fill-start), var(--progress-fill-end));
+  border-radius: inherit;
+  animation: progress-fill 3s ease-out forwards;
+}
+
+@keyframes progress-fill {
+  from {
+    width: 0;
+  }
+  to {
+    width: 100%;
+  }
+}
+
+.countdown {
+  font-size: 1.05rem;
+  text-align: center;
+  color: var(--text-color);
+  font-weight: 500;
+}
+
+@media (max-width: 520px) {
+  .vip-card {
+    padding: 32px 24px 38px;
+  }
+
+  .card-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .header-text {
+    text-align: left;
+    max-width: 100%;
+  }
+
+  .title {
+    font-size: 1.7rem;
+  }
+}

--- a/server.js
+++ b/server.js
@@ -2809,6 +2809,39 @@ app.get('/api/payment-status/:transactionId', async (req, res) => {
   }
 });
 
+// 🔥 ENDPOINT: Página do telegram (acesso VIP)
+app.get('/telegram', (req, res) => {
+  try {
+    const telegramPath = path.join(__dirname, 'MODELO1', 'WEB', 'telegram', 'index.html');
+
+    if (!fs.existsSync(telegramPath)) {
+      return res.status(404).send('Página não encontrada');
+    }
+
+    fs.readFile(telegramPath, 'utf8', (error, content) => {
+      if (error) {
+        console.error('Erro ao ler página do telegram:', error);
+        return res.status(500).send('Erro interno do servidor');
+      }
+
+      const botLink = process.env.BOT1_TELEGRAM_LINK || 'https://t.me/bot1';
+      const placeholder = "<%= process.env.BOT1_TELEGRAM_LINK || 'https://t.me/bot1' %>";
+      const sanitizedBotLink = botLink
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+      const renderedContent = content.replace(placeholder, sanitizedBotLink);
+
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.send(renderedContent);
+    });
+  } catch (error) {
+    console.error('Erro ao servir página do telegram:', error);
+    res.status(500).send('Erro interno do servidor');
+  }
+});
+
 // 🔥 ENDPOINT: Página de loader (pré-carregamento)
 app.get('/loader', (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- add a styled Telegram VIP waiting page with countdown, progress bar, and promotional elements
- implement client logic to preserve start/payload parameters and redirect to the configured bot link after 3 seconds
- expose an Express GET /telegram route that injects the bot link into the page before responding

## Testing
- npm start *(fails: local environment lacks required PostgreSQL service)*

------
https://chatgpt.com/codex/tasks/task_e_68e13e48131c832aa37e4875da939103