### PR TITLE
Add UTMify conversion service and debug utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ WHATSAPP_FB_PIXEL_TOKEN=
 # Token da API da UTMify utilizado pelo funil WhatsApp (mantenha em segredo)
 WHATSAPP_UTMIFY_API_TOKEN=
 
+# Configuração do envio de conversões para a UTMify via backend
+UTMIFY_API_URL=
+UTMIFY_API_TOKEN=
+
 # URL base pública usada pelo funil WhatsApp para carregar recursos
 BASE_URL=
 

--- a/config_gateway_pix.env.example
+++ b/config_gateway_pix.env.example
@@ -26,6 +26,7 @@ PUSHINPAY_TOKEN=seu_token_pushinpay
 # PUSHINPAY_WEBHOOK_TOKEN=seu_token_webhook_pushinpay  # OPCIONAL - header customizado
 
 # UTMify
+UTMIFY_API_URL=https://api.utmify.com/v1
 UTMIFY_API_TOKEN=seu_token_utmify
 
 # URLs

--- a/services/utmify.js
+++ b/services/utmify.js
@@ -1,8 +1,26 @@
 const axios = require('axios');
-const { v4: uuidv4 } = require('uuid');
-const adAccountId = process.env.UTMIFY_AD_ACCOUNT_ID; // ex: '129355640213755'
 
-function sanitizeTrackingValue(value) {
+const HEX_64_REGEX = /^[a-f0-9]{64}$/i;
+const MAX_ATTEMPTS = 3;
+const BACKOFF_DELAYS_MS = [200, 500, 800];
+const REQUEST_TIMEOUT_MS = 5000;
+const UTM_FIELDS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
+
+function getConfig() {
+  const apiUrl = process.env.UTMIFY_API_URL ? process.env.UTMIFY_API_URL.trim() : '';
+  const apiToken = process.env.UTMIFY_API_TOKEN ? process.env.UTMIFY_API_TOKEN.trim() : '';
+  return {
+    apiUrl: apiUrl ? apiUrl.replace(/\/+$/, '') : '',
+    apiToken
+  };
+}
+
+function isConfigured() {
+  const { apiUrl, apiToken } = getConfig();
+  return Boolean(apiUrl && apiToken);
+}
+
+function sanitizeUtmValue(value) {
   if (value === null || value === undefined) {
     return null;
   }
@@ -11,184 +29,228 @@ function sanitizeTrackingValue(value) {
     if (!trimmed) {
       return null;
     }
-    if (trimmed.toLowerCase() === 'unknown') {
-      return null;
-    }
-    return trimmed;
+    return trimmed.toLowerCase();
   }
   return value;
 }
 
-function sanitizeTrackingData(trackingData) {
-  if (!trackingData || typeof trackingData !== 'object') {
-    return {};
-  }
-  const sanitized = { ...trackingData };
-  ['src', 'sck', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'].forEach(field => {
-    sanitized[field] = sanitizeTrackingValue(trackingData[field]);
+function sanitizeUtm(utm = {}) {
+  const sanitized = {};
+  UTM_FIELDS.forEach(field => {
+    const sanitizedValue = sanitizeUtmValue(utm[field]);
+    if (sanitizedValue !== null && sanitizedValue !== undefined) {
+      sanitized[field] = sanitizedValue;
+    }
   });
   return sanitized;
 }
 
-function formatDateUTC(date) {
-  const pad = n => String(n).padStart(2, '0');
-  return (
-    date.getUTCFullYear() +
-    '-' +
-    pad(date.getUTCMonth() + 1) +
-    '-' +
-    pad(date.getUTCDate()) +
-    ' ' +
-    pad(date.getUTCHours()) +
-    ':' +
-    pad(date.getUTCMinutes()) +
-    ':' +
-    pad(date.getUTCSeconds())
-  );
+function sanitizeHash(value) {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (!HEX_64_REGEX.test(trimmed)) {
+    return null;
+  }
+  return trimmed.toLowerCase();
 }
 
-function gerarEmailFake() {
-  return `${uuidv4()}@example.org`;
-}
-
-function sanitizeName(str) {
-  return (str || '')
-    .toString()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
-}
-
-// 🔥 NOVA FUNÇÃO: Processar UTM no formato nome|id (similar à do server.js)
-function processUTMForUtmify(utmValue) {
-  if (!utmValue) return { name: null, id: null, formatted: null };
-  
-  try {
-    const decoded = decodeURIComponent(utmValue);
-    const parts = decoded.split('|');
-    
-    if (parts.length >= 2) {
-      const name = parts[0].trim();
-      const id = parts[1].trim();
-
-      // Validar se o ID é numérico
-      if (name && id && /^\d+$/.test(id)) {
-        const formatted = `${name}|${id}`;
-        console.log(`✅ UTM processado para UTMify: "${utmValue}" → nome: "${name}", id: "${id}", formatado: "${formatted}"`);
-        return { name, id, formatted };
-      }
-
-      const fallbackName = name || decoded;
-      console.log(
-        `ℹ️ UTM sem ID numérico válido para UTMify: "${utmValue}" → usando fallback "${fallbackName}"`
-      );
-      return { name: fallbackName, id: null, formatted: fallbackName };
+function sanitizeIds(ids = {}) {
+  const sanitized = {};
+  if (ids.external_id_hash) {
+    const externalIdHash = sanitizeHash(ids.external_id_hash);
+    if (externalIdHash) {
+      sanitized.external_id_hash = externalIdHash;
     }
-
-    // Se não tem formato nome|id, retorna apenas o nome/valor decodificado
-    console.log(`ℹ️ UTM sem formato nome|id para UTMify: "${utmValue}"`);
-    return { name: decoded, id: null, formatted: decoded };
-    
-  } catch (error) {
-    console.error(`❌ Erro ao processar UTM para UTMify "${utmValue}":`, error.message);
-    return { name: utmValue, id: null, formatted: utmValue };
   }
+  if (ids.fbp) {
+    const fbp = typeof ids.fbp === 'string' ? ids.fbp.trim() : ids.fbp;
+    if (fbp) {
+      sanitized.fbp = fbp;
+    }
+  }
+  if (ids.fbc) {
+    const fbc = typeof ids.fbc === 'string' ? ids.fbc.trim() : ids.fbc;
+    if (fbc) {
+      sanitized.fbc = fbc;
+    }
+  }
+  if (ids.zip_hash) {
+    const zipHash = sanitizeHash(ids.zip_hash);
+    if (zipHash) {
+      sanitized.zip_hash = zipHash;
+    }
+  }
+  return sanitized;
 }
 
-async function enviarConversaoParaUtmify({ payer_name, telegram_id, transactionValueCents, trackingData, orderId, nomeOferta }) {
-  const now = new Date();
-  const createdAt = formatDateUTC(now);
-  const finalOrderId = orderId || uuidv4();
-  const sanitizedTracking = sanitizeTrackingData(trackingData);
-  const {
-    src,
-    sck = null,
-    utm_source = null,
-    utm_medium = null,
-    utm_campaign = null,
-    utm_content = null,
-    utm_term = null
-  } = sanitizedTracking;
-
-  // 🔥 CORREÇÃO: Usar função processUTMForUtmify para processar UTMs
-  const utmCampaignProcessed = processUTMForUtmify(utm_campaign);
-  const utmMediumProcessed = processUTMForUtmify(utm_medium);
-  const utmContentProcessed = processUTMForUtmify(utm_content);
-
-  if (!utmCampaignProcessed.id || !utmContentProcessed.id) {
-    console.warn('UTM parsing issue:', { 
-      campaignId: utmCampaignProcessed.id, 
-      adId: utmContentProcessed.id, 
-      utm_campaign, 
-      utm_content 
-    });
+function sanitizeClient(client = {}) {
+  const sanitized = {};
+  if (client.ip) {
+    const ip = typeof client.ip === 'string' ? client.ip.trim() : client.ip;
+    if (ip) {
+      sanitized.ip = ip;
+    }
   }
+  if (client.user_agent) {
+    const userAgent = typeof client.user_agent === 'string' ? client.user_agent.trim() : client.user_agent;
+    if (userAgent) {
+      sanitized.user_agent = userAgent;
+    }
+  }
+  return sanitized;
+}
+
+function normalizeValue(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Number(value.toFixed(2));
+  }
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return Number(parsed.toFixed(2));
+    }
+  }
+  return null;
+}
+
+function buildOrderPayload({ order_id, value, currency = 'BRL', utm = {}, ids = {}, client = {} }) {
+  const orderId = typeof order_id === 'string' ? order_id.trim() : order_id;
+  if (!orderId) {
+    throw new Error('order_id é obrigatório para enviar conversão à UTMify');
+  }
+
+  const normalizedValue = normalizeValue(value);
+  const sanitizedUtm = sanitizeUtm(utm);
+  const sanitizedIds = sanitizeIds(ids);
+  const sanitizedClient = sanitizeClient(client);
 
   const payload = {
-    orderId: finalOrderId,
-    platform: 'pushinpay',
-    paymentMethod: 'pix',
-    status: 'paid',
-    createdAt,
-    approvedDate: createdAt,
-    refundedAt: null,
-    customer: {
-      name: payer_name,
-      email: gerarEmailFake(),
-      phone: null,
-      document: null
-    },
-    products: [
-      {
-        id: 'curso-vitalicio',
-        name: nomeOferta || 'Oferta Desconhecida',
-        planId: 'curso-vitalicio',
-        planName: nomeOferta || 'Oferta Desconhecida',
-        quantity: 1,
-        priceInCents: transactionValueCents
-      }
-    ],
-    trackingParameters: {
-      src,
-      sck,
-      utm_source,
-      utm_medium:
-        utmMediumProcessed.formatted ?? utm_medium ?? utmMediumProcessed.name,
-      utm_content:
-        utmContentProcessed.formatted ?? utm_content ?? utmContentProcessed.name,
-      utm_term,
-      // 🔥 CORREÇÃO: Usar utm_campaign no formato nome|id
-      utm_campaign: utmCampaignProcessed.formatted
-    },
-    // A UTMify espera os valores brutos (sem taxas) para a comissão.
-    commission: {
-      totalPriceInCents: transactionValueCents,
-      gatewayFeeInCents: 0,
-      userCommissionInCents: transactionValueCents
-    },
-    isTest: false
+    order_id: orderId,
+    currency: currency || 'BRL'
   };
-  console.log('UTMify Payload:', JSON.stringify(payload, null, 2));
-  console.log('📊 UTM details:', {
-    utmCampaignProcessed,
-    utmMediumProcessed,
-    utmContentProcessed
-  });
-  try {
-    const res = await axios.post(
-      'https://api.utmify.com.br/api-credentials/orders',
-      payload,
-      { headers: { 'x-api-token': process.env.UTMIFY_API_TOKEN } }
-    );
-    console.log('Resposta UTMify:', res.data);
-    return res.data;
-  } catch (err) {
-    console.error('Erro UTMify:', err.response?.status, err.response?.data);
-    console.error('Payload enviado:', JSON.stringify(payload, null, 2));
-    throw err;
+
+  if (normalizedValue !== null) {
+    payload.value = normalizedValue;
   }
+  if (Object.keys(sanitizedUtm).length > 0) {
+    payload.utm = sanitizedUtm;
+  }
+  if (Object.keys(sanitizedIds).length > 0) {
+    payload.ids = sanitizedIds;
+  }
+  if (Object.keys(sanitizedClient).length > 0) {
+    payload.client = sanitizedClient;
+  }
+
+  return payload;
 }
 
-module.exports = { enviarConversaoParaUtmify };
+async function postOrder(options = {}) {
+  const { apiUrl, apiToken } = getConfig();
+  if (!apiUrl || !apiToken) {
+    return { ok: false, sent: false, skipped: true, reason: 'missing_config' };
+  }
+
+  let payload;
+  try {
+    payload = buildOrderPayload(options);
+  } catch (error) {
+    console.warn('[UTMify] Conversão ignorada:', error.message);
+    return { ok: false, sent: false, skipped: true, reason: error.message };
+  }
+
+  const endpoint = `${apiUrl}/order/conversion`;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const response = await axios.post(endpoint, payload, {
+        timeout: REQUEST_TIMEOUT_MS,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Authorization': `Bearer ${apiToken}`
+        }
+      });
+
+      console.log(`[UTMify] Conversão enviada (${payload.order_id}) tentativa ${attempt}`);
+      return { ok: true, sent: true, attempt, response: response.data };
+    } catch (error) {
+      const status = error.response?.status || null;
+      const message = error.response?.data || error.message;
+      console.warn(`[UTMify] Falha ao enviar (${payload.order_id}) tentativa ${attempt}`, {
+        status,
+        message
+      });
+
+      if (attempt >= MAX_ATTEMPTS) {
+        return { ok: false, sent: false, attempt, status, error: message };
+      }
+
+      const delay = BACKOFF_DELAYS_MS[Math.min(attempt - 1, BACKOFF_DELAYS_MS.length - 1)];
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+
+  return { ok: false, sent: false, attempt: MAX_ATTEMPTS, error: 'unexpected_state' };
+}
+
+async function enviarConversaoParaUtmify(legacyPayload = {}) {
+  const {
+    orderId = null,
+    transactionValueCents = null,
+    trackingData = {},
+    currency = 'BRL',
+    telegram_id = null,
+    external_id_hash = null,
+    fbp = null,
+    fbc = null,
+    zip_hash = null
+  } = legacyPayload;
+
+  const value = Number.isFinite(transactionValueCents)
+    ? Number((transactionValueCents / 100).toFixed(2))
+    : null;
+
+  const orderIdSource = orderId || telegram_id || null;
+  if (!orderIdSource) {
+    return { ok: false, sent: false, skipped: true, reason: 'missing_order_id' };
+  }
+
+  const utm = {};
+  UTM_FIELDS.forEach(field => {
+    if (trackingData && Object.prototype.hasOwnProperty.call(trackingData, field)) {
+      utm[field] = trackingData[field];
+    }
+  });
+
+  const ids = {
+    external_id_hash: trackingData?.external_id_hash || external_id_hash,
+    fbp: trackingData?.fbp || fbp,
+    fbc: trackingData?.fbc || fbc,
+    zip_hash: trackingData?.zip_hash || zip_hash
+  };
+
+  const client = {
+    ip: trackingData?.ip || trackingData?.client_ip_address || null,
+    user_agent: trackingData?.user_agent || trackingData?.client_user_agent || null
+  };
+
+  return postOrder({
+    order_id: orderIdSource,
+    value,
+    currency,
+    utm,
+    ids,
+    client
+  });
+}
+
+module.exports = {
+  isConfigured,
+  postOrder,
+  enviarConversaoParaUtmify
+};


### PR DESCRIPTION
## Summary
- add environment variables for configuring the backend UTMify integration
- replace the UTMify service with a postOrder helper that sanitizes data, retries, and shares logic with existing callers
- send UTMify conversions after successful Telegram purchases and expose a debug endpoint to replay stored orders

## Testing
- npm test *(fails: test-database.js is missing in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e2affbc6a0832a902d832de62b3225