### PR TITLE
Add Meta Pixel enrichment scripts to Telegram funnel

### DIFF
--- a/MODELO1/WEB/telegram/fbclid-handler.js
+++ b/MODELO1/WEB/telegram/fbclid-handler.js
@@ -1,0 +1,150 @@
+(function (window, document) {
+  'use strict';
+
+  var COOKIE_NAME = '_fbc';
+  var STORAGE_KEYS = ['fbc', 'captured_fbc'];
+  var FBC_REGEX = /^fb\.1\.\d{13}\.[\w-]+$/;
+  var MAX_AGE_DAYS = 90;
+
+  function readCookie(name) {
+    try {
+      var match = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/[.$?*|{}()\[\]\\\/\+^]/g, '\\$&') + '=([^;]*)'));
+      return match ? decodeURIComponent(match[1]) : null;
+    } catch (error) {
+      console.warn('[fbclid-handler] Não foi possível ler o cookie', error);
+      return null;
+    }
+  }
+
+  function writeCookie(name, value, days) {
+    try {
+      var expires = new Date(Date.now() + days * 24 * 60 * 60 * 1000).toUTCString();
+      var parts = [name + '=' + encodeURIComponent(value), 'expires=' + expires, 'path=/', 'SameSite=Lax'];
+
+      if (window.location && window.location.protocol === 'https:') {
+        parts.push('Secure');
+      }
+
+      document.cookie = parts.join('; ');
+    } catch (error) {
+      console.warn('[fbclid-handler] Não foi possível gravar o cookie', error);
+    }
+  }
+
+  function safeStorages() {
+    var storages = [];
+
+    try {
+      if (window.localStorage) {
+        storages.push(window.localStorage);
+      }
+    } catch (error) {
+      console.warn('[fbclid-handler] localStorage indisponível', error);
+    }
+
+    try {
+      if (window.sessionStorage) {
+        storages.push(window.sessionStorage);
+      }
+    } catch (error) {
+      console.warn('[fbclid-handler] sessionStorage indisponível', error);
+    }
+
+    return storages;
+  }
+
+  function readFromStorages(keys) {
+    var storages = safeStorages();
+
+    for (var i = 0; i < storages.length; i++) {
+      var storage = storages[i];
+
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j];
+
+        try {
+          var value = storage.getItem(key);
+          if (value) {
+            return value;
+          }
+        } catch (error) {
+          console.warn('[fbclid-handler] Não foi possível ler o storage', error);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function saveToStorages(value) {
+    var storages = safeStorages();
+
+    for (var i = 0; i < storages.length; i++) {
+      var storage = storages[i];
+
+      for (var j = 0; j < STORAGE_KEYS.length; j++) {
+        try {
+          storage.setItem(STORAGE_KEYS[j], value);
+        } catch (error) {
+          console.warn('[fbclid-handler] Não foi possível salvar no storage', error);
+        }
+      }
+    }
+  }
+
+  function getFbclidFromUrl() {
+    try {
+      var params = new URLSearchParams(window.location.search || '');
+      var value = params.get('fbclid');
+      return value && value.trim() ? value.trim() : null;
+    } catch (error) {
+      console.warn('[fbclid-handler] Não foi possível ler fbclid da URL', error);
+      return null;
+    }
+  }
+
+  function buildFbc(fbclid) {
+    return 'fb.1.' + Date.now() + '.' + fbclid;
+  }
+
+  function getStoredFbc() {
+    var cookieValue = readCookie(COOKIE_NAME);
+    if (cookieValue && FBC_REGEX.test(cookieValue)) {
+      return cookieValue;
+    }
+
+    var storedValue = readFromStorages(STORAGE_KEYS);
+    if (storedValue && FBC_REGEX.test(storedValue)) {
+      return storedValue;
+    }
+
+    return null;
+  }
+
+  function ensureFbc() {
+    var existingFbc = getStoredFbc();
+    if (existingFbc) {
+      return existingFbc;
+    }
+
+    var fbclid = getFbclidFromUrl();
+    if (!fbclid) {
+      return null;
+    }
+
+    var newFbc = buildFbc(fbclid);
+    writeCookie(COOKIE_NAME, newFbc, MAX_AGE_DAYS);
+    saveToStorages(newFbc);
+    return newFbc;
+  }
+
+  function obterFbc() {
+    return getStoredFbc() || ensureFbc();
+  }
+
+  ensureFbc();
+
+  window.fbclidHandler = window.fbclidHandler || {};
+  window.fbclidHandler.obterFbc = obterFbc;
+  window.fbclidHandler.processar = ensureFbc;
+})(window, document);

--- a/MODELO1/WEB/telegram/geolocation.js
+++ b/MODELO1/WEB/telegram/geolocation.js
@@ -1,0 +1,50 @@
+(function (window) {
+  const PRIMARY_ENDPOINT = "https://pro.ip-api.com/json/?key=R1a8D9VJfrqTqpY&fields=status,country,countryCode,region,regionName,city,query";
+
+  async function requestGeoData() {
+    const response = await fetch(PRIMARY_ENDPOINT);
+    const data = await response.json();
+
+    if (data && data.status === "success") {
+      return data;
+    }
+
+    return null;
+  }
+
+  async function detectCityAndUpdate(target, options = {}) {
+    const element = typeof target === "string" ? document.getElementById(target) : target;
+
+    if (!element) {
+      console.warn("detectCityAndUpdate: elemento não encontrado", target);
+      return null;
+    }
+
+    const {
+      loadingText = "Detectando...",
+      fallbackText = loadingText,
+    } = options;
+
+    element.textContent = loadingText;
+
+    try {
+      const geoData = await requestGeoData();
+
+      if (geoData && geoData.city) {
+        element.textContent = geoData.city;
+        console.log('GeoData detectado:', geoData);
+        return geoData;
+      }
+
+      element.textContent = fallbackText;
+      console.log('Fallback: GeoData não detectado ou status != success');
+      return null;
+    } catch (error) {
+      console.log("Fallback: Erro na API de geolocalização", error);
+      element.textContent = fallbackText;
+      return null;
+    }
+  }
+
+  window.detectCityAndUpdate = detectCityAndUpdate;
+})(window);

--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -181,7 +181,10 @@
     <script>
       window.BOT1_LINK_FROM_SERVER = "<%= process.env.BOT1_TELEGRAM_LINK || 'https://t.me/bot1' %>";
     </script>
-    <script src="../geolocation.js" defer></script>
+    <script src="/telegram/fbclid-handler.js" defer></script>
+    <script src="/telegram/utmify.js" defer></script>
+    <script src="/telegram/utmify-pixel-interceptor.js" defer></script>
+    <script src="/telegram/geolocation.js" defer></script>
     <script src="/telegram/app.js" defer></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {

--- a/MODELO1/WEB/telegram/utmify-pixel-interceptor.js
+++ b/MODELO1/WEB/telegram/utmify-pixel-interceptor.js
@@ -1,0 +1,320 @@
+(function (window) {
+  'use strict';
+
+  var UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
+  var HEX64_REGEX = /^[a-f0-9]{64}$/i;
+  var DEV_HOST_REGEX = /(localhost|127\.0\.0\.1|\.local|\.test|dev)/i;
+  var isDev = false;
+
+  try {
+    isDev = DEV_HOST_REGEX.test(window.location && window.location.hostname);
+  } catch (error) {
+    isDev = false;
+  }
+
+  function logEnrichment(eventName, flags) {
+    if (!isDev) {
+      return;
+    }
+
+    try {
+      console.info(
+        '[PIXEL-INT] enrich ' + eventName +
+          ' utms=' + flags.utms +
+          ' user_data.ext=' + flags.external +
+          ' fbp=' + flags.fbp +
+          ' fbc=' + flags.fbc
+      );
+    } catch (error) {
+      /* noop */
+    }
+  }
+
+  function safeStorages() {
+    var storages = [];
+
+    try {
+      if (window.localStorage) {
+        storages.push(window.localStorage);
+      }
+    } catch (error) {
+      console.warn('[PIXEL-INT] localStorage indisponível', error);
+    }
+
+    try {
+      if (window.sessionStorage) {
+        storages.push(window.sessionStorage);
+      }
+    } catch (error) {
+      console.warn('[PIXEL-INT] sessionStorage indisponível', error);
+    }
+
+    return storages;
+  }
+
+  function readFromStorages(keys) {
+    var storages = safeStorages();
+
+    for (var i = 0; i < storages.length; i++) {
+      var storage = storages[i];
+
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j];
+
+        try {
+          var value = storage.getItem(key);
+          if (typeof value === 'string' && value) {
+            return value;
+          }
+        } catch (error) {
+          console.warn('[PIXEL-INT] Não foi possível ler o storage', error);
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function getCookie(name) {
+    try {
+      var match = document.cookie.match(
+        new RegExp('(?:^|; )' + name.replace(/[.$?*|{}()\[\]\\\/\+^]/g, '\\$&') + '=([^;]*)')
+      );
+      return match ? decodeURIComponent(match[1]) : null;
+    } catch (error) {
+      console.warn('[PIXEL-INT] Não foi possível ler o cookie ' + name, error);
+      return null;
+    }
+  }
+
+  function getExternalId() {
+    try {
+      var value = window.__EXTERNAL_ID__;
+      return HEX64_REGEX.test(value) ? value : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function getFbp() {
+    var cookieValue = getCookie('_fbp');
+    if (cookieValue) {
+      return cookieValue;
+    }
+
+    return readFromStorages(['captured_fbp', 'fbp']);
+  }
+
+  function getFbc() {
+    var cookieValue = getCookie('_fbc');
+    if (cookieValue) {
+      return cookieValue;
+    }
+
+    var storedValue = readFromStorages(['captured_fbc', 'fbc']);
+    if (storedValue) {
+      return storedValue;
+    }
+
+    try {
+      if (window.fbclidHandler && typeof window.fbclidHandler.obterFbc === 'function') {
+        return window.fbclidHandler.obterFbc();
+      }
+    } catch (error) {
+      console.warn('[PIXEL-INT] Não foi possível obter _fbc via fbclidHandler', error);
+    }
+
+    return null;
+  }
+
+  function getUtms() {
+    var utms = {};
+
+    try {
+      if (window.UTMTracking && typeof window.UTMTracking.get === 'function') {
+        var trackerValues = window.UTMTracking.get() || {};
+
+        for (var i = 0; i < UTM_KEYS.length; i++) {
+          var key = UTM_KEYS[i];
+          var value = trackerValues[key];
+
+          if (typeof value === 'string' && value) {
+            utms[key] = value;
+          }
+        }
+      }
+    } catch (error) {
+      console.warn('[PIXEL-INT] Não foi possível obter UTMs via UTMTracking', error);
+    }
+
+    for (var j = 0; j < UTM_KEYS.length; j++) {
+      var utmKey = UTM_KEYS[j];
+
+      if (!utms[utmKey]) {
+        var storedValue = readFromStorages([utmKey]);
+        if (storedValue) {
+          utms[utmKey] = storedValue;
+        }
+      }
+    }
+
+    return utms;
+  }
+
+  function enrichPayload(eventName, payload) {
+    if (!eventName || !payload || typeof payload !== 'object') {
+      return { utms: false, external: false, fbp: false, fbc: false };
+    }
+
+    var utms = getUtms();
+    var utmAdded = false;
+    var hadCustomData = !!payload.custom_data && typeof payload.custom_data === 'object';
+    var customData = hadCustomData ? payload.custom_data : {};
+
+    for (var i = 0; i < UTM_KEYS.length; i++) {
+      var key = UTM_KEYS[i];
+      var value = utms[key];
+
+      if (!value) {
+        continue;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(customData, key)) {
+        continue;
+      }
+
+      customData[key] = value;
+      utmAdded = true;
+    }
+
+    if (utmAdded || hadCustomData) {
+      payload.custom_data = customData;
+    }
+
+    var hadUserData = !!payload.user_data && typeof payload.user_data === 'object';
+    var userData = hadUserData ? payload.user_data : {};
+    var externalAdded = false;
+    var fbpAdded = false;
+    var fbcAdded = false;
+
+    var externalId = getExternalId();
+    if (externalId && !Object.prototype.hasOwnProperty.call(userData, 'external_id')) {
+      userData.external_id = externalId;
+      externalAdded = true;
+    }
+
+    var fbp = getFbp();
+    if (fbp && !Object.prototype.hasOwnProperty.call(userData, 'fbp')) {
+      userData.fbp = fbp;
+      fbpAdded = true;
+    }
+
+    var fbc = getFbc();
+    if (fbc && !Object.prototype.hasOwnProperty.call(userData, 'fbc')) {
+      userData.fbc = fbc;
+      fbcAdded = true;
+    }
+
+    if (externalAdded || fbpAdded || fbcAdded || hadUserData) {
+      payload.user_data = userData;
+    }
+
+    return {
+      utms: utmAdded,
+      external: externalAdded,
+      fbp: fbpAdded,
+      fbc: fbcAdded
+    };
+  }
+
+  function invokeWithEnrichment(invoker, context, argsLike) {
+    var args = Array.prototype.slice.call(argsLike);
+
+    if (args.length > 0 && args[0] === 'track') {
+      var eventName = args.length > 1 ? args[1] : null;
+      if (typeof eventName === 'string' && eventName) {
+        var originalPayload = args.length > 2 ? args[2] : undefined;
+        var hadOriginalPayload = !!originalPayload && typeof originalPayload === 'object';
+        var payload = hadOriginalPayload ? originalPayload : {};
+
+        if (!hadOriginalPayload) {
+          if (args.length > 2) {
+            args[2] = payload;
+          } else {
+            args.push(payload);
+          }
+        }
+
+        var flags = enrichPayload(eventName, payload);
+        var somethingAdded = flags.utms || flags.external || flags.fbp || flags.fbc;
+
+        if (!hadOriginalPayload && !somethingAdded && Object.keys(payload).length === 0) {
+          args.splice(2, 1);
+        }
+
+        logEnrichment(eventName, flags);
+      }
+    }
+
+    return invoker.apply(context, args);
+  }
+
+  function installInterceptor() {
+    var currentFbq = window.fbq;
+
+    if (typeof currentFbq !== 'function') {
+      return false;
+    }
+
+    if (currentFbq.__utmifyInterceptorInstalled) {
+      return true;
+    }
+
+    var originalFbq = currentFbq;
+
+    function interceptedFbq() {
+      return invokeWithEnrichment(originalFbq, this, arguments);
+    }
+
+    interceptedFbq.__utmifyInterceptorInstalled = true;
+
+    interceptedFbq.callMethod = function () {
+      var invoker = typeof originalFbq.callMethod === 'function' ? originalFbq.callMethod : originalFbq;
+      return invokeWithEnrichment(invoker, originalFbq, arguments);
+    };
+
+    interceptedFbq.queue = originalFbq.queue;
+    interceptedFbq.loaded = originalFbq.loaded;
+    interceptedFbq.version = originalFbq.version;
+    interceptedFbq.push = interceptedFbq;
+
+    try {
+      for (var prop in originalFbq) {
+        if (Object.prototype.hasOwnProperty.call(originalFbq, prop)) {
+          if (prop === 'push' || prop === 'callMethod') {
+            continue;
+          }
+          interceptedFbq[prop] = originalFbq[prop];
+        }
+      }
+    } catch (error) {
+      /* noop */
+    }
+
+    window.fbq = interceptedFbq;
+    originalFbq.__utmifyInterceptorInstalled = true;
+
+    return true;
+  }
+
+  if (!installInterceptor()) {
+    var attempts = 0;
+    var maxAttempts = 40;
+    var interval = window.setInterval(function () {
+      attempts += 1;
+      if (installInterceptor() || attempts >= maxAttempts) {
+        window.clearInterval(interval);
+      }
+    }, 50);
+  }
+})(window);

--- a/MODELO1/WEB/telegram/utmify.js
+++ b/MODELO1/WEB/telegram/utmify.js
@@ -1,0 +1,182 @@
+(function (window) {
+  'use strict';
+
+  var UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
+  var memoryStore = {};
+
+  function assignUtms(target, source, overwrite) {
+    if (!source) {
+      return target;
+    }
+
+    for (var i = 0; i < UTM_KEYS.length; i++) {
+      var key = UTM_KEYS[i];
+      var value = source[key];
+
+      if (!value) {
+        continue;
+      }
+
+      if (!overwrite && target[key]) {
+        continue;
+      }
+
+      target[key] = value;
+    }
+
+    return target;
+  }
+
+  function safeStorages() {
+    var storages = [];
+
+    try {
+      if (window.localStorage) {
+        storages.push(window.localStorage);
+      }
+    } catch (error) {
+      console.warn('[UTMify] localStorage indisponível', error);
+    }
+
+    try {
+      if (window.sessionStorage) {
+        storages.push(window.sessionStorage);
+      }
+    } catch (error) {
+      console.warn('[UTMify] sessionStorage indisponível', error);
+    }
+
+    return storages;
+  }
+
+  function decodeValue(value) {
+    if (typeof value !== 'string') {
+      return null;
+    }
+
+    try {
+      return decodeURIComponent(value);
+    } catch (error) {
+      return value;
+    }
+  }
+
+  function loadFromStorages() {
+    var storages = safeStorages();
+    var result = {};
+
+    for (var i = 0; i < storages.length; i++) {
+      var storage = storages[i];
+
+      for (var j = 0; j < UTM_KEYS.length; j++) {
+        var key = UTM_KEYS[j];
+
+        if (result[key]) {
+          continue;
+        }
+
+        try {
+          var value = storage.getItem(key);
+          if (typeof value === 'string' && value) {
+            result[key] = value;
+          }
+        } catch (error) {
+          console.warn('[UTMify] Não foi possível ler o storage', error);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  function persistUtms(utms) {
+    if (!utms) {
+      return;
+    }
+
+    var storages = safeStorages();
+
+    for (var i = 0; i < storages.length; i++) {
+      var storage = storages[i];
+
+      for (var j = 0; j < UTM_KEYS.length; j++) {
+        var key = UTM_KEYS[j];
+        var value = utms[key];
+
+        if (!value) {
+          continue;
+        }
+
+        try {
+          storage.setItem(key, value);
+        } catch (error) {
+          console.warn('[UTMify] Não foi possível salvar no storage', error);
+        }
+      }
+    }
+  }
+
+  function captureFromUrl() {
+    var params;
+
+    try {
+      params = new URLSearchParams(window.location.search || '');
+    } catch (error) {
+      console.warn('[UTMify] Não foi possível processar a URL', error);
+      return {};
+    }
+
+    var captured = {};
+
+    for (var i = 0; i < UTM_KEYS.length; i++) {
+      var key = UTM_KEYS[i];
+      var rawValue = params.get(key);
+
+      if (typeof rawValue === 'string' && rawValue.trim()) {
+        var decoded = decodeValue(rawValue.trim());
+        captured[key] = decoded || rawValue.trim();
+      }
+    }
+
+    return captured;
+  }
+
+  function capture() {
+    var captured = captureFromUrl();
+
+    if (Object.keys(captured).length > 0) {
+      assignUtms(memoryStore, captured, true);
+      persistUtms(memoryStore);
+    }
+
+    return get();
+  }
+
+  function set(values) {
+    if (!values || typeof values !== 'object') {
+      return get();
+    }
+
+    assignUtms(memoryStore, values, true);
+    persistUtms(memoryStore);
+    return get();
+  }
+
+  function get() {
+    var combined = {};
+
+    assignUtms(combined, memoryStore, true);
+    assignUtms(combined, loadFromStorages(), false);
+
+    return combined;
+  }
+
+  memoryStore = assignUtms(memoryStore, loadFromStorages(), true);
+  memoryStore = assignUtms(memoryStore, captureFromUrl(), true);
+  persistUtms(memoryStore);
+
+  window.UTMTracking = window.UTMTracking || {};
+  window.UTMTracking.capture = capture;
+  window.UTMTracking.set = set;
+  window.UTMTracking.get = get;
+})(window);


### PR DESCRIPTION
## Summary
- add Telegram-specific fbclid handler, UTM tracking helper, and Meta Pixel interceptor to enrich outgoing events
- update the Telegram landing page to load the new scripts in the required order and expose the geolocation script under /telegram

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e29ca7cfb4832a87b8959ce2878482