### PR TITLE
Revamp neon styling for Telegram waiting screen

### DIFF
--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -1,16 +1,23 @@
 :root {
-  --bg-gradient-start: #2d0b66;
-  --bg-gradient-end: #1b2a6b;
-  --card-bg: rgba(18, 21, 43, 0.85);
-  --card-border: rgba(255, 47, 141, 0.7);
-  --glow-color: rgba(255, 47, 141, 0.45);
-  --text-color: #ffffff;
-  --subtitle-color: #b5b5c5;
-  --badge-bg: linear-gradient(90deg, #ff2ea6, #7a2cff);
-  --progress-bg: #2b2b3a;
-  --progress-fill-start: #ff2ea6;
-  --progress-fill-end: #7a2cff;
-  --card-radius: 24px;
+  --bg-primary: #040015;
+  --bg-secondary: #12003a;
+  --bg-accent: rgba(255, 72, 176, 0.55);
+  --card-surface: rgba(9, 10, 28, 0.82);
+  --card-glass: rgba(18, 19, 45, 0.65);
+  --card-border-glow-start: rgba(255, 110, 214, 0.95);
+  --card-border-glow-end: rgba(122, 66, 255, 0.95);
+  --text-primary: #f7f7ff;
+  --text-secondary: rgba(222, 226, 255, 0.75);
+  --vip-glow: rgba(255, 79, 194, 0.8);
+  --badge-gradient-start: rgba(255, 94, 205, 0.95);
+  --badge-gradient-end: rgba(142, 72, 255, 0.95);
+  --badge-border: rgba(255, 160, 235, 0.55);
+  --progress-track: rgba(255, 255, 255, 0.08);
+  --progress-border: rgba(255, 255, 255, 0.16);
+  --progress-fill-start: #ff52c5;
+  --progress-fill-end: #7a36ff;
+  --countdown-color: rgba(221, 226, 255, 0.7);
+  --card-radius: 32px;
 }
 
 * {
@@ -21,30 +28,67 @@
 
 body {
   min-height: 100vh;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
-    sans-serif;
-  background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, sans-serif;
+  color: var(--text-primary);
+  background: radial-gradient(circle at center, rgba(255, 91, 204, 0.24) 0%, rgba(115, 55, 255, 0.1) 32%, rgba(6, 0, 30, 0) 60%),
+    linear-gradient(145deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
+  background-attachment: fixed;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: var(--text-color);
-  padding: 24px;
+  padding: 32px 18px;
+  position: relative;
+  overflow: hidden;
+}
+
+body::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: clamp(420px, 72vw, 640px);
+  height: clamp(420px, 72vw, 640px);
+  background: radial-gradient(circle, rgba(255, 94, 205, 0.42) 0%, rgba(255, 115, 226, 0.24) 38%, rgba(10, 0, 33, 0) 70%);
+  filter: blur(32px);
+  transform: translate(-50%, -50%);
+  opacity: 0.85;
+  pointer-events: none;
+  z-index: 0;
 }
 
 .page-wrapper {
   position: relative;
   width: 100%;
-  max-width: 520px;
+  max-width: 360px;
+  z-index: 1;
+}
+
+.page-wrapper::before {
+  content: '';
+  position: absolute;
+  inset: -140px;
+  background: radial-gradient(circle at center, rgba(255, 79, 194, 0.32) 0%, rgba(140, 70, 255, 0.18) 35%, rgba(4, 0, 21, 0) 70%);
+  filter: blur(48px);
+  z-index: -2;
+  opacity: 0.9;
 }
 
 .vip-card {
   position: relative;
-  background: var(--card-bg);
+  padding: 52px 38px 46px;
   border-radius: var(--card-radius);
-  padding: 42px 36px 48px;
-  border: 2px solid transparent;
-  overflow: hidden;
+  background: var(--card-surface);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(18px);
   text-align: center;
+  overflow: hidden;
+  transform-origin: center;
+  animation: card-enter 620ms cubic-bezier(0.25, 0.9, 0.35, 1) forwards;
+  box-shadow:
+    0 22px 70px -32px rgba(8, 0, 40, 0.8),
+    0 0 45px rgba(255, 84, 201, 0.35),
+    0 0 85px rgba(122, 54, 255, 0.2);
 }
 
 .vip-card::before {
@@ -52,17 +96,28 @@ body {
   position: absolute;
   inset: -2px;
   border-radius: inherit;
-  background: linear-gradient(135deg, rgba(255, 114, 209, 0.9), rgba(138, 125, 255, 0.9));
-  z-index: -2;
+  padding: 1.6px;
+  background: linear-gradient(135deg, var(--card-border-glow-start), var(--card-border-glow-end));
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  opacity: 0.92;
+  filter: drop-shadow(0 0 28px rgba(255, 92, 210, 0.45));
+  z-index: -1;
 }
 
 .vip-card::after {
   content: '';
   position: absolute;
-  inset: 0;
-  border-radius: calc(var(--card-radius) - 2px);
-  background: var(--card-bg);
-  box-shadow: 0 0 35px var(--glow-color);
+  inset: 4px;
+  border-radius: calc(var(--card-radius) - 6px);
+  background: linear-gradient(155deg, rgba(16, 18, 45, 0.82) 0%, rgba(18, 20, 48, 0.68) 60%, rgba(24, 12, 52, 0.45) 100%);
+  box-shadow:
+    inset 0 0 35px rgba(255, 89, 202, 0.12),
+    inset 0 0 60px rgba(115, 55, 255, 0.12);
   z-index: -1;
 }
 
@@ -70,123 +125,143 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 16px;
-  margin-bottom: 20px;
+  gap: 18px;
+  margin-bottom: 26px;
 }
 
 .header-icons {
-  display: flex;
-  justify-content: center;
+  display: inline-flex;
   align-items: center;
-  gap: 16px;
-  margin-bottom: 20px;
+  justify-content: center;
+  gap: 12px;
 }
 
 .icon-telegram {
-  width: 64px;
-  height: 64px;
+  width: 66px;
+  height: 66px;
   border-radius: 50%;
+  object-fit: cover;
+  box-shadow:
+    inset 0 0 18px rgba(255, 255, 255, 0.35),
+    0 0 26px rgba(64, 130, 255, 0.45);
 }
 
 .icon-avatar {
-  width: 64px;
-  height: 64px;
-  border-radius: 12px;
+  width: 66px;
+  height: 66px;
+  border-radius: 16px;
   object-fit: cover;
+  box-shadow:
+    0 12px 28px rgba(0, 0, 0, 0.35),
+    0 0 32px rgba(255, 77, 181, 0.32);
 }
 
 .title {
-  margin: 12px 0 10px;
-  font-size: 22px;
+  margin: 6px 0 12px;
+  font-size: 26px;
   font-weight: 800;
   line-height: 1.15;
-  text-align: center;
-  color: #ffffff;                      /* base branca */
-  text-shadow:
-    0 0 6px rgba(255, 46, 166, 0.35),  /* glow suave rosa */
-    0 1px 0 rgba(0,0,0,0.25);
   letter-spacing: 0.2px;
-
-  /* Remover qualquer gradiente anterior do h1 */
-  background: none !important;
-  -webkit-background-clip: initial !important;
-  -webkit-text-fill-color: initial !important;
+  color: var(--text-primary);
+  text-shadow:
+    0 0 18px rgba(255, 84, 201, 0.35),
+    0 8px 30px rgba(10, 0, 38, 0.65);
 }
 
 .title .vip {
-  background: linear-gradient(90deg, #ff2ea6 0%, #7a2cff 100%);
+  background: linear-gradient(92deg, rgba(255, 98, 207, 0.95) 0%, rgba(122, 66, 255, 0.95) 100%);
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  text-shadow:
-    0 0 10px rgba(255, 46, 166, 0.65),  /* glow mais forte */
-    0 0 18px rgba(122, 44, 255, 0.45);
+  filter: drop-shadow(0 0 10px var(--vip-glow));
 }
 
 .subtitle {
   font-size: 14px;
-  color: var(--subtitle-color);
-  text-align: center;
-  margin-bottom: 20px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  margin-bottom: 26px;
 }
 
 .badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 22px;
+  gap: 8px;
+  padding: 11px 24px;
   border-radius: 999px;
-  color: #fff;
   font-size: 15px;
   font-weight: 600;
-  text-align: center;
-  line-height: 1.1;
-
-  /* vidro + neon */
-  background: rgba(255, 46, 166, 0.12);
-  border: 1.5px solid rgba(255, 46, 166, 0.7);
-  backdrop-filter: blur(6px);
+  color: #ffffff;
+  background: linear-gradient(120deg, var(--badge-gradient-start) 0%, var(--badge-gradient-end) 100%);
+  border: 1.4px solid var(--badge-border);
   box-shadow:
-    0 0 8px rgba(255, 46, 166, 0.45),
-    0 0 16px rgba(255, 46, 166, 0.35);
-  transition: all 0.3s ease;
-}
-
-.badge:hover {
-  box-shadow:
-    0 0 12px rgba(255, 46, 166, 0.6),
-    0 0 24px rgba(255, 46, 166, 0.4);
-  transform: scale(1.02);
+    inset 0 0 18px rgba(255, 255, 255, 0.22),
+    0 0 28px rgba(255, 92, 210, 0.55);
+  backdrop-filter: blur(12px);
+  text-shadow: 0 1px 10px rgba(28, 0, 45, 0.35);
 }
 
 .badge-text {
-  display: inline;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   white-space: nowrap;
-  text-shadow: 0 0 4px rgba(0, 0, 0, 0.25);
-  letter-spacing: 0.1px;
-}
-
-/* Remova regras antigas do .badge .fire (se existirem) */
-.badge .fire {
-  display: none !important;
 }
 
 .progress-bar {
-  width: 100%;
-  height: 8px;
-  background: var(--progress-bg);
-  border-radius: 6px;
+  width: 84%;
+  max-width: 280px;
+  margin: 26px auto 20px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--progress-track);
+  border: 1px solid var(--progress-border);
+  box-shadow:
+    inset 0 2px 12px rgba(0, 0, 0, 0.45),
+    0 0 20px rgba(255, 92, 210, 0.28);
   overflow: hidden;
-  margin: 20px 0;
+  position: relative;
+}
+
+.progress-bar::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0));
+  pointer-events: none;
 }
 
 .progress-fill {
-  height: 100%;
+  position: absolute;
+  inset: 1.5px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--progress-fill-start) 0%, var(--progress-fill-end) 100%);
+  box-shadow:
+    0 0 25px rgba(255, 90, 208, 0.65),
+    0 10px 35px rgba(122, 54, 255, 0.45);
   width: 0;
-  background: linear-gradient(90deg, var(--progress-fill-start), var(--progress-fill-end));
-  border-radius: inherit;
-  box-shadow: 0 0 8px rgba(255, 46, 166, 0.7);
   animation: progress-fill 3s ease-out forwards;
+}
+
+.progress-fill::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 18%;
+  width: 45%;
+  height: 60%;
+  transform: translateY(-50%);
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.6), rgba(255, 255, 255, 0));
+  opacity: 0.65;
+}
+
+.countdown {
+  font-size: 13px;
+  color: var(--countdown-color);
+  letter-spacing: 0.15px;
 }
 
 @keyframes progress-fill {
@@ -198,22 +273,39 @@ body {
   }
 }
 
-.countdown {
-  font-size: 14px;
-  color: #b5b5c5;
-  text-align: center;
+@keyframes card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
-@media (max-width: 520px) {
-  .vip-card {
-    padding: 32px 24px 38px;
+@media (max-width: 420px) {
+  body {
+    padding: 28px 16px;
   }
 
-  .card-header {
-    align-items: center;
+  .page-wrapper {
+    max-width: 340px;
+  }
+
+  .vip-card {
+    padding: 46px 28px 40px;
   }
 
   .title {
-    font-size: 1.7rem;
+    font-size: 24px;
+  }
+
+  .subtitle {
+    font-size: 13px;
+  }
+
+  .progress-bar {
+    width: 88%;
   }
 }


### PR DESCRIPTION
## Summary
- replace the /telegram waiting screen background with layered radial and linear gradients to match the neon glow reference
- restyle the VIP card, icons, badge, progress bar, and typography with brighter colors, glassmorphism, and glow effects
- adjust layout proportions, spacing, and animations for a centered, premium presentation on mobile viewports

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e163607c24832ab289f331d773079e