### PR TITLE
Ensure currency is retained when sending Purchase CAPI events

### DIFF
--- a/services/purchaseCapi.js
+++ b/services/purchaseCapi.js
@@ -177,14 +177,21 @@ async function sendPurchaseEvent(purchaseData) {
   const customData = {};
 
   // Valor e moeda
+  if (currency) {
+    customData.currency = currency;
+  }
+
   if (price_cents !== null && price_cents !== undefined) {
     // Converter centavos para reais
     customData.value = parseFloat((price_cents / 100).toFixed(2));
-    customData.currency = currency;
-    console.log('[PURCHASE-CAPI] ✅ Valor convertido:', { 
-      price_cents, 
-      value_reais: customData.value, 
-      currency 
+    console.log('[PURCHASE-CAPI] ✅ Valor convertido:', {
+      price_cents,
+      value_reais: customData.value,
+      currency
+    });
+  } else if (currency) {
+    console.warn('[PURCHASE-CAPI] ⚠️ price_cents ausente, mantendo apenas currency no payload', {
+      currency
     });
   }
 


### PR DESCRIPTION
## Summary
- ensure Purchase CAPI payloads always include the currency provided by PushinPay
- add a warning log when price data is missing so currency-only payloads are visible in logs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e514f05928832aac1fa9f15186c3e1