### PR TITLE
Align Purchase CAPI test event handling

### DIFF
--- a/utils/metaTestEvent.js
+++ b/utils/metaTestEvent.js
@@ -1,0 +1,17 @@
+function getMetaTestEventCode(config) {
+  if (process.env.TEST_EVENT_CODE) {
+    return { code: process.env.TEST_EVENT_CODE, source: 'env' };
+  }
+
+  if (process.env.META_TEST_EVENT_CODE) {
+    return { code: process.env.META_TEST_EVENT_CODE, source: 'env' };
+  }
+
+  if (config?.facebook?.test_event_code) {
+    return { code: config.facebook.test_event_code, source: 'config' };
+  }
+
+  return { code: null, source: null };
+}
+
+module.exports = { getMetaTestEventCode };


### PR DESCRIPTION
## Summary
- add a shared helper to resolve Meta test event codes from environment variables or configuration
- update the Purchase CAPI sender to normalize timestamps, apply the shared test_event_code logic, and mirror the Lead logging pattern

## Testing
- node -e "require('./services/purchaseCapi'); console.log('module loaded');"


------
https://chatgpt.com/codex/tasks/task_e_68e5575c3878832a8ec6b9a5b0774ca1