### PR TITLE
Restore Meta CAPI lead test code propagation and add debug logs

### DIFF
--- a/services/facebook.js
+++ b/services/facebook.js
@@ -1243,6 +1243,10 @@ async function sendLeadCapi(options = {}) {
     payload.event_source_url = eventSourceUrl;
   }
 
+  if (test_event_code) {
+    payload.test_event_code = test_event_code;
+  }
+
   logWithContext('log', '[LeadCAPI] Evento preparado para envio', {
     event_name: payload.event_name,
     event_id: finalEventId,


### PR DESCRIPTION
## Summary
- restore propagation of `test_event_code` for Lead Meta CAPI events so the Events Manager test tab receives them again
- add Lead-specific debug logs around Meta CAPI requests while preserving the event_time clamp behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c5377014832aaeb9d744a0d81c16