### PR TITLE
Adjust VIP card layout and glow intensity

### DIFF
--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -1,9 +1,9 @@
 :root {
   --bg1: #0a0f2c;
   --bg2: #1a1440;
-  --brand1: #ff007f;
-  --brand2: #7928ca;
-  --brand3: #00c6ff;
+  --brand1: #ff4b2b;
+  --brand2: #ff416c;
+  --brand3: #ff0000;
   --text: #ffffff;
   --muted: #aaa4d6;
   --card-surface: rgba(20, 20, 40, 0.55);
@@ -11,7 +11,7 @@
   --info-border: rgba(255, 0, 127, 0.25);
   --info-color: #ff80b5;
   --progress-track: rgba(255, 255, 255, 0.1);
-  --shadow-color: rgba(255, 0, 128, 0.3);
+  --shadow-color: rgba(255, 0, 128, 0.5);
 }
 
 * {
@@ -26,10 +26,10 @@ body {
   background: radial-gradient(circle at top, var(--bg1), var(--bg2));
   color: var(--text);
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   text-align: center;
-  padding: 0;                 /* remove “gordura” lateral que estreitava o card */
+  padding: 20px 0 0;
   overflow: hidden;
 }
 
@@ -46,7 +46,7 @@ body::after {
     rgba(121, 40, 202, 0.2),
     transparent 70%
   );
-  filter: blur(70px);
+  filter: blur(90px);
   z-index: 0;
 }
 
@@ -75,14 +75,15 @@ body::after {
   width: clamp(340px, 92vw, 560px);
   max-width: 560px;
   padding: clamp(2.2rem, 5.6vw, 3.3rem) clamp(1.5rem, 4.4vw, 2.5rem);
-  min-height: clamp(420px, 45vh, 540px);
+  min-height: clamp(460px, 50vh, 580px);
   display: flex;
   flex-direction: column;
   justify-content: center;
   border-radius: 20px;
   background: var(--card-surface);
   backdrop-filter: blur(12px);
-  box-shadow: 0 0 40px var(--shadow-color), 0 0 80px var(--shadow-color);
+  box-shadow: 0 0 50px var(--shadow-color), 0 0 100px var(--shadow-color),
+    0 0 150px var(--shadow-color);
   position: relative;
   overflow: hidden;
 }
@@ -92,20 +93,21 @@ body::after {
   position: absolute;
   inset: -2px;
   border-radius: 22px;
-  padding: 2px;
+  padding: 3px;
   background: linear-gradient(135deg, var(--brand1), var(--brand2), var(--brand3));
   -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
+  filter: brightness(1.3);
   animation: glow 6s linear infinite;
 }
 
 @keyframes glow {
   0% {
-    filter: hue-rotate(0deg);
+    filter: hue-rotate(0deg) brightness(1.3);
   }
   100% {
-    filter: hue-rotate(360deg);
+    filter: hue-rotate(360deg) brightness(1.3);
   }
 }
 
@@ -144,7 +146,7 @@ body::after {
   font-weight: 800;
   line-height: 1.22;
   margin-bottom: 10px;
-  text-shadow: 0 0 14px rgba(255, 0, 127, 0.6), 0 0 24px rgba(0, 198, 255, 0.4);
+  text-shadow: 0 0 20px rgba(255, 0, 127, 0.8), 0 0 30px rgba(0, 198, 255, 0.6);
 }
 
 .title span {


### PR DESCRIPTION
## Summary
- raise the VIP card toward the top of the viewport while keeping ample breathing room
- intensify the card glow with brighter border animation, deeper shadows, and a warmer gradient palette
- extend the card height and reinforce the headline glow to match the reference look

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e229b1ce44832aa0f72d750d87b82f