### PR TITLE
Normalize Telegram webhook base URL

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -191,9 +191,15 @@ async function processCobrancaQueue() {
 class TelegramBotService {
   constructor(options = {}) {
     this.token = options.token;
-    this.baseUrl = options.baseUrl;
+    const normalizedBaseUrl = typeof options.baseUrl === 'string'
+      ? options.baseUrl.trim().replace(/\/+$/, '')
+      : null;
+    this.baseUrl = normalizedBaseUrl;
     // url utilizada na geração dos links enviados aos usuários
-    this.frontendUrl = options.frontendUrl || process.env.FRONTEND_URL || options.baseUrl;
+    const resolvedFrontendUrl = options.frontendUrl || process.env.FRONTEND_URL || options.baseUrl;
+    this.frontendUrl = typeof resolvedFrontendUrl === 'string'
+      ? resolvedFrontendUrl.trim().replace(/\/+$/, '')
+      : resolvedFrontendUrl;
     this.config = options.config || {};
     this.postgres = options.postgres;
     this.sqlite = options.sqlite;


### PR DESCRIPTION
## Summary
- trim trailing slashes from configured base URL so Telegram webhook paths are correct
- normalize the optional frontend URL in the same way to keep generated links consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e36f82f210832aa2ca6fe20710275b