### PR TITLE
Add Meta CAPI test_event_code override support

### DIFF
--- a/routes/debug.js
+++ b/routes/debug.js
@@ -295,6 +295,16 @@ router.post('/retry/capi', async (req, res) => {
     return res.status(400).json({ ok: false, error: 'invalid_type' });
   }
 
+  const headerTestEventCodeRaw = req.headers['x-test-event-code'];
+  const headerTestEventCode = Array.isArray(headerTestEventCodeRaw)
+    ? String(headerTestEventCodeRaw[0] || '').trim()
+    : typeof headerTestEventCodeRaw === 'string'
+      ? headerTestEventCodeRaw.trim()
+      : '';
+  const bodyTestEventCodeRaw = req.body?.test_event_code;
+  const bodyTestEventCode = typeof bodyTestEventCodeRaw === 'string' ? bodyTestEventCodeRaw.trim() : '';
+  const overrideTestEventCode = headerTestEventCode || bodyTestEventCode || null;
+
   const tokenHash = res.locals.panelTokenHash || 'unknown';
   const tgHash = hashFragment(telegramId);
   const tokenSummary = token ? hashFragment(token) : null;
@@ -336,7 +346,8 @@ router.post('/retry/capi', async (req, res) => {
         fbc: tracking.fbc || null,
         client_ip_address: clientIp || null,
         client_user_agent: clientUa || null,
-        utms
+        utms,
+        test_event_code: overrideTestEventCode
       });
 
       return res.json({
@@ -368,7 +379,8 @@ router.post('/retry/capi', async (req, res) => {
       fbc: tracking.fbc || tokenRow.fbc || null,
       client_ip_address: clientIp || tokenRow.ip_criacao || null,
       client_user_agent: clientUa || tokenRow.user_agent || tokenRow.user_agent_criacao || null,
-      utms
+      utms,
+      test_event_code: overrideTestEventCode
     });
 
     console.log('[debug] retry purchase concluído', {

--- a/routes/telegram.js
+++ b/routes/telegram.js
@@ -377,6 +377,16 @@ router.post('/debug/capi/initiate', async (req, res) => {
       return res.status(404).json({ error: 'not_found' });
     }
 
+    const headerTestEventCodeRaw = req.headers['x-test-event-code'];
+    const headerTestEventCode = Array.isArray(headerTestEventCodeRaw)
+      ? String(headerTestEventCodeRaw[0] || '').trim()
+      : typeof headerTestEventCodeRaw === 'string'
+        ? headerTestEventCodeRaw.trim()
+        : '';
+    const bodyTestEventCodeRaw = req.body?.test_event_code;
+    const bodyTestEventCode = typeof bodyTestEventCodeRaw === 'string' ? bodyTestEventCodeRaw.trim() : '';
+    const overrideTestEventCode = headerTestEventCode || bodyTestEventCode || null;
+
     const eventTime = Math.floor(Date.now() / 1000);
     const eventId = buildEventId(telegramId, user.criado_em);
 
@@ -397,7 +407,8 @@ router.post('/debug/capi/initiate', async (req, res) => {
         utm_campaign: user.utm_campaign,
         utm_content: user.utm_content,
         utm_term: user.utm_term
-      }
+      },
+      test_event_code: overrideTestEventCode
     });
 
     return res.json({ ok: sendResult.success, event_id: eventId, capi: sendResult });


### PR DESCRIPTION
## Summary
- resolve Meta CAPI test_event_code from environment or per-request override and attach it to outbound Graph API calls
- pass optional overrides through the debug retry endpoints and Telegram debug route without exposing sensitive data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e37ebe45d4832a9b88d0f9f271c223