### PR TITLE
Adjust telegram message rotation timing

### DIFF
--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -100,7 +100,7 @@
           lines[1].textContent = lineTwo;
         };
 
-        const getRandomDelay = () => 1000 + Math.random() * 500;
+        const getStableDelay = () => 2000;
 
         const queueNextChange = (delay) => {
           window.setTimeout(() => {
@@ -114,13 +114,13 @@
                 infoElement.classList.remove('is-fading');
               });
 
-              queueNextChange(getRandomDelay());
+              queueNextChange(getStableDelay());
             }, fadeDuration);
           }, delay);
         };
 
         applyMessage(currentIndex);
-        queueNextChange(200);
+        queueNextChange(getStableDelay());
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- slow down the status message rotation in the Telegram landing page to update every two seconds
- ensure subsequent updates reuse the same stable delay for consistent pacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e23e6aa6d8832aa4c2ff65320da7de