### PR TITLE
Fix SQLite tokens schema to include payer data columns

### DIFF
--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -170,6 +170,9 @@ function initialize(path = './pagamentos.db') {
     if (!checkCol('payer_name')) {
       addColumnSafely('tokens', 'payer_name', 'TEXT');
     }
+    if (!checkCol('payer_cpf')) {
+      addColumnSafely('tokens', 'payer_cpf', 'TEXT');
+    }
     if (!checkCol('payer_national_registration')) {
       addColumnSafely('tokens', 'payer_national_registration', 'TEXT');
     }
@@ -208,6 +211,15 @@ function initialize(path = './pagamentos.db') {
     }
     if (!checkCol('gateway')) {
       addColumnSafely('tokens', 'gateway', 'TEXT DEFAULT "oasyfy"');
+    }
+    if (!checkCol('payer_name_temp')) {
+      addColumnSafely('tokens', 'payer_name_temp', 'TEXT');
+    }
+    if (!checkCol('payer_cpf_temp')) {
+      addColumnSafely('tokens', 'payer_cpf_temp', 'TEXT');
+    }
+    if (!checkCol('end_to_end_id_temp')) {
+      addColumnSafely('tokens', 'end_to_end_id_temp', 'TEXT');
     }
     if (!checkCol('identifier')) {
       addColumnSafely('tokens', 'identifier', 'TEXT');


### PR DESCRIPTION
## Summary
- ensure the SQLite tokens table includes the payer_cpf field used by the Telegram callback
- add safety migrations for temporary payer data columns so SELECT queries succeed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5102557fc832abe0afe726c6aa01f