### PR TITLE
Adjust Telegram VIP title styling

### DIFF
--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -16,7 +16,10 @@
           </div>
         </div>
 
-        <h1 class="title">Estamos preparando seu acesso VIP...</h1>
+        <h1 class="title">
+          Estamos preparando<br>
+          seu <span class="vip">acesso VIP</span>...
+        </h1>
 
         <p class="subtitle">Aguarde alguns segundos enquanto configuramos seu acesso exclusivo.</p>
 

--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -96,14 +96,23 @@ body {
 }
 
 .title {
+  margin: 12px 0 10px;
   font-size: 22px;
-  font-weight: 700;
+  font-weight: 800;
+  line-height: 1.15;
   text-align: center;
-  background: linear-gradient(90deg, #ff2ea6, #7a2cff);
+  color: #ffffff;
+  text-shadow: 0 0 6px rgba(255, 46, 166, 0.35);
+  letter-spacing: 0.2px;
+}
+
+.title .vip {
+  background: linear-gradient(90deg, #ff2ea6 0%, #a65bff 100%);
   -webkit-background-clip: text;
+  background-clip: text;
   -webkit-text-fill-color: transparent;
-  text-shadow: 0 0 8px rgba(255, 46, 166, 0.6);
-  margin-bottom: 12px;
+  text-shadow: 0 0 10px rgba(255, 46, 166, 0.65),
+               0 0 18px rgba(166, 91, 255, 0.45);
 }
 
 .subtitle {


### PR DESCRIPTION
## Summary
- update the Telegram landing page heading to break the VIP message across two lines with the highlighted span
- refresh the heading styles to match the provided gradient, glow, and typography

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e147de573c832a86f2653eabdf4a8c