### PR TITLE
Adjust Telegram redirect timing and messaging

### DIFF
--- a/MODELO1/WEB/telegram/app.js
+++ b/MODELO1/WEB/telegram/app.js
@@ -1,6 +1,6 @@
 (function () {
   const DEFAULT_LINK = 'https://t.me/bot1';
-  const REDIRECT_DELAY = 3000;
+  const REDIRECT_DELAY = 4000;
 
   function buildTargetUrl(baseLink, searchParams) {
     const params = new URLSearchParams(searchParams);

--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -60,7 +60,7 @@
           <div class="bar" id="progress-bar"></div>
         </div>
 
-        <p id="countdown" class="countdown">Redirecionando em 3 segundos...</p>
+        <p id="countdown" class="countdown">Redirecionando em 4 segundos...</p>
       </article>
     </div>
 
@@ -102,7 +102,7 @@
 
         const getStableDelay = () => 2000;
 
-        const queueNextChange = (delay) => {
+        const scheduleSingleChange = (delay) => {
           window.setTimeout(() => {
             infoElement.classList.add('is-fading');
 
@@ -113,14 +113,12 @@
               window.requestAnimationFrame(() => {
                 infoElement.classList.remove('is-fading');
               });
-
-              queueNextChange(getStableDelay());
             }, fadeDuration);
           }, delay);
         };
 
         applyMessage(currentIndex);
-        queueNextChange(getStableDelay());
+        scheduleSingleChange(getStableDelay());
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- increase the Telegram landing redirect timeout to four seconds and sync the countdown label
- allow the info banner copy to fade only once per page load instead of looping indefinitely

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e23f8e821c832aa59bb7a63f259652