### PR TITLE
Harden webhook and observability for production

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,14 @@ curl http://localhost:3000/health/full
 ```
 
 O JSON de retorno indica `ok`, status do banco, contadores diários e se os módulos CAPI/UTMify/Geo estão configurados.
+
+## Checklist de Deploy
+
+- `PANEL_ACCESS_TOKEN` configurado e protegido.
+- `FB_PIXEL_ID` e `FB_PIXEL_TOKEN` definidos; se aplicável, `WHATSAPP_FB_PIXEL_ID` e `WHATSAPP_FB_PIXEL_TOKEN` também.
+- `UTMIFY_API_URL` e `UTMIFY_API_TOKEN` ativos para disparo de conversões.
+- `GEO_PROVIDER_URL` (ou padrão) e `GEO_API_KEY` disponíveis para lookup de localização.
+- `BASE_URL` e `FRONTEND_URL` alinhados com a configuração de CORS do ambiente.
+- TLS e HSTS habilitados no proxy/reverse proxy diante do serviço.
+- Rotas `/debug/*` e `/metrics/*` protegidas por token forte ou allowlist de IP.
+- Cron diário de limpeza (payloads + funnel) configurado e monitorado.

--- a/routes/metrics.js
+++ b/routes/metrics.js
@@ -7,6 +7,17 @@ const router = express.Router();
 router.use(panelLimiter);
 router.use(requirePanelToken);
 
+router.use((req, res, next) => {
+  const requestId = req.requestId || null;
+  const tokenHash = res.locals.panelTokenHash || 'unknown';
+  console.log('[panel-access] metrics', {
+    req_id: requestId,
+    token_hash: tokenHash,
+    path: req.path
+  });
+  next();
+});
+
 router.get('/events/daily', async (req, res) => {
   const daysParam = req.query.days;
 
@@ -14,7 +25,8 @@ router.get('/events/daily', async (req, res) => {
     const data = await funnelMetrics.getDailyCounters(daysParam);
     return res.json({ ok: true, data });
   } catch (error) {
-    console.warn('[metrics] daily erro', { error: error.message });
+    const requestId = req.requestId || null;
+    console.warn('[metrics] daily erro', { req_id: requestId, error: error.message });
     return res.status(503).json({ ok: false, error: 'metrics_unavailable' });
   }
 });
@@ -24,7 +36,8 @@ router.get('/events/today', async (req, res) => {
     const data = await funnelMetrics.getTodayCounters();
     return res.json({ ok: true, data });
   } catch (error) {
-    console.warn('[metrics] today erro', { error: error.message });
+    const requestId = req.requestId || null;
+    console.warn('[metrics] today erro', { req_id: requestId, error: error.message });
     return res.status(503).json({ ok: false, error: 'metrics_unavailable' });
   }
 });


### PR DESCRIPTION
## Summary
- Harden the Telegram webhook by validating payload size, format and tracking data while sanitising log output
- Add request tracing, production CORS/HSTS, targeted rate limiting, scheduled cleanup jobs and supporting indexes
- Extend debug/metrics tooling with audit logging, health and dry-run endpoints plus propagate safe logging to Facebook/UTMify services
- Document a production deploy checklist for environment readiness

## Testing
- `npm test` *(fails: missing test-database.js script)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b8a2a1d4832a889e005ea707b08e