### PR TITLE
Ensure Lead CAPI events use unique UUIDs and improve logging

### DIFF
--- a/migrations/20251112_ensure_funnel_events_telegram_id.sql
+++ b/migrations/20251112_ensure_funnel_events_telegram_id.sql
@@ -1,0 +1,3 @@
+-- Ensure funnel_events has telegram_id column for lead tracking metrics
+ALTER TABLE IF EXISTS public.funnel_events
+  ADD COLUMN IF NOT EXISTS telegram_id BIGINT;

--- a/routes/telegram.js
+++ b/routes/telegram.js
@@ -1,6 +1,5 @@
 const express = require('express');
 const crypto = require('crypto');
-const { uniqueEventId } = require('../helpers/eventId');
 
 const router = express.Router();
 
@@ -355,7 +354,6 @@ router.post('/telegram/webhook', async (req, res) => {
     });
 
     const eventTime = Math.floor(Date.now() / 1000);
-    const eventId = uniqueEventId();
     const overrideTestEventCode = resolveTestEventCode(req);
 
     const finalExternalIdHash = normalizeExternalIdHash(
@@ -366,7 +364,6 @@ router.post('/telegram/webhook', async (req, res) => {
       telegramId,
       eventTime,
       eventSourceUrl: upserted?.event_source_url || eventSourceUrl,
-      eventId,
       externalIdHash: finalExternalIdHash,
       fbp: upserted?.fbp || sanitizedFbp,
       fbc: upserted?.fbc || sanitizedFbc,
@@ -384,7 +381,7 @@ router.post('/telegram/webhook', async (req, res) => {
       test_event_code: overrideTestEventCode
     });
 
-    const resolvedEventId = sendResult?.event_id || eventId;
+    const resolvedEventId = sendResult?.event_id || null;
 
     console.info('[START] evento registrado', {
       req_id: requestId,

--- a/services/funnelMetrics.js
+++ b/services/funnelMetrics.js
@@ -62,6 +62,10 @@ async function recordEvent(eventName, options = {}) {
     return { recorded: false, reason: 'pool_unavailable' };
   }
 
+  if (!tablesReady) {
+    return { recorded: false, reason: 'tables_unavailable' };
+  }
+
   const safeEvent = KNOWN_EVENTS.has(eventName) ? eventName : String(eventName || 'unknown');
   const telegramId = options.telegramId ? Number(options.telegramId) || null : null;
   const token = options.token ? String(options.token) : null;
@@ -93,6 +97,9 @@ async function recordEvent(eventName, options = {}) {
         event: safeEvent,
         reason: error.message
       });
+    }
+    if (error.code === '42703' || /column\s+"?telegram_id"?/i.test(error.message)) {
+      console.warn('[funnel-metrics] desativando gravação até ajuste do schema (coluna ausente)');
     }
     tablesReady = false;
     return { recorded: false, reason: error.message };


### PR DESCRIPTION
## Summary
- generate UUIDv4 event IDs for Lead CAPI sends, add detailed pre/post logs, and wrap funnel metric writes to avoid retries on failures
- refresh Meta CAPI Lead sender to use per-attempt UUIDs with fbtrace/request logging and add a migration guaranteeing funnel_events.telegram_id exists
- update Telegram flows to rely on returned event IDs, removing shared identifiers between browser and server paths

## Testing
- npm test *(fails: missing /workspace/-HotBotWebV2/test-database.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e38d5f1e84832a99dde00368d957ef