### PR TITLE
Add metrics dashboard and dynamic Telegram bot link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ UTMIFY_API_TOKEN=
 # URL base pública usada pelo funil WhatsApp para carregar recursos
 BASE_URL=
 
+# Username do Bot 1 no Telegram (sem @)
+BOT1_USERNAME=
+
 # Configurações do Pixel principal usado pelo Telegram/Webhook
 FB_PIXEL_ID=
 FB_PIXEL_TOKEN=

--- a/MODELO1/WEB/telegram/app.js
+++ b/MODELO1/WEB/telegram/app.js
@@ -1,5 +1,5 @@
 (function () {
-  const DEFAULT_LINK = 'https://t.me/bot1';
+  const DEFAULT_LINK = '';
   const REDIRECT_DELAY = 4000;
   const MAX_PIXEL_ATTEMPTS = 5;
   const PIXEL_RETRY_DELAY = 250;
@@ -513,8 +513,15 @@
   }
 
   document.addEventListener('DOMContentLoaded', () => {
-    const baseLink = window.BOT1_LINK_FROM_SERVER || DEFAULT_LINK;
-    const redirectBaseLink = (baseLink || DEFAULT_LINK).split('?')[0] || DEFAULT_LINK;
+    const baseLinkFromServer = typeof window.BOT1_LINK_FROM_SERVER === 'string'
+      ? window.BOT1_LINK_FROM_SERVER.trim()
+      : '';
+    const baseLink = baseLinkFromServer || DEFAULT_LINK;
+    if (!baseLink) {
+      console.warn('BOT1 link não configurado.');
+      return;
+    }
+    const redirectBaseLink = baseLink.split('?')[0] || baseLink;
     const countdownEl = document.getElementById('countdown');
     const progressBar = document.getElementById('progress-bar');
     const loadTimestamp = Date.now();

--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -179,7 +179,7 @@
     </div>
 
     <script>
-      window.BOT1_LINK_FROM_SERVER = "<%= process.env.BOT1_TELEGRAM_LINK || 'https://t.me/bot1' %>";
+      window.BOT1_LINK_FROM_SERVER = "__BOT1_TELEGRAM_LINK__";
     </script>
     <script src="/telegram/fbclid-handler.js" defer></script>
     <script src="/telegram/utmify.js" defer></script>

--- a/public/metrics/index.html
+++ b/public/metrics/index.html
@@ -1,0 +1,215 @@
+metrics-dashboard
+
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>HotBotWebV2 – Métricas</title>
+  <style>
+    :root { --bg:#0f1115; --card:#151923; --text:#e6e8ee; --muted:#9aa3b2; --ok:#47d16a; --warn:#f5c451; --err:#ff6b6b; }
+    * { box-sizing: border-box; }
+    body { margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif; background: var(--bg); color: var(--text); }
+    header { padding: 20px; border-bottom: 1px solid #222836; display:flex; align-items:center; gap:16px; }
+    h1 { margin: 0; font-size: 20px; }
+    .wrap { padding: 20px; display: grid; grid-template-columns: 1fr; gap: 20px; max-width: 1080px; margin: 0 auto; }
+    .card { background: var(--card); border: 1px solid #202636; border-radius: 16px; padding: 16px; box-shadow: 0 6px 20px rgba(0,0,0,.2); }
+    .row { display:flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+    label { font-size: 12px; color: var(--muted); }
+    input, button, select { background:#0e121a; color:var(--text); border:1px solid #2a3142; border-radius:10px; padding:10px 12px; outline:none; }
+    button { cursor:pointer; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { text-align: left; font-size: 13px; padding: 10px; border-bottom: 1px solid #242a3a; }
+    th { color: var(--muted); font-weight: 600; }
+    .kpi { display:grid; grid-template-columns: repeat(4, minmax(0,1fr)); gap: 12px; }
+    .kpi .card { padding: 14px; }
+    .kpi .val { font-size: 22px; font-weight: 700; }
+    .ok { color: var(--ok); } .warn { color: var(--warn); } .err { color: var(--err); }
+    canvas { width: 100%; height: 260px; display:block; background:#0b0f16; border:1px solid #1c2232; border-radius:12px; }
+    .small { font-size: 12px; color: var(--muted); }
+    @media (max-width: 700px){ .kpi{grid-template-columns: repeat(2,minmax(0,1fr));} }
+  </style>
+</head>
+<body>
+<header>
+  <h1>HotBotWebV2 – Métricas</h1>
+</header>
+
+<div class="wrap">
+  <div class="card">
+    <div class="row">
+      <div>
+        <label>Host</label><br/>
+        <input id="host" placeholder="https://SEU.DOMINIO" style="min-width:300px"/>
+      </div>
+      <div>
+        <label>Bearer (PANEL_ACCESS_TOKEN)</label><br/>
+        <input id="token" placeholder="PANEL_ACCESS_TOKEN" style="min-width:300px"/>
+      </div>
+      <div>
+        <label>Dias</label><br/>
+        <select id="days">
+          <option>7</option><option selected>14</option><option>30</option>
+        </select>
+      </div>
+      <div style="align-self:end;">
+        <button id="load">Carregar</button>
+      </div>
+    </div>
+    <div class="small" style="margin-top:8px">Este painel lê <code>/metrics/events/daily</code>, <code>/metrics/events/today</code> e <code>/health/full</code>. Precisa do Bearer válido.</div>
+  </div>
+
+  <div class="kpi">
+    <div class="card"><div class="small">InitiateCheckout (hoje)</div><div class="val" id="kpi-ic">–</div></div>
+    <div class="card"><div class="small">Purchase (hoje)</div><div class="val" id="kpi-pur">–</div></div>
+    <div class="card"><div class="small">UTMify sent (hoje)</div><div class="val" id="kpi-utm">–</div></div>
+    <div class="card"><div class="small">Falhas (hoje)</div><div class="val warn" id="kpi-fail">–</div></div>
+  </div>
+
+  <div class="card">
+    <div class="row" style="justify-content:space-between;">
+      <div><strong>Séries diárias</strong></div>
+      <div class="small" id="rangeLbl">–</div>
+    </div>
+    <canvas id="chart"></canvas>
+  </div>
+
+  <div class="card">
+    <strong>Health</strong>
+    <table id="healthTbl"><thead><tr><th>Check</th><th>Status</th></tr></thead><tbody></tbody></table>
+  </div>
+
+  <div class="card">
+    <strong>Hoje (raw)</strong>
+    <pre id="todayRaw" style="white-space:pre-wrap"></pre>
+  </div>
+
+  <div class="card">
+    <strong>Daily (raw)</strong>
+    <pre id="dailyRaw" style="white-space:pre-wrap"></pre>
+  </div>
+</div>
+
+<script>
+const $ = sel => document.querySelector(sel);
+
+async function fetchJSON(url, token){
+  const res = await fetch(url, {
+    headers: token ? { "Authorization": "Bearer " + token } : {}
+  });
+  if(!res.ok) throw new Error(res.status + " " + res.statusText);
+  return res.json();
+}
+
+function drawChart(canvas, series){
+  const ctx = canvas.getContext('2d');
+  const W = canvas.width = canvas.clientWidth * window.devicePixelRatio;
+  const H = canvas.height = 260 * window.devicePixelRatio;
+  ctx.clearRect(0,0,W,H);
+  ctx.font = (12*window.devicePixelRatio) + "px system-ui";
+  ctx.fillStyle = "#9aa3b2";
+
+  // axes
+  const padL = 40*window.devicePixelRatio;
+  const padB = 24*window.devicePixelRatio;
+  const padT = 10*window.devicePixelRatio;
+  const padR = 10*window.devicePixelRatio;
+  const plotW = W - padL - padR;
+  const plotH = H - padT - padB;
+  ctx.strokeStyle = "#242a3a";
+  ctx.beginPath();
+  ctx.moveTo(padL, padT);
+  ctx.lineTo(padL, padT+plotH);
+  ctx.lineTo(padL+plotW, padT+plotH);
+  ctx.stroke();
+
+  // find max
+  const keys = ["ic_sent","purchase_sent","utmify_sent","fail_total"];
+  const maxVal = Math.max(1, ...series.map(d => Math.max(...keys.map(k => d[k]||0))));
+  const xStep = plotW / Math.max(1, series.length-1);
+
+  // line helper
+  function line(key){
+    ctx.beginPath();
+    series.forEach((d,i) => {
+      const x = padL + i*xStep;
+      const y = padT + plotH - (plotH * ( (d[key]||0)/maxVal ));
+      if(i===0) ctx.moveTo(x,y); else ctx.lineTo(x,y);
+    });
+    ctx.lineWidth = 2*window.devicePixelRatio;
+    ctx.stroke();
+  }
+
+  // Draw 4 lines one by one (default colors)
+  ctx.strokeStyle = "#7aa2f7"; line("ic_sent");
+  ctx.strokeStyle = "#9ece6a"; line("purchase_sent");
+  ctx.strokeStyle = "#b48ead"; line("utmify_sent");
+  ctx.strokeStyle = "#f7768e"; line("fail_total");
+
+  // y ticks
+  ctx.fillStyle = "#9aa3b2";
+  for(let i=0;i<=4;i++){
+    const val = Math.round(maxVal*i/4);
+    const y = padT + plotH - (plotH*i/4);
+    ctx.fillText(String(val), 4*window.devicePixelRatio, y);
+    ctx.strokeStyle = "rgba(255,255,255,0.05)";
+    ctx.beginPath(); ctx.moveTo(padL,y); ctx.lineTo(padL+plotW,y); ctx.stroke();
+  }
+}
+
+function sumFails(d){
+  const keys = Object.keys(d||{}).filter(k => k.endsWith("_fail") || k.endsWith("_dup"));
+  return keys.reduce((acc,k)=>acc+(d[k]||0),0);
+}
+
+$("#load").addEventListener("click", async ()=>{
+  const host = $("#host").value.trim().replace(/\/+$/,"");
+  const token = $("#token").value.trim();
+  const days = $("#days").value;
+
+  try{
+    const [daily, today, health] = await Promise.all([
+      fetchJSON(host + "/metrics/events/daily?days=" + encodeURIComponent(days), token),
+      fetchJSON(host + "/metrics/events/today", token),
+      fetchJSON(host + "/health/full", null)
+    ]);
+
+    // KPIs hoje
+    $("#kpi-ic").textContent = today.ic_sent ?? 0;
+    $("#kpi-pur").textContent = today.purchase_sent ?? 0;
+    $("#kpi-utm").textContent = today.utmify_sent ?? 0;
+    $("#kpi-fail").textContent = sumFails(today);
+
+    // Chart
+    const series = (daily.days || daily).map(d => ({
+      date: d.date || d.day || d.dt || "—",
+      ic_sent: d.ic_sent||0,
+      purchase_sent: d.purchase_sent||0,
+      utmify_sent: d.utmify_sent||0,
+      fail_total: sumFails(d)
+    }));
+    $("#rangeLbl").textContent = series.length ? (series[0].date + " → " + series[series.length-1].date) : "–";
+    drawChart($("#chart"), series);
+
+    // Health table
+    const tbody = $("#healthTbl tbody");
+    tbody.innerHTML = "";
+    Object.entries(health).forEach(([k,v])=>{
+      const tr = document.createElement("tr");
+      const td1 = document.createElement("td"); td1.textContent = k;
+      const td2 = document.createElement("td"); td2.textContent = v ? "OK" : "FALHA"; td2.className = v ? "ok" : "err";
+      tr.appendChild(td1); tr.appendChild(td2);
+      tbody.appendChild(tr);
+    });
+
+    // Raw
+    $("#todayRaw").textContent = JSON.stringify(today, null, 2);
+    $("#dailyRaw").textContent = JSON.stringify(daily, null, 2);
+
+  }catch(err){
+    alert("Erro ao carregar: " + err.message);
+  }
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add the static metrics dashboard in `public/metrics` and serve it from `/metrics`
- require a `BOT1_USERNAME` env variable and inject the Telegram link server-side
- update the Telegram loader script to handle missing configuration gracefully
- restore the `.env` template to its original placeholder content to avoid unintended binary diffs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e36894dbb0832aab7ad633b76c3679