### PR TITLE
Fix purchase flow schema and request logging

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -23,6 +23,7 @@ const { enviarConversaoParaUtmify, postOrder: postUtmifyOrder } = require('../..
 const { appendDataToSheet } = require('../../services/googleSheets.js');
 const UnifiedPixService = require('../../services/unifiedPixService');
 const funnelMetrics = require('../../services/funnelMetrics');
+const { normalizeTransactionId } = require('../../helpers/purchaseFlow');
 
 const TRACKING_UTM_FIELDS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
 const TRACKING_FIELDS = [...TRACKING_UTM_FIELDS, 'fbp', 'fbc', 'ip', 'user_agent', 'kwai_click_id', 'src', 'sck'];

--- a/database/postgres.js
+++ b/database/postgres.js
@@ -302,6 +302,12 @@ async function createTables(pool) {
         END IF;
         IF NOT EXISTS (
           SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='email'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN email TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
           WHERE table_name='tokens' AND column_name='utm_source'
         ) THEN
           ALTER TABLE tokens ADD COLUMN utm_source TEXT;
@@ -421,6 +427,12 @@ async function createTables(pool) {
         END IF;
         IF NOT EXISTS (
           SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='payer_cpf'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN payer_cpf TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
           WHERE table_name='tokens' AND column_name='payer_national_registration'
         ) THEN
           ALTER TABLE tokens ADD COLUMN payer_national_registration TEXT;
@@ -461,6 +473,30 @@ async function createTables(pool) {
           WHERE table_name='tokens' AND column_name='event_attempts'
         ) THEN
           ALTER TABLE tokens ADD COLUMN event_attempts INTEGER DEFAULT 0;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='transaction_id'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN transaction_id TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='event_id_purchase'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN event_id_purchase TEXT;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='price_cents'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN price_cents INTEGER;
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name='tokens' AND column_name='currency'
+        ) THEN
+          ALTER TABLE tokens ADD COLUMN currency TEXT;
         END IF;
         IF NOT EXISTS (
           SELECT 1 FROM information_schema.columns
@@ -565,6 +601,10 @@ async function createTables(pool) {
     // Criar índice para status dos tokens
     await pool.query(`
       CREATE INDEX IF NOT EXISTS idx_tokens_status ON tokens(status)
+    `);
+
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_tokens_event_id_purchase ON tokens(event_id_purchase)
     `);
 
     // Tabela de downsell progress

--- a/server.js
+++ b/server.js
@@ -1703,8 +1703,9 @@ app.get('/api/purchase/context', async (req, res) => {
 
 // 🎯 NOVO: Endpoint para salvar email e telefone na página de obrigado
 app.post('/api/save-contact', async (req, res) => {
+  const requestId = generateRequestId();
+
   try {
-    const requestId = generateRequestId();
     const { token, email, phone } = req.body;
 
     console.log('[PURCHASE-TOKEN] 📝 save-contact recebido', {


### PR DESCRIPTION
## Summary
- ensure the PostgreSQL bootstrap adds the purchase flow columns (email, payer_cpf, transaction_id, event_id_purchase, price_cents, currency) and index for event_id_purchase
- import normalizeTransactionId in the Telegram bot webhook to avoid runtime reference errors
- fix the save-contact endpoint so requestId is always defined during error handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d1ea2904832a86686425413092a8