### PR TITLE
Align purchase dedupe logging and thank-you flow

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -20,6 +20,7 @@
         fetch('/api/config')
             .then(r => r.json())
             .then(config => {
+                window.__PIXEL_CONFIG = config;
                 if (config.FB_PIXEL_ID) {
                     fbq('init', config.FB_PIXEL_ID);
                     console.log('[PIXEL] ✅ Meta Pixel inicializado:', config.FB_PIXEL_ID);
@@ -229,163 +230,307 @@
     </div>
 
     <script>
-        // Obter parâmetros da URL
-        const urlParams = new URLSearchParams(window.location.search);
-        const token = urlParams.get('token');
-        const valor = parseFloat(urlParams.get('valor')) || 0;
+        (async () => {
+            const urlParams = new URLSearchParams(window.location.search);
+            const token = urlParams.get('token');
+            const fbclidParam = urlParams.get('fbclid');
+            const valorParam = urlParams.get('valor');
+            let valor = valorParam ? parseFloat(valorParam) : null;
 
-        console.log('[OBRIGADO] Token:', token ? token.substring(0, 10) + '...' : null);
-        console.log('[OBRIGADO] Valor:', valor);
+            console.log('[PURCHASE-BROWSER] 🔗 Parâmetros de URL', Object.fromEntries(urlParams.entries()));
 
-        // Validar token
-        if (!token) {
-            document.getElementById('errorMessage').textContent = '❌ Token inválido. Entre em contato com o suporte.';
-            document.getElementById('errorMessage').style.display = 'block';
-            document.getElementById('contactForm').style.display = 'none';
-        }
-
-        // Capturar _fbp e _fbc de cookies
-        function getCookie(name) {
-            const value = `; ${document.cookie}`;
-            const parts = value.split(`; ${name}=`);
-            if (parts.length === 2) return parts.pop().split(';').shift();
-            return null;
-        }
-
-        const fbp = getCookie('_fbp');
-        const fbc = getCookie('_fbc') || urlParams.get('fbclid') ? `fb.1.${Date.now()}.${urlParams.get('fbclid')}` : null;
-
-        console.log('[OBRIGADO] _fbp:', fbp);
-        console.log('[OBRIGADO] _fbc:', fbc);
-
-        // Máscara de telefone simples
-        document.getElementById('phone').addEventListener('input', function(e) {
-            let value = e.target.value.replace(/\D/g, '');
-            if (value.length > 11) value = value.slice(0, 11);
-            
-            if (value.length >= 11) {
-                e.target.value = `(${value.slice(0,2)}) ${value.slice(2,7)}-${value.slice(7,11)}`;
-            } else if (value.length >= 7) {
-                e.target.value = `(${value.slice(0,2)}) ${value.slice(2,7)}-${value.slice(7)}`;
-            } else if (value.length >= 2) {
-                e.target.value = `(${value.slice(0,2)}) ${value.slice(2)}`;
-            } else {
-                e.target.value = value;
-            }
-        });
-
-        // Handler do formulário
-        document.getElementById('contactForm').addEventListener('submit', async function(e) {
-            e.preventDefault();
-
-            const email = document.getElementById('email').value.trim();
-            const phone = document.getElementById('phone').value.replace(/\D/g, '');
-
-            // Validações simples
-            if (!email || !email.includes('@')) {
-                alert('Por favor, insira um email válido');
+            if (!token) {
+                const errorMessage = document.getElementById('errorMessage');
+                errorMessage.textContent = '❌ Token inválido. Entre em contato com o suporte.';
+                errorMessage.style.display = 'block';
+                document.getElementById('contactForm').style.display = 'none';
                 return;
             }
 
-            if (phone.length < 10) {
-                alert('Por favor, insira um telefone válido com DDD');
-                return;
-            }
+            const TRACKING_UTM_FIELDS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
 
-            // Mostrar loading
-            document.getElementById('contactForm').classList.add('hidden');
-            document.getElementById('loading').style.display = 'block';
+            let contextData = null;
+            let eventId = null;
+            let transactionId = null;
+            let currency = 'BRL';
+            let utms = {};
+            let eventSourceUrl = null;
+            let payerName = null;
+            let payerCpf = null;
+            let fbpFromContext = null;
+            let fbcFromContext = null;
+            let fbclid = fbclidParam || null;
+            let contents = [];
+
+            const splitName = (fullName = '') => {
+                const trimmed = (fullName || '').trim();
+                if (!trimmed) {
+                    return { firstName: null, lastName: null };
+                }
+                const parts = trimmed.split(/\s+/);
+                if (parts.length === 1) {
+                    return { firstName: parts[0], lastName: null };
+                }
+                return { firstName: parts[0], lastName: parts.slice(1).join(' ') };
+            };
 
             try {
-                // 1. Salvar email e phone no banco
-                console.log('[OBRIGADO] 📝 Salvando email e telefone...');
-                const saveResponse = await fetch('/api/save-contact', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ token, email, phone })
-                });
+                const response = await fetch(`/api/purchase/context?token=${encodeURIComponent(token)}`);
+                const payload = await response.json();
+                if (response.ok && payload.success) {
+                    contextData = payload.data;
+                    console.log('[PURCHASE-BROWSER] 🧾 Contexto recebido', contextData);
 
-                if (!saveResponse.ok) {
-                    throw new Error('Erro ao salvar dados de contato');
-                }
+                    eventId = contextData.event_id_purchase || null;
+                    transactionId = contextData.transaction_id || null;
+                    currency = contextData.currency || currency;
+                    utms = contextData.utms || {};
+                    eventSourceUrl = contextData.event_source_url || null;
+                    payerName = contextData.payer_name || null;
+                    payerCpf = contextData.payer_cpf || null;
+                    fbpFromContext = contextData.fbp || null;
+                    fbcFromContext = contextData.fbc || null;
+                    fbclid = fbclid || contextData.fbclid || null;
+                    if (typeof contextData.value === 'number') {
+                        valor = contextData.value;
+                    }
 
-                const saveData = await saveResponse.json();
-                console.log('[OBRIGADO] ✅ Dados salvos:', saveData);
-
-                // Obter event_id do backend
-                const eventId = saveData.event_id_purchase;
-                
-                if (!eventId) {
-                    console.warn('[OBRIGADO] ⚠️ event_id não disponível');
-                }
-
-                // 2. Disparar Purchase (browser Pixel) com eventID
-                console.log('[OBRIGADO] 🎯 [PIXEL] Disparando Purchase browser com eventID:', eventId);
-                
-                if (typeof fbq !== 'undefined') {
-                    fbq('track', 'Purchase', {
-                        value: valor,
-                        currency: 'BRL'
-                    }, {
-                        eventID: eventId
-                    });
-                    console.log('[OBRIGADO] ✅ [PIXEL] Purchase browser disparado');
+                    if (contextData.plano_id || contextData.transaction_id) {
+                        contents = [{
+                            id: contextData.plano_id || contextData.transaction_id,
+                            quantity: 1,
+                            item_price: typeof valor === 'number' ? valor : contextData.value,
+                            title: contextData.nome_oferta || undefined
+                        }];
+                    }
                 } else {
-                    console.warn('[OBRIGADO] ⚠️ [PIXEL] fbq não disponível');
+                    console.warn('[PURCHASE-BROWSER] ⚠️ Erro ao carregar contexto', payload);
                 }
-
-                // 3. Marcar pixel_sent no backend
-                await fetch('/api/mark-pixel-sent', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ token })
-                });
-
-                // 4. Disparar Purchase CAPI no backend
-                console.log('[OBRIGADO] 🚀 [CAPI] Chamando endpoint Purchase CAPI...');
-                const capiResponse = await fetch('/api/capi/purchase', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ 
-                        token,
-                        event_id: eventId
-                    })
-                });
-
-                const capiData = await capiResponse.json();
-                
-                if (capiData.success) {
-                    console.log('[OBRIGADO] ✅ [CAPI] Purchase CAPI enviado com sucesso');
-                } else {
-                    console.warn('[OBRIGADO] ⚠️ [CAPI] Erro ao enviar Purchase CAPI:', capiData.error);
-                    // Não bloquear o fluxo mesmo se CAPI falhar
-                }
-
-                // 5. Mostrar sucesso e redirecionar
-                document.getElementById('loading').style.display = 'none';
-                document.getElementById('successMessage').style.display = 'block';
-
-                // Redirecionar após 2 segundos
-                setTimeout(() => {
-                    // Obter URL do grupo da query string ou usar padrão
-                    const grupo = urlParams.get('G1') || urlParams.get('G2') || urlParams.get('G3') || 'G1';
-                    const redirectUrl = urlParams.get('redirect') || `/acesso?grupo=${grupo}`;
-                    window.location.href = redirectUrl;
-                }, 2000);
-
             } catch (error) {
-                console.error('[OBRIGADO] ❌ Erro:', error);
-                document.getElementById('loading').style.display = 'none';
-                document.getElementById('errorMessage').style.display = 'block';
-                document.getElementById('errorMessage').textContent = `❌ ${error.message}`;
-                
-                // Mostrar formulário novamente para retry
-                setTimeout(() => {
-                    document.getElementById('contactForm').classList.remove('hidden');
-                    document.getElementById('errorMessage').style.display = 'none';
-                }, 3000);
+                console.error('[PURCHASE-BROWSER] ❌ Falha ao carregar contexto', error);
             }
-        });
+
+            if (!eventSourceUrl) {
+                const baseUrl = window.__PIXEL_CONFIG?.FRONTEND_URL || window.location.origin;
+                const normalizedBase = baseUrl.replace(/\/+$/, '');
+                const url = new URL(window.location.pathname, normalizedBase);
+                url.search = urlParams.toString();
+                eventSourceUrl = url.toString();
+            }
+
+            const getCookie = (name) => {
+                const value = `; ${document.cookie}`;
+                const parts = value.split(`; ${name}=`);
+                if (parts.length === 2) return parts.pop().split(';').shift();
+                return null;
+            };
+
+            const cookieFbp = getCookie('_fbp');
+            let cookieFbc = getCookie('_fbc');
+
+            if (!cookieFbc && fbclid) {
+                cookieFbc = `fb.1.${Date.now()}.${fbclid}`;
+            }
+
+            const finalFbp = cookieFbp || fbpFromContext || null;
+            const finalFbc = cookieFbc || fbcFromContext || null;
+
+            console.log('[PURCHASE-BROWSER] 🍪 Identificadores resolvidos', {
+                token,
+                event_id: eventId,
+                transaction_id: transactionId,
+                fbp_cookie: cookieFbp,
+                fbc_cookie: cookieFbc,
+                fbp_context: fbpFromContext,
+                fbc_context: fbcFromContext,
+                fbp_final: finalFbp,
+                fbc_final: finalFbc,
+                fbclid
+            });
+
+            const phoneInputEl = document.getElementById('phone');
+            phoneInputEl.addEventListener('input', function (e) {
+                let value = e.target.value.replace(/\D/g, '');
+                if (value.length > 11) value = value.slice(0, 11);
+
+                if (value.length >= 11) {
+                    e.target.value = `(${value.slice(0, 2)}) ${value.slice(2, 7)}-${value.slice(7, 11)}`;
+                } else if (value.length >= 7) {
+                    e.target.value = `(${value.slice(0, 2)}) ${value.slice(2, 7)}-${value.slice(7)}`;
+                } else if (value.length >= 2) {
+                    e.target.value = `(${value.slice(0, 2)}) ${value.slice(2)}`;
+                } else {
+                    e.target.value = value;
+                }
+            });
+
+            const contactForm = document.getElementById('contactForm');
+            const loadingEl = document.getElementById('loading');
+            const successMessage = document.getElementById('successMessage');
+            const errorMessage = document.getElementById('errorMessage');
+
+            const normalizePhoneForPixel = (value) => {
+                if (!value) return null;
+                const digits = value.replace(/\D/g, '');
+                if (!digits) return null;
+                if (digits.startsWith('55') && digits.length === 13) {
+                    return `+${digits}`;
+                }
+                if (digits.length === 11 || digits.length === 10) {
+                    return `+55${digits}`;
+                }
+                return digits.startsWith('+') ? digits : `+${digits}`;
+            };
+
+            contactForm.addEventListener('submit', async (e) => {
+                e.preventDefault();
+
+                const email = document.getElementById('email').value.trim();
+                const phoneInput = phoneInputEl.value;
+                const phoneDigits = phoneInput.replace(/\D/g, '');
+                const normalizedPhone = normalizePhoneForPixel(phoneInput);
+
+                if (!email || !email.includes('@')) {
+                    alert('Por favor, insira um email válido');
+                    return;
+                }
+
+                if (phoneDigits.length < 10) {
+                    alert('Por favor, insira um telefone válido com DDD');
+                    return;
+                }
+
+                contactForm.classList.add('hidden');
+                loadingEl.style.display = 'block';
+
+                try {
+                    console.log('[PURCHASE-BROWSER] ✉️ Enviando save-contact', {
+                        token,
+                        email,
+                        phone: phoneDigits
+                    });
+
+                    const saveResponse = await fetch('/api/save-contact', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ token, email, phone: phoneDigits })
+                    });
+
+                    const saveData = await saveResponse.json();
+                    console.log('[PURCHASE-BROWSER] 📬 Resposta save-contact', saveData);
+
+                    if (!saveResponse.ok || !saveData.success) {
+                        throw new Error(saveData.error || 'Erro ao salvar dados de contato');
+                    }
+
+                    if (saveData.event_id_purchase) {
+                        eventId = saveData.event_id_purchase;
+                    }
+                    if (saveData.transaction_id) {
+                        transactionId = saveData.transaction_id;
+                    }
+
+                    const { firstName, lastName } = splitName(payerName || '');
+                    const cpfDigits = payerCpf ? payerCpf.replace(/\D/g, '') : null;
+
+                    const advancedMatching = {
+                        ...(email ? { em: email } : {}),
+                        ...(normalizedPhone ? { ph: normalizedPhone } : {}),
+                        ...(cpfDigits ? { external_id: cpfDigits } : {}),
+                        ...(firstName ? { fn: firstName } : {}),
+                        ...(lastName ? { ln: lastName } : {})
+                    };
+
+                    console.log('[PURCHASE-BROWSER] 👤 Advanced matching resolvido', advancedMatching);
+
+                    const pixelUtms = {};
+                    for (const field of TRACKING_UTM_FIELDS) {
+                        if (utms[field]) {
+                            pixelUtms[field] = utms[field];
+                        } else if (urlParams.get(field)) {
+                            pixelUtms[field] = urlParams.get(field);
+                        }
+                    }
+
+                    const pixelCustomData = {
+                        ...(typeof valor === 'number' ? { value: Number(valor.toFixed(2)) } : {}),
+                        currency,
+                        transaction_id: transactionId,
+                        ...pixelUtms,
+                        ...(fbclid ? { fbclid } : {})
+                    };
+
+                    if (contents.length) {
+                        pixelCustomData.contents = contents;
+                        pixelCustomData.content_ids = contents.map(item => item.id).filter(Boolean);
+                        pixelCustomData.content_type = 'product';
+                    }
+
+                    console.log('[PURCHASE-BROWSER] 🧾 Pixel custom_data', pixelCustomData);
+
+                    if (typeof fbq !== 'undefined') {
+                        if (window.__PIXEL_CONFIG?.FB_PIXEL_ID) {
+                            fbq('set', 'userData', advancedMatching);
+                        }
+                        fbq('track', 'Purchase', pixelCustomData, { eventID: eventId });
+                        console.log('[PURCHASE-BROWSER] 🎯 Purchase (browser) disparado', {
+                            event_id: eventId,
+                            custom_data: pixelCustomData
+                        });
+                    } else {
+                        console.warn('[PURCHASE-BROWSER] ⚠️ fbq não disponível');
+                    }
+
+                    await fetch('/api/mark-pixel-sent', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ token })
+                    });
+
+                    console.log('[PURCHASE-BROWSER] 🏁 pixel_sent marcado', { token });
+
+                    const capiPayload = {
+                        token,
+                        event_id: eventId,
+                        event_source_url: eventSourceUrl
+                    };
+
+                    console.log('[PURCHASE-BROWSER] 🚀 Chamando /api/capi/purchase', capiPayload);
+
+                    const capiResponse = await fetch('/api/capi/purchase', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(capiPayload)
+                    });
+
+                    const capiData = await capiResponse.json();
+                    console.log('[PURCHASE-BROWSER] 📡 Resposta /api/capi/purchase', capiData);
+
+                    if (!capiResponse.ok || !capiData.success) {
+                        console.warn('[PURCHASE-BROWSER] ⚠️ Erro ao enviar Purchase CAPI', capiData);
+                    }
+
+                    loadingEl.style.display = 'none';
+                    successMessage.style.display = 'block';
+
+                    setTimeout(() => {
+                        const grupo = urlParams.get('G1') || urlParams.get('G2') || urlParams.get('G3') || 'G1';
+                        const redirectUrl = urlParams.get('redirect') || `/acesso?grupo=${grupo}`;
+                        window.location.href = redirectUrl;
+                    }, 2000);
+                } catch (error) {
+                    console.error('[PURCHASE-BROWSER] ❌ Erro no fluxo', error);
+                    loadingEl.style.display = 'none';
+                    errorMessage.style.display = 'block';
+                    errorMessage.textContent = `❌ ${error.message}`;
+
+                    setTimeout(() => {
+                        contactForm.classList.remove('hidden');
+                        errorMessage.style.display = 'none';
+                    }, 3000);
+                }
+            });
+        })();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- persist normalized webhook data with deterministic event IDs, normalized thank-you URLs, and explicit Purchase logging across the PushinPay handler
- expose a purchase context endpoint and overhaul the CAPI pipeline to merge webhook and thank-you data, emit full payload logs, and record dedupe schema details
- refresh the thank-you flow to load context, emit advanced Pixel Purchase events with UTMs, and trigger the server-side Purchase using the shared event ID

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e438409abc832aaf20862480d7c3d5