### PR TITLE
Adjust Telegram VIP title styling

### DIFF
--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -18,7 +18,7 @@
 
         <h1 class="title">
           Estamos preparando<br>
-          seu <span class="vip">acesso VIP</span>...
+          seu <span class="vip">acesso VIP...</span>
         </h1>
 
         <p class="subtitle">Aguarde alguns segundos enquanto configuramos seu acesso exclusivo.</p>

--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -101,18 +101,26 @@ body {
   font-weight: 800;
   line-height: 1.15;
   text-align: center;
-  color: #ffffff;
-  text-shadow: 0 0 6px rgba(255, 46, 166, 0.35);
+  color: #ffffff;                      /* base branca */
+  text-shadow:
+    0 0 6px rgba(255, 46, 166, 0.35),  /* glow suave rosa */
+    0 1px 0 rgba(0,0,0,0.25);
   letter-spacing: 0.2px;
+
+  /* Remover qualquer gradiente anterior do h1 */
+  background: none !important;
+  -webkit-background-clip: initial !important;
+  -webkit-text-fill-color: initial !important;
 }
 
 .title .vip {
-  background: linear-gradient(90deg, #ff2ea6 0%, #a65bff 100%);
+  background: linear-gradient(90deg, #ff2ea6 0%, #7a2cff 100%);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  text-shadow: 0 0 10px rgba(255, 46, 166, 0.65),
-               0 0 18px rgba(166, 91, 255, 0.45);
+  text-shadow:
+    0 0 10px rgba(255, 46, 166, 0.65),  /* glow mais forte */
+    0 0 18px rgba(122, 44, 255, 0.45);
 }
 
 .subtitle {


### PR DESCRIPTION
## Summary
- update the Telegram landing heading markup so the VIP ellipsis inherits the gradient styling
- refresh the Telegram title styling to keep the base text white while applying the stronger gradient glow to the VIP span

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e158a90888832ab26aabf9bcdebfa5