### PR TITLE
Add Meta Pixel PageView and ViewContent tracking for Telegram landing

### DIFF
--- a/MODELO1/WEB/geolocation.js
+++ b/MODELO1/WEB/geolocation.js
@@ -1,12 +1,12 @@
 (function (window) {
-  const PRIMARY_ENDPOINT = "https://pro.ip-api.com/json/?key=R1a8D9VJfrqTqpY&fields=status,country,countryCode,region,city";
+  const PRIMARY_ENDPOINT = "https://pro.ip-api.com/json/?key=R1a8D9VJfrqTqpY&fields=status,country,countryCode,region,regionName,city,query";
 
-  async function requestCity() {
+  async function requestGeoData() {
     const response = await fetch(PRIMARY_ENDPOINT);
     const data = await response.json();
 
-    if (data && data.status === "success" && data.city) {
-      return data.city;
+    if (data && data.status === "success") {
+      return data;
     }
 
     return null;
@@ -28,16 +28,16 @@
     element.textContent = loadingText;
 
     try {
-      const city = await requestCity();
+      const geoData = await requestGeoData();
 
-      if (city) {
-        element.textContent = city;
-        console.log('Cidade detectada:', city);
-        return city;
+      if (geoData && geoData.city) {
+        element.textContent = geoData.city;
+        console.log('GeoData detectado:', geoData);
+        return geoData;
       }
 
       element.textContent = fallbackText;
-      console.log('Fallback: Cidade não detectada ou status != success');
+      console.log('Fallback: GeoData não detectado ou status != success');
       return null;
     } catch (error) {
       console.log("Fallback: Erro na API de geolocalização", error);

--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -11,6 +11,71 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="/telegram/styles.css" />
+
+    <!-- Meta Pixel Code -->
+    <script>
+      !(function (f, b, e, v, n, t, s) {
+        if (f.fbq) return;
+        n = f.fbq = function () {
+          n.callMethod ? n.callMethod.apply(n, arguments) : n.queue.push(arguments);
+        };
+        if (!f._fbq) f._fbq = n;
+        n.push = n;
+        n.loaded = !0;
+        n.version = '2.0';
+        n.queue = [];
+        t = b.createElement(e);
+        t.async = !0;
+        t.src = v;
+        s = b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t, s);
+      })(
+        window,
+        document,
+        'script',
+        'https://connect.facebook.net/en_US/fbevents.js'
+      );
+    </script>
+    <noscript>
+      <img
+        height="1"
+        width="1"
+        style="display: none"
+        src="https://www.facebook.com/tr?id=YOUR_PIXEL_ID&ev=PageView&noscript=1"
+        alt=""
+      />
+    </noscript>
+    <script>
+      (function () {
+        if (window.__fbPixelConfigPromise) {
+          return;
+        }
+
+        window.__FB_PIXEL_ID__ = window.__FB_PIXEL_ID__ || null;
+
+        const configPromise = typeof fetch === 'function'
+          ? fetch('/api/config', { credentials: 'same-origin' })
+              .then((response) => (response.ok ? response.json() : null))
+              .then((config) => {
+                if (config && config.FB_PIXEL_ID) {
+                  fbq('init', config.FB_PIXEL_ID);
+                  window.__FB_PIXEL_ID__ = config.FB_PIXEL_ID;
+                  return config;
+                }
+
+                console.warn('Meta Pixel ID não configurado no servidor.');
+                return config;
+              })
+              .catch((error) => {
+                console.warn('Não foi possível carregar a configuração do Meta Pixel.', error);
+                return null;
+              })
+          : Promise.resolve(null);
+
+        window.__fbPixelConfigPromise = configPromise;
+      })();
+    </script>
+    <!-- End Meta Pixel Code -->
   </head>
   <body>
     <div class="page-wrapper">
@@ -67,15 +132,7 @@
     <script>
       window.BOT1_LINK_FROM_SERVER = "<%= process.env.BOT1_TELEGRAM_LINK || 'https://t.me/bot1' %>";
     </script>
-    <script src="../geolocation.js"></script>
-    <script>
-      document.addEventListener('DOMContentLoaded', function () {
-        detectCityAndUpdate('city', {
-          loadingText: 'Detectando...',
-          fallbackText: 'Detectando...'
-        });
-      });
-    </script>
+    <script src="../geolocation.js" defer></script>
     <script src="/telegram/app.js" defer></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- embed the Meta Pixel loader in the Telegram landing page and load the pixel ID from the existing /api/config endpoint
- expand the geolocation helper to return enriched geo/IP data for use in event payloads
- update the redirect script to hash available user data, await pixel readiness, and fire manual PageView and ViewContent events with advanced matching information

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e24c9fd8cc832ab705575868190227