### PR TITLE
Remove plano_id from purchase context query

### DIFF
--- a/server.js
+++ b/server.js
@@ -1632,8 +1632,7 @@ app.get('/api/purchase/context', async (req, res) => {
         utm_content,
         fbp,
         fbc,
-        nome_oferta,
-        plano_id
+        nome_oferta
       FROM tokens
       WHERE token = $1
       LIMIT 1


### PR DESCRIPTION
## Summary
- update the purchase context query to stop selecting the plano_id column

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e2eb97f8832a900e07f678319c0d