### PR TITLE
Adjust VIP card modal height

### DIFF
--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -75,6 +75,10 @@ body::after {
   width: clamp(340px, 92vw, 560px);
   max-width: 560px;
   padding: clamp(2.2rem, 5.6vw, 3.3rem) clamp(1.5rem, 4.4vw, 2.5rem);
+  min-height: clamp(420px, 45vh, 540px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   border-radius: 20px;
   background: var(--card-surface);
   backdrop-filter: blur(12px);


### PR DESCRIPTION
## Summary
- enforce a taller baseline for the VIP card with a responsive min-height
- center the card contents vertically using flex layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1cce104ec832a9f314ec8cdd9921b