### PR TITLE
Adjust Telegram info text layout

### DIFF
--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -37,7 +37,8 @@
         </p>
 
         <div class="info">
-          🔥 92% das vagas já foram preenchidas
+          <span>🔥92% das vagas já foram</span>
+          <span>preenchidas</span>
         </div>
 
         <div class="progress" aria-hidden="true">

--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -162,10 +162,11 @@ body::after {
 }
 
 .info {
-  display: inline-flex;       /* emoji + texto no mesmo flow */
+  display: inline-flex;
+  flex-direction: column;      /* permite que o texto ocupe duas linhas */
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: 4px;
   background: var(--info-bg);
   border: 1px solid var(--info-border);
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- split the Telegram VIP card info text into two lines to emphasize availability
- update the info badge layout to stack text vertically while keeping the styling centered

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e22361d844832a9218fc7d5c985518