### PR TITLE
Apply neon blue Telegram theme

### DIFF
--- a/MODELO1/WEB/telegram/styles.css
+++ b/MODELO1/WEB/telegram/styles.css
@@ -1,17 +1,17 @@
 :root {
-  --bg1: #0a0f2c;
-  --bg2: #1a1440;
-  --brand1: #ff4b2b;  /* Mantido tons vermelhos mais brilhantes, como na imagem desejada */
-  --brand2: #ff416c;
-  --brand3: #ff0000;
+  --bg1: #030b1a;
+  --bg2: #001e3c;
+  --brand1: #00b7ff;
+  --brand2: #00ffff;
+  --brand3: #2ad1ff;
   --text: #ffffff;
-  --muted: #aaa4d6;
-  --card-surface: rgba(20, 20, 40, 0.55);
-  --info-bg: rgba(255, 0, 127, 0.08);
-  --info-border: rgba(255, 0, 127, 0.25);
-  --info-color: #ff80b5;
-  --progress-track: rgba(255, 255, 255, 0.1);
-  --shadow-color: rgba(255, 0, 128, 0.5);  /* Mantido opacidade para glow intenso */
+  --muted: #bfdfff;
+  --card-surface: rgba(4, 30, 66, 0.88);
+  --info-bg: rgba(0, 183, 255, 0.15);
+  --info-border: rgba(0, 183, 255, 0.4);
+  --info-color: #00d8ff;
+  --progress-track: rgba(255, 255, 255, 0.12);
+  --shadow-color: rgba(0, 183, 255, 0.25);
 }
 
 * {
@@ -23,7 +23,7 @@
 body {
   min-height: 100vh;
   font-family: 'Inter', sans-serif;
-  background: radial-gradient(circle at top, var(--bg1), var(--bg2));
+  background: linear-gradient(180deg, var(--bg1) 0%, var(--bg2) 100%);
   color: var(--text);
   display: flex;
   align-items: center;  /* Voltado para center: centraliza verticalmente o card */
@@ -42,8 +42,8 @@ body::after {
   border-radius: 50%;
   background: radial-gradient(
     circle,
-    rgba(255, 0, 127, 0.35),
-    rgba(121, 40, 202, 0.2),
+    rgba(0, 183, 255, 0.35),
+    rgba(42, 209, 255, 0.25),
     transparent 70%
   );
   filter: blur(90px);  /* Mantido blur para glow difuso */
@@ -81,7 +81,7 @@ body::after {
   border-radius: 20px;
   background: var(--card-surface);
   backdrop-filter: blur(12px);
-  box-shadow: 0 0 50px var(--shadow-color), 0 0 100px var(--shadow-color), 0 0 150px var(--shadow-color);  /* Mantido glow brilhante */
+  box-shadow: 0 0 30px var(--shadow-color), 0 0 70px var(--shadow-color);
   position: relative;
   overflow: hidden;
 }
@@ -122,7 +122,7 @@ body::after {
   height: 84px;
   border-radius: 50%;
   object-fit: cover;
-  filter: drop-shadow(0 0 8px rgba(0, 198, 255, 0.6));
+  filter: drop-shadow(0 0 8px rgba(0, 183, 255, 0.6));
 }
 
 .avatar {
@@ -131,7 +131,7 @@ body::after {
   border-radius: 50%;
   border: 3px solid #fff;
   object-fit: cover;
-  box-shadow: 0 0 20px rgba(255, 0, 127, 0.5), 0 0 30px rgba(121, 40, 202, 0.4);
+  box-shadow: 0 0 20px rgba(0, 183, 255, 0.4), 0 0 32px rgba(0, 255, 255, 0.25);
   transition: transform 0.3s ease;
 }
 
@@ -144,11 +144,11 @@ body::after {
   font-weight: 800;
   line-height: 1.22;
   margin-bottom: 10px;
-  text-shadow: 0 0 20px rgba(255, 0, 127, 0.8), 0 0 30px rgba(0, 198, 255, 0.6);  /* Mantido brilho no título */
+  text-shadow: 0 0 12px #00b7ff, 0 0 24px rgba(0, 183, 255, 0.7);
 }
 
 .title span {
-  background: linear-gradient(90deg, var(--brand1), var(--brand2));
+  background: linear-gradient(90deg, var(--brand1), var(--brand3));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
@@ -174,7 +174,7 @@ body::after {
   font-size: 15px;
   margin-bottom: 22px;
   color: var(--info-color);
-  text-shadow: 0 0 8px rgba(255, 0, 127, 0.3);
+  text-shadow: 0 0 12px rgba(0, 183, 255, 0.4);
   text-align: center;
 }
 
@@ -191,13 +191,13 @@ body::after {
   width: 0;
   height: 100%;
   background: linear-gradient(90deg, var(--brand1), var(--brand2));
-  box-shadow: 0 0 20px rgba(255, 0, 127, 0.6), 0 0 30px rgba(120, 40, 202, 0.6);
+  box-shadow: 0 0 18px rgba(0, 183, 255, 0.5), 0 0 28px rgba(0, 255, 255, 0.4);
   transition: width 0.2s linear;
 }
 
 .countdown {
   font-size: 14px;
-  color: var(--muted);
+  color: #89cfff;
 }
 
 /* Escalonamento estilo Elementor */


### PR DESCRIPTION
## Summary
- retheme the Telegram VIP card layout with neon blue Telegram-inspired palette
- refresh glow effects, gradients, and progress bar to match the new palette
- adjust countdown and highlight colors for improved contrast

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e23395d8e4832a83d05a746e70c6a9