### PR TITLE
Fix Telegram payment confirmation fallback when BASE_URL missing

### DIFF
--- a/MODELO1/BOT/bot1.js
+++ b/MODELO1/BOT/bot1.js
@@ -4,10 +4,21 @@ const config = require('./config1');
 const postgres = require('../../database/postgres');
 const sqlite = require('../../database/sqlite');
 
+const sanitizeUrl = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const baseUrl = sanitizeUrl(process.env.BASE_URL) || sanitizeUrl(process.env.FRONTEND_URL);
+const frontendUrl = sanitizeUrl(process.env.FRONTEND_URL) || baseUrl;
+
 const bot = new TelegramBotService({
   token: process.env.TELEGRAM_TOKEN,
-  baseUrl: process.env.BASE_URL,
-  frontendUrl: process.env.FRONTEND_URL || process.env.BASE_URL,
+  baseUrl,
+  frontendUrl,
   config,
   postgres,
   sqlite,

--- a/MODELO1/BOT/bot2.js
+++ b/MODELO1/BOT/bot2.js
@@ -4,10 +4,21 @@ const config = require('./config2');
 const postgres = require('../../database/postgres');
 const sqlite = require('../../database/sqlite');
 
+const sanitizeUrl = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const baseUrl = sanitizeUrl(process.env.BASE_URL) || sanitizeUrl(process.env.FRONTEND_URL);
+const frontendUrl = sanitizeUrl(process.env.FRONTEND_URL) || baseUrl;
+
 const bot = new TelegramBotService({
   token: process.env.TELEGRAM_TOKEN_BOT2,
-  baseUrl: process.env.BASE_URL,
-  frontendUrl: process.env.FRONTEND_URL || process.env.BASE_URL,
+  baseUrl,
+  frontendUrl,
   config,
   postgres,
   sqlite,

--- a/MODELO1/BOT/bot4.js
+++ b/MODELO1/BOT/bot4.js
@@ -4,10 +4,21 @@ const config = require('./config4');
 const postgres = require('../../database/postgres');
 const sqlite = require('../../database/sqlite');
 
+const sanitizeUrl = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const baseUrl = sanitizeUrl(process.env.BASE_URL) || sanitizeUrl(process.env.FRONTEND_URL);
+const frontendUrl = sanitizeUrl(process.env.FRONTEND_URL) || baseUrl;
+
 const bot = new TelegramBotService({
   token: process.env.TELEGRAM_TOKEN_BOT4,
-  baseUrl: process.env.BASE_URL,
-  frontendUrl: process.env.FRONTEND_URL || process.env.BASE_URL,
+  baseUrl,
+  frontendUrl,
   config,
   postgres,
   sqlite,

--- a/MODELO1/BOT/bot5.js
+++ b/MODELO1/BOT/bot5.js
@@ -4,10 +4,21 @@ const config = require('./config5');
 const postgres = require('../../database/postgres');
 const sqlite = require('../../database/sqlite');
 
+const sanitizeUrl = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const baseUrl = sanitizeUrl(process.env.BASE_URL) || sanitizeUrl(process.env.FRONTEND_URL);
+const frontendUrl = sanitizeUrl(process.env.FRONTEND_URL) || baseUrl;
+
 const bot = new TelegramBotService({
   token: process.env.TELEGRAM_TOKEN_BOT5,
-  baseUrl: process.env.BASE_URL,
-  frontendUrl: process.env.FRONTEND_URL || process.env.BASE_URL,
+  baseUrl,
+  frontendUrl,
   config,
   postgres,
   sqlite,

--- a/MODELO1/BOT/bot6.js
+++ b/MODELO1/BOT/bot6.js
@@ -4,10 +4,21 @@ const config = require('./config6');
 const postgres = require('../../database/postgres');
 const sqlite = require('../../database/sqlite');
 
+const sanitizeUrl = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const baseUrl = sanitizeUrl(process.env.BASE_URL) || sanitizeUrl(process.env.FRONTEND_URL);
+const frontendUrl = sanitizeUrl(process.env.FRONTEND_URL) || baseUrl;
+
 const bot = new TelegramBotService({
   token: process.env.TELEGRAM_TOKEN_BOT6,
-  baseUrl: process.env.BASE_URL,
-  frontendUrl: process.env.FRONTEND_URL || process.env.BASE_URL,
+  baseUrl,
+  frontendUrl,
   config,
   postgres,
   sqlite,

--- a/MODELO1/BOT/bot7.js
+++ b/MODELO1/BOT/bot7.js
@@ -4,10 +4,21 @@ const config = require('./config7');
 const postgres = require('../../database/postgres');
 const sqlite = require('../../database/sqlite');
 
+const sanitizeUrl = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const baseUrl = sanitizeUrl(process.env.BASE_URL) || sanitizeUrl(process.env.FRONTEND_URL);
+const frontendUrl = sanitizeUrl(process.env.FRONTEND_URL) || baseUrl;
+
 const bot = new TelegramBotService({
   token: process.env.TELEGRAM_TOKEN_BOT7,
-  baseUrl: process.env.BASE_URL,
-  frontendUrl: process.env.FRONTEND_URL || process.env.BASE_URL,
+  baseUrl,
+  frontendUrl,
   config,
   postgres,
   sqlite,

--- a/MODELO1/BOT/bot_especial.js
+++ b/MODELO1/BOT/bot_especial.js
@@ -8,13 +8,29 @@ const sqlite = require('../../database/sqlite');
 const ambiente = process.env.NODE_ENV || 'development';
 const isTeste = process.env.AMBIENTE_TESTE === 'true' || ambiente === 'test';
 
-const baseUrl = isTeste 
-  ? process.env.BASE_URL_TESTE || process.env.BASE_URL 
-  : process.env.BASE_URL;
+const sanitizeUrl = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
 
-const frontendUrl = isTeste 
-  ? process.env.FRONTEND_URL_TESTE || process.env.FRONTEND_URL || baseUrl
-  : process.env.FRONTEND_URL || baseUrl;
+const baseUrlTeste = sanitizeUrl(process.env.BASE_URL_TESTE);
+const baseUrlProd = sanitizeUrl(process.env.BASE_URL);
+const rawBaseUrl = isTeste
+  ? baseUrlTeste || baseUrlProd
+  : baseUrlProd;
+
+const fallbackBaseUrl = rawBaseUrl || (isTeste
+  ? sanitizeUrl(process.env.FRONTEND_URL_TESTE) || sanitizeUrl(process.env.FRONTEND_URL)
+  : sanitizeUrl(process.env.FRONTEND_URL));
+
+const baseUrl = fallbackBaseUrl;
+
+const frontendUrl = (isTeste ? sanitizeUrl(process.env.FRONTEND_URL_TESTE) : null)
+  || sanitizeUrl(process.env.FRONTEND_URL)
+  || baseUrl;
 
 const bot = new TelegramBotService({
   token: process.env.TELEGRAM_TOKEN_ESPECIAL,

--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -201,19 +201,24 @@ async function processCobrancaQueue() {
 class TelegramBotService {
   constructor(options = {}) {
     this.token = options.token;
-    const normalizedBaseUrl = typeof options.baseUrl === 'string'
+    const normalizedBaseUrl = typeof options.baseUrl === 'string' && options.baseUrl.trim()
       ? options.baseUrl.trim().replace(/\/+$/, '')
       : null;
-    this.baseUrl = normalizedBaseUrl;
+    this.botId = options.bot_id || 'bot';
     // url utilizada na geração dos links enviados aos usuários
     const resolvedFrontendUrl = options.frontendUrl || process.env.FRONTEND_URL || options.baseUrl;
     this.frontendUrl = typeof resolvedFrontendUrl === 'string'
       ? resolvedFrontendUrl.trim().replace(/\/+$/, '')
       : resolvedFrontendUrl;
+    this.baseUrl = normalizedBaseUrl || (typeof this.frontendUrl === 'string'
+      ? this.frontendUrl
+      : null);
+    if (!normalizedBaseUrl && this.baseUrl) {
+      console.warn(`[${this.botId}] BASE_URL não fornecida — usando FRONTEND_URL como fallback: ${this.baseUrl}`);
+    }
     this.config = options.config || {};
     this.postgres = options.postgres;
     this.sqlite = options.sqlite;
-    this.botId = options.bot_id || 'bot';
     let grupo = 'G1';
     if (this.token === process.env.TELEGRAM_TOKEN_BOT2) grupo = 'G2';
     if (this.token === process.env.TELEGRAM_TOKEN_ESPECIAL) grupo = 'G3';

--- a/server.js
+++ b/server.js
@@ -551,7 +551,17 @@ if (process.env.NODE_ENV !== 'production') {
 const TELEGRAM_TOKEN = process.env.TELEGRAM_TOKEN;
 const TELEGRAM_TOKEN_BOT2 = process.env.TELEGRAM_TOKEN_BOT2;
 const TELEGRAM_TOKEN_ESPECIAL = process.env.TELEGRAM_TOKEN_ESPECIAL;
-const BASE_URL = process.env.BASE_URL;
+const sanitizeUrl = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+};
+
+const rawBaseUrl = sanitizeUrl(process.env.BASE_URL);
+const fallbackBaseUrl = sanitizeUrl(process.env.FRONTEND_URL);
+const BASE_URL = rawBaseUrl || fallbackBaseUrl;
 const PORT = process.env.PORT || 3000;
 const ADMIN_SECRET = process.env.ADMIN_SECRET;
 const URL_ENVIO_1 = process.env.URL_ENVIO_1;
@@ -575,6 +585,9 @@ if (!TELEGRAM_TOKEN_ESPECIAL) {
   console.error('TELEGRAM_TOKEN_ESPECIAL não definido');
 }
 
+if (!rawBaseUrl && BASE_URL) {
+  console.warn(`BASE_URL não definido — usando fallback: ${BASE_URL}`);
+}
 if (!BASE_URL) {
   console.error('BASE_URL não definido');
 }


### PR DESCRIPTION
## Summary
- sanitize and reuse FRONTEND_URL as a fallback base URL for every Telegram bot when BASE_URL is absent
- update TelegramBotService to log and use the frontend URL when no explicit base URL is configured
- allow the server bootstrap to warn and reuse the frontend URL when BASE_URL is missing so callbacks keep working

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e50ba3b978832abc96d427a34a01bc