### PR TITLE
Move Lead tracking to backend and fix schema

### DIFF
--- a/MODELO1/WEB/telegram/app.js
+++ b/MODELO1/WEB/telegram/app.js
@@ -675,8 +675,7 @@
 
       const finalUrl = `${redirectBaseLink}?start=${encodeURIComponent(finalStartParam)}`;
 
-      console.info('[TRACK] Lead about to redirect');
-      await trackMetaEvent('Lead', leadPayload);
+      // Lead removed from the presell. The Lead event is now triggered on /start (backend).
       console.info(`[TRACK] start payload bytes=${payloadByteLength}`);
       console.info(`[TRACK] final redirect URL built (source=${fallbackPayloadId ? 'payload_id' : 'base64'})`);
 

--- a/migrations/20241005_add_purchase_dedup_and_tracking_columns.sql
+++ b/migrations/20241005_add_purchase_dedup_and_tracking_columns.sql
@@ -1,0 +1,33 @@
+CREATE TABLE IF NOT EXISTS purchase_event_dedup (
+  id BIGSERIAL PRIMARY KEY,
+  transaction_id TEXT UNIQUE,
+  event_id TEXT UNIQUE,
+  first_seen_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_purchase_event_dedup_seen ON purchase_event_dedup(first_seen_at);
+
+ALTER TABLE tracking_data
+  ADD COLUMN IF NOT EXISTS external_id_hash TEXT,
+  ADD COLUMN IF NOT EXISTS zip_hash TEXT,
+  ADD COLUMN IF NOT EXISTS client_ip_address TEXT,
+  ADD COLUMN IF NOT EXISTS client_user_agent TEXT,
+  ADD COLUMN IF NOT EXISTS event_source_url TEXT,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+
+ALTER TABLE telegram_users
+  ADD COLUMN IF NOT EXISTS external_id_hash TEXT,
+  ADD COLUMN IF NOT EXISTS zip_hash TEXT,
+  ADD COLUMN IF NOT EXISTS fbp TEXT,
+  ADD COLUMN IF NOT EXISTS fbc TEXT,
+  ADD COLUMN IF NOT EXISTS utm_source TEXT,
+  ADD COLUMN IF NOT EXISTS utm_medium TEXT,
+  ADD COLUMN IF NOT EXISTS utm_campaign TEXT,
+  ADD COLUMN IF NOT EXISTS utm_term TEXT,
+  ADD COLUMN IF NOT EXISTS utm_content TEXT,
+  ADD COLUMN IF NOT EXISTS client_ip_address TEXT,
+  ADD COLUMN IF NOT EXISTS client_user_agent TEXT,
+  ADD COLUMN IF NOT EXISTS event_source_url TEXT,
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+
+CREATE INDEX IF NOT EXISTS idx_tel_users_tg ON telegram_users(telegram_id);

--- a/services/funnelMetrics.js
+++ b/services/funnelMetrics.js
@@ -1,6 +1,8 @@
 const postgres = require('../database/postgres');
 
 const KNOWN_EVENTS = new Set([
+  'lead_sent',
+  'lead_fail',
   'ic_sent',
   'ic_fail',
   'purchase_sent',


### PR DESCRIPTION
## Summary
- remove the presell Lead pixel trigger so only PageView/ViewContent fire before redirect
- send Meta Lead events from the /start handler via a new CAPI helper and update funnel metrics
- add a migration to create the purchase dedupe table and ensure tracking columns exist

## Testing
- npm test *(fails: Cannot find module test-database.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e37841eafc832ab8fc01bee0b4a7e7