### PR TITLE
Adjust telegram VIP card width for mobile viewports

### DIFF
--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -29,7 +29,7 @@ body {
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 16px;
+  padding: 12px; /* menos margem externa para caber um card mais largo */
   overflow: hidden;
 }
 
@@ -70,9 +70,10 @@ body::after {
 }
 
 .vip-card {
-  max-width: 500px;
-  width: 100%;
-  padding: 36px 28px;
+  /* card mais largo no mobile, ocupando ~90–94vw */
+  width: min(94vw, 520px);
+  max-width: 520px;
+  padding: 30px 24px;
   border-radius: 20px;
   background: var(--card-surface);
   backdrop-filter: blur(12px);
@@ -107,21 +108,21 @@ body::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 20px;
-  margin-bottom: 22px;
+  gap: 18px;
+  margin-bottom: 20px;
 }
 
 .telegram-logo {
-  width: 70px;
-  height: 70px;
+  width: 78px;  /* ligeiramente maiores para o card mais largo */
+  height: 78px;
   border-radius: 50%;
   object-fit: cover;
   filter: drop-shadow(0 0 8px rgba(0, 198, 255, 0.6));
 }
 
 .avatar {
-  width: 80px;
-  height: 80px;
+  width: 78px;
+  height: 78px;
   border-radius: 50%;
   border: 3px solid #fff;
   object-fit: cover;
@@ -134,9 +135,9 @@ body::after {
 }
 
 .title {
-  font-size: clamp(22px, 5vw, 28px);
+  font-size: clamp(26px, 6vw, 36px); /* título acompanha a nova largura */
   font-weight: 800;
-  line-height: 1.3;
+  line-height: 1.22;
   margin-bottom: 10px;
   text-shadow: 0 0 14px rgba(255, 0, 127, 0.6), 0 0 24px rgba(0, 198, 255, 0.4);
 }
@@ -150,18 +151,25 @@ body::after {
 .subtitle {
   font-size: 15px;
   color: var(--muted);
-  margin-bottom: 18px;
+  line-height: 1.45;
+  max-width: 36ch;      /* mais largo para o card maior */
+  margin: 0 auto 18px;
 }
 
 .info {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
   background: var(--info-bg);
   border: 1px solid var(--info-border);
   border-radius: 12px;
-  padding: 12px;
-  font-size: 14px;
-  margin-bottom: 24px;
+  padding: 14px 16px;
+  font-size: 15px;
+  margin-bottom: 22px;
   color: var(--info-color);
   text-shadow: 0 0 8px rgba(255, 0, 127, 0.3);
+  text-align: center;
 }
 
 .progress {
@@ -186,18 +194,10 @@ body::after {
   color: var(--muted);
 }
 
-@media (max-width: 480px) {
-  .vip-card {
-    padding: 32px 24px;
-  }
-
-  .header {
-    gap: 16px;
-  }
-
-  .telegram-logo,
-  .avatar {
-    width: 64px;
-    height: 64px;
-  }
+/* Ajustes progressivos (mantém o card grande sem exagero em telas médias) */
+@media (min-width: 420px) {
+  .vip-card { width: min(92vw, 540px); max-width: 540px; }
+}
+@media (min-width: 768px) {
+  .vip-card { width: min(80vw, 580px); max-width: 580px; }
 }


### PR DESCRIPTION
## Summary
- expand the VIP card width to use up to ~94vw on small screens while capping growth on larger viewports
- tweak padding, typography, and info block layout to maintain balanced proportions within the wider card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c5b6a3a8832abdfe1062978d46ed