### PR TITLE
Allow repeated lead events without deduplication

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -22,6 +22,7 @@ const { enviarConversaoParaUtmify, postOrder: postUtmifyOrder } = require('../..
 const { appendDataToSheet } = require('../../services/googleSheets.js');
 const UnifiedPixService = require('../../services/unifiedPixService');
 const funnelMetrics = require('../../services/funnelMetrics');
+const { uniqueEventId } = require('../../helpers/eventId');
 
 const TRACKING_UTM_FIELDS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
 const TRACKING_FIELDS = [...TRACKING_UTM_FIELDS, 'fbp', 'fbc', 'ip', 'user_agent', 'kwai_click_id', 'src', 'sck'];
@@ -825,8 +826,7 @@ class TelegramBotService {
         ? startTimestamp
         : Math.floor(Date.now() / 1000);
 
-    const eventIdSeed = `lead|${this.botId || 'bot'}|${cleanTelegramId}|${eventTime}`;
-    const eventId = crypto.createHash('sha1').update(eventIdSeed).digest('hex');
+    const eventId = uniqueEventId();
 
     const utms = {};
     TRACKING_UTM_FIELDS.forEach(field => {

--- a/helpers/eventId.js
+++ b/helpers/eventId.js
@@ -1,0 +1,15 @@
+const crypto = require('crypto');
+
+function uniqueEventId() {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  const timestamp = Date.now().toString(36);
+  const randomPart = crypto.randomBytes(8).toString('hex');
+  return `${timestamp}-${randomPart}`;
+}
+
+module.exports = {
+  uniqueEventId
+};

--- a/routes/telegram.js
+++ b/routes/telegram.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const crypto = require('crypto');
+const { uniqueEventId } = require('../helpers/eventId');
 
 const router = express.Router();
 
@@ -354,7 +355,7 @@ router.post('/telegram/webhook', async (req, res) => {
     });
 
     const eventTime = Math.floor(Date.now() / 1000);
-    const eventId = buildEventId(telegramId, upserted?.criado_em, 'lead');
+    const eventId = uniqueEventId();
     const overrideTestEventCode = resolveTestEventCode(req);
 
     const finalExternalIdHash = normalizeExternalIdHash(

--- a/services/metaCapi.js
+++ b/services/metaCapi.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const crypto = require('crypto');
+const { uniqueEventId } = require('../helpers/eventId');
 
 const FACEBOOK_API_VERSION = 'v17.0';
 const { FB_PIXEL_ID, FB_PIXEL_TOKEN, FB_TEST_EVENT_CODE } = process.env;
@@ -309,7 +310,7 @@ async function sendLeadEvent(eventPayload = {}) {
   });
   const customData = buildCustomData(utmData);
 
-  const resolvedEventId = eventId || `${telegramId || 'lead'}-${Date.now()}`;
+  const resolvedEventId = eventId || uniqueEventId();
 
   const eventPayloadData = {
     event_name: 'Lead',


### PR DESCRIPTION
## Summary
- add a reusable helper to generate random event IDs for lead events
- update lead emission paths to use random IDs and skip deduplication in Facebook CAPI
- scope purchase deduplication logic to purchase-like events only

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e387ea7f58832a83eb001da5fb65aa