### PR TITLE
Add payload_id fallback for Telegram start payloads

### DIFF
--- a/services/payloads.js
+++ b/services/payloads.js
@@ -1,0 +1,46 @@
+const { getPool, executeQuery } = require('../database/postgres');
+
+function ensurePool() {
+  const pool = getPool();
+
+  if (!pool) {
+    throw new Error('PostgreSQL pool is not initialized');
+  }
+
+  return pool;
+}
+
+function sanitizePayloadId(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+async function getPayloadById(payloadId) {
+  const sanitized = sanitizePayloadId(payloadId);
+
+  if (!sanitized) {
+    return null;
+  }
+
+  const pool = ensurePool();
+
+  const query = `
+    SELECT payload_id, utm_source, utm_medium, utm_campaign, utm_term,
+           utm_content, fbp, fbc, ip, user_agent, kwai_click_id
+      FROM payloads
+     WHERE payload_id = $1
+     LIMIT 1
+  `;
+
+  const result = await executeQuery(pool, query, [sanitized]);
+
+  return result.rows[0] || null;
+}
+
+module.exports = {
+  getPayloadById,
+};


### PR DESCRIPTION
## Summary
- add client-side fallback to request payload_id when the start payload exceeds the Base64 length threshold and log the redirect source
- allow the Telegram webhook to resolve payload_id payloads by loading persisted data and reusing the existing upsert + CAPI flow
- add a payload DAO and document how to test the new fallback in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2a4859da8832abb05764fc61fbfca