### PR TITLE
Align purchase deduplication and persistence

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -28,6 +28,7 @@
             })
             .catch(err => console.error('[PIXEL] ❌ Erro ao carregar config:', err));
     </script>
+    <script src="/shared/purchaseNormalization.js"></script>
     <noscript><img height="1" width="1" style="display:none"
     src="https://www.facebook.com/tr?id=YOUR_PIXEL_ID&ev=PageView&noscript=1"
     /></noscript>
@@ -236,6 +237,11 @@
             const fbclidParam = urlParams.get('fbclid');
             const valorParam = urlParams.get('valor');
             let valor = valorParam ? parseFloat(valorParam) : null;
+            const normalizationLib = window.PurchaseNormalization;
+
+            if (!normalizationLib) {
+                console.error('[PURCHASE-BROWSER] ❌ Biblioteca de normalização indisponível');
+            }
 
             console.log('[PURCHASE-BROWSER] 🔗 Parâmetros de URL', Object.fromEntries(urlParams.entries()));
 
@@ -293,7 +299,7 @@
                         utm_term: contextData.utm_term || null,
                         utm_content: contextData.utm_content || null
                     };
-                    eventSourceUrl = contextData.event_source_url || null;
+                    eventSourceUrl = normalizationLib?.normalizeUrlForEventSource(contextData.event_source_url) || null;
                     payerName = contextData.payer_name || null;
                     payerCpf = contextData.payer_cpf || null;
                     fbpFromContext = contextData.fbp || null;
@@ -333,7 +339,7 @@
                 const normalizedBase = baseUrl.replace(/\/+$/, '');
                 const url = new URL(window.location.pathname, normalizedBase);
                 url.search = urlParams.toString();
-                eventSourceUrl = url.toString();
+                eventSourceUrl = normalizationLib?.normalizeUrlForEventSource(url.toString()) || url.toString();
             }
 
             if (contextData) {
@@ -410,26 +416,12 @@
             const successMessage = document.getElementById('successMessage');
             const errorMessage = document.getElementById('errorMessage');
 
-            const normalizePhoneForPixel = (value) => {
-                if (!value) return null;
-                const digits = value.replace(/\D/g, '');
-                if (!digits) return null;
-                if (digits.startsWith('55') && digits.length === 13) {
-                    return `+${digits}`;
-                }
-                if (digits.length === 11 || digits.length === 10) {
-                    return `+55${digits}`;
-                }
-                return digits.startsWith('+') ? digits : `+${digits}`;
-            };
-
             contactForm.addEventListener('submit', async (e) => {
                 e.preventDefault();
 
                 const email = document.getElementById('email').value.trim();
                 const phoneInput = phoneInputEl.value;
                 const phoneDigits = phoneInput.replace(/\D/g, '');
-                const normalizedPhone = normalizePhoneForPixel(phoneInput);
 
                 if (!email || !email.includes('@')) {
                     alert('Por favor, insira um email válido');
@@ -477,22 +469,30 @@
                         transactionId = saveData.transaction_id;
                     }
 
+                    if (!normalizationLib) {
+                        throw new Error('Biblioteca de normalização indisponível');
+                    }
+
                     const { firstName, lastName } = splitName(payerName || '');
                     const cpfDigits = payerCpf ? payerCpf.replace(/\D/g, '') : null;
 
-                    const advancedMatchingLog = {
-                        em: email || null,
-                        ph: normalizedPhone || null,
-                        external_id: cpfDigits || null,
-                        fn: firstName || null,
-                        ln: lastName || null
+                    const normalizedData = {
+                        email: normalizationLib.normalizeEmail(email),
+                        phone: normalizationLib.normalizePhone(phoneDigits),
+                        first_name: normalizationLib.normalizeName(firstName || ''),
+                        last_name: normalizationLib.normalizeName(lastName || ''),
+                        external_id: normalizationLib.normalizeExternalId(cpfDigits || '')
                     };
 
-                    const advancedMatching = Object.fromEntries(
-                        Object.entries(advancedMatchingLog).filter(([, value]) => value)
-                    );
+                    const normalizationSnapshot = normalizationLib.buildNormalizationSnapshot(normalizedData);
+                    console.log('[NORMALIZE]', normalizationSnapshot);
 
-                    console.log('[PURCHASE-BROWSER] advancedMatching com', advancedMatchingLog);
+                    const advancedMatchingHashed = normalizationLib.buildAdvancedMatching(normalizedData);
+                    console.log('[ADVANCED-MATCH]', advancedMatchingHashed);
+
+                    const advancedMatching = Object.fromEntries(
+                        Object.entries(advancedMatchingHashed).filter(([, value]) => value)
+                    );
 
                     const pixelUtms = {};
                     for (const field of TRACKING_UTM_FIELDS) {
@@ -501,6 +501,11 @@
                         } else if (urlParams.get(field)) {
                             pixelUtms[field] = urlParams.get(field);
                         }
+                    }
+
+                    const resolvedEventId = transactionId ? `pur:${transactionId}` : eventId;
+                    if (resolvedEventId) {
+                        eventId = resolvedEventId;
                     }
 
                     const pixelCustomData = {
@@ -515,6 +520,10 @@
                         pixelCustomData.contents = contents;
                         pixelCustomData.content_ids = contents.map(item => item.id).filter(Boolean);
                         pixelCustomData.content_type = 'product';
+                        const firstContentWithTitle = contents.find(item => item && item.title);
+                        if (firstContentWithTitle && firstContentWithTitle.title) {
+                            pixelCustomData.content_name = firstContentWithTitle.title;
+                        }
                     }
 
                     console.log('[PURCHASE-BROWSER] 🧾 Pixel custom_data', pixelCustomData);
@@ -533,7 +542,7 @@
                         throw new Error('Valor do Purchase ausente ou zero - não será enviado');
                     }
 
-                    console.log(`[PURCHASE-BROWSER] eventID=${eventId}`);
+                    console.log(`[PURCHASE-BROWSER] event_id=${eventId}`);
 
                     if (typeof fbq !== 'undefined') {
                         if (window.__PIXEL_CONFIG?.FB_PIXEL_ID) {
@@ -541,8 +550,9 @@
                         }
                         fbq('track', 'Purchase', pixelCustomData, { eventID: eventId });
                         console.log('[PURCHASE-BROWSER] track Purchase com', {
-                            eventID: eventId,
-                            custom_data: pixelCustomData
+                            event_id: eventId,
+                            custom_data: pixelCustomData,
+                            utms: pixelUtms
                         });
                     } else {
                         console.warn('[PURCHASE-BROWSER] ⚠️ fbq não disponível');

--- a/services/purchasePersistence.js
+++ b/services/purchasePersistence.js
@@ -1,0 +1,191 @@
+const sqlite = require('../database/sqlite');
+
+let hasFunnelEventsTable = null;
+let ensuredPurchaseContextTable = false;
+let ensuredSqliteTable = false;
+
+async function checkFunnelEventsTable(pool) {
+  if (!pool) {
+    hasFunnelEventsTable = false;
+    return false;
+  }
+
+  if (hasFunnelEventsTable !== null) {
+    return hasFunnelEventsTable;
+  }
+
+  try {
+    const result = await pool.query("SELECT to_regclass('public.funnel_events') AS table_name");
+    hasFunnelEventsTable = Boolean(result?.rows?.[0]?.table_name);
+  } catch (error) {
+    console.warn(`[DB] falha ao verificar public.funnel_events err=${error.message}`);
+    hasFunnelEventsTable = false;
+  }
+
+  return hasFunnelEventsTable;
+}
+
+async function ensurePostgresPurchaseContext(pool) {
+  if (ensuredPurchaseContextTable || !pool) {
+    return;
+  }
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS purchase_context (
+      id BIGSERIAL PRIMARY KEY,
+      occurred_at TIMESTAMPTZ DEFAULT NOW(),
+      event_id TEXT UNIQUE,
+      transaction_id TEXT,
+      price_cents INTEGER,
+      meta JSONB
+    )
+  `);
+
+  ensuredPurchaseContextTable = true;
+}
+
+function ensureSqlitePurchaseContext(db) {
+  if (!db || ensuredSqliteTable) {
+    return;
+  }
+
+  db.prepare(`
+    CREATE TABLE IF NOT EXISTS purchase_context (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      occurred_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      event_id TEXT UNIQUE,
+      transaction_id TEXT,
+      price_cents INTEGER,
+      meta TEXT
+    )
+  `).run();
+
+  ensuredSqliteTable = true;
+}
+
+function buildMetaPayload(event = {}) {
+  const {
+    utms = {},
+    fbp = null,
+    fbc = null,
+    client_ip_address = null,
+    client_user_agent = null,
+    event_source_url = null,
+    advanced_matching = {},
+    contents = [],
+    content_ids = [],
+    content_type = null,
+    content_name = null
+  } = event || {};
+
+  return {
+    utms,
+    fbp,
+    fbc,
+    client_ip_address,
+    client_user_agent,
+    event_source_url,
+    advanced_matching,
+    contents: Array.isArray(contents) ? contents : [],
+    content_ids: Array.isArray(content_ids) ? content_ids : [],
+    content_type: content_type || null,
+    content_name: content_name || null
+  };
+}
+
+async function savePurchaseContext({ pool = null, sqliteDb = null, event = {} } = {}) {
+  const eventId = event?.event_id || null;
+  if (!eventId) {
+    return false;
+  }
+
+  const record = {
+    event_name: event?.event_name || 'purchase',
+    transaction_id: event?.transaction_id || null,
+    price_cents: Number.isFinite(event?.price_cents) ? Math.trunc(event.price_cents) : null,
+    event_id: eventId,
+    meta: buildMetaPayload(event)
+  };
+
+  // Tentar salvar em Postgres primeiro
+  if (pool) {
+    try {
+      const funnelExists = await checkFunnelEventsTable(pool);
+      if (!funnelExists) {
+        await ensurePostgresPurchaseContext(pool);
+      }
+
+      const targetTable = funnelExists ? 'public.funnel_events' : 'purchase_context';
+      const query = `
+        INSERT INTO ${targetTable} (event_name, transaction_id, price_cents, event_id, meta)
+        VALUES ($1, $2, $3, $4, $5::jsonb)
+        ON CONFLICT (event_id) DO NOTHING
+      `;
+      const values = [
+        record.event_name,
+        record.transaction_id,
+        record.price_cents,
+        record.event_id,
+        JSON.stringify(record.meta)
+      ];
+      const result = await pool.query(query, values);
+
+      if (result.rowCount > 0) {
+        console.log('[DB] saved purchase', {
+          event_id: record.event_id,
+          transaction_id: record.transaction_id,
+          price_cents: record.price_cents
+        });
+        return true;
+      }
+
+      console.log('[DB] purchase já existente', {
+        event_id: record.event_id,
+        transaction_id: record.transaction_id
+      });
+      return false;
+    } catch (error) {
+      console.error(`[DB] erro ao salvar purchase no Postgres err=${error.stack || error.message}`);
+    }
+  }
+
+  const database = sqliteDb || (typeof sqlite?.get === 'function' ? sqlite.get() : null);
+  if (database) {
+    try {
+      ensureSqlitePurchaseContext(database);
+      const stmt = database.prepare(`
+        INSERT OR IGNORE INTO purchase_context (event_name, transaction_id, price_cents, event_id, meta)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+      const info = stmt.run(
+        record.event_name,
+        record.transaction_id,
+        record.price_cents,
+        record.event_id,
+        JSON.stringify(record.meta)
+      );
+
+      if (info.changes > 0) {
+        console.log('[DB] saved purchase', {
+          event_id: record.event_id,
+          transaction_id: record.transaction_id,
+          price_cents: record.price_cents
+        });
+        return true;
+      }
+
+      console.log('[DB] purchase já existente', {
+        event_id: record.event_id,
+        transaction_id: record.transaction_id
+      });
+    } catch (error) {
+      console.error(`[DB] erro ao salvar purchase no SQLite err=${error.stack || error.message}`);
+    }
+  }
+
+  return false;
+}
+
+module.exports = {
+  savePurchaseContext
+};

--- a/shared/purchaseNormalization.js
+++ b/shared/purchaseNormalization.js
@@ -1,0 +1,299 @@
+(function (globalScope, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory(require('crypto'));
+  } else {
+    const exports = factory(null);
+    globalScope.PurchaseNormalization = exports;
+  }
+})(typeof globalThis !== 'undefined' ? globalThis : typeof self !== 'undefined' ? self : this, function (nodeCrypto) {
+  const hasNodeCrypto = !!(nodeCrypto && typeof nodeCrypto.createHash === 'function');
+
+  const BASE_URL_PROTOCOLS = new Set(['http:', 'https:']);
+
+  function baseNormalize(value) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    const stringified = String(value).trim();
+    return stringified ? stringified : null;
+  }
+
+  function normalizeEmail(value) {
+    const normalized = baseNormalize(value);
+    return normalized ? normalized.toLowerCase() : null;
+  }
+
+  function normalizePhone(value) {
+    const normalized = baseNormalize(value);
+    if (!normalized) {
+      return null;
+    }
+    const digits = normalized.replace(/\D+/g, '');
+    return digits || null;
+  }
+
+  function normalizeName(value) {
+    const normalized = baseNormalize(value);
+    if (!normalized) {
+      return null;
+    }
+    const withoutAccents = normalized
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^\w\s'-]+/g, '');
+    const trimmed = withoutAccents.trim();
+    return trimmed ? trimmed.toLowerCase() : null;
+  }
+
+  function normalizeExternalId(value) {
+    const normalized = baseNormalize(value);
+    return normalized || null;
+  }
+
+  function toUtf8Bytes(input) {
+    if (typeof input !== 'string') {
+      throw new TypeError('sha256 expects a string input');
+    }
+
+    if (typeof TextEncoder !== 'undefined') {
+      return new TextEncoder().encode(input);
+    }
+
+    if (typeof Buffer !== 'undefined') {
+      return Buffer.from(input, 'utf8');
+    }
+
+    const encoded = unescape(encodeURIComponent(input));
+    const bytes = new Uint8Array(encoded.length);
+    for (let i = 0; i < encoded.length; i += 1) {
+      bytes[i] = encoded.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  function bytesToBinaryString(bytes) {
+    if (typeof bytes === 'string') {
+      return bytes;
+    }
+    let binary = '';
+    for (let i = 0; i < bytes.length; i += 1) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return binary;
+  }
+
+  function sha256Native(input) {
+    if (!hasNodeCrypto) {
+      return null;
+    }
+    return nodeCrypto.createHash('sha256').update(input, 'utf8').digest('hex');
+  }
+
+  function sha256Portable(input) {
+    const bytes = toUtf8Bytes(input);
+    const ascii = bytesToBinaryString(bytes);
+    const rightRotate = (value, amount) => (value >>> amount) | (value << (32 - amount));
+
+    const mathPow = Math.pow;
+    const maxWord = mathPow(2, 32);
+    const words = [];
+    let asciiBitLength = ascii.length * 8;
+
+    const hash = [];
+    const k = [];
+    const isComposite = {};
+    let primeCounter = 0;
+
+    for (let candidate = 2; primeCounter < 64; candidate += 1) {
+      if (!isComposite[candidate]) {
+        for (let i = candidate * candidate; i < 313; i += candidate) {
+          isComposite[i] = candidate;
+        }
+        hash[primeCounter] = (mathPow(candidate, 0.5) * maxWord) | 0;
+        k[primeCounter] = (mathPow(candidate, 1 / 3) * maxWord) | 0;
+        primeCounter += 1;
+      }
+    }
+
+    ascii += '\x80';
+    while (ascii.length % 64 !== 56) {
+      ascii += '\x00';
+    }
+
+    for (let i = 0; i < ascii.length; i += 1) {
+      const charCode = ascii.charCodeAt(i);
+      const wordIndex = i >> 2;
+      words[wordIndex] = words[wordIndex] || 0;
+      words[wordIndex] |= charCode << ((3 - (i % 4)) * 8);
+    }
+
+    words.push((asciiBitLength / maxWord) | 0);
+    words.push(asciiBitLength >>> 0);
+
+    for (let j = 0; j < words.length; j += 16) {
+      const w = new Array(64);
+      for (let i = 0; i < 16; i += 1) {
+        w[i] = words[j + i] | 0;
+      }
+      for (let i = 16; i < 64; i += 1) {
+        const s0 = rightRotate(w[i - 15], 7) ^ rightRotate(w[i - 15], 18) ^ (w[i - 15] >>> 3);
+        const s1 = rightRotate(w[i - 2], 17) ^ rightRotate(w[i - 2], 19) ^ (w[i - 2] >>> 10);
+        w[i] = (w[i - 16] + s0 + w[i - 7] + s1) | 0;
+      }
+
+      let a = hash[0];
+      let b = hash[1];
+      let c = hash[2];
+      let d = hash[3];
+      let e = hash[4];
+      let f = hash[5];
+      let g = hash[6];
+      let h = hash[7];
+
+      for (let i = 0; i < 64; i += 1) {
+        const s1 = rightRotate(e, 6) ^ rightRotate(e, 11) ^ rightRotate(e, 25);
+        const ch = (e & f) ^ (~e & g);
+        const temp1 = (h + s1 + ch + k[i] + w[i]) | 0;
+        const s0 = rightRotate(a, 2) ^ rightRotate(a, 13) ^ rightRotate(a, 22);
+        const maj = (a & b) ^ (a & c) ^ (b & c);
+        const temp2 = (s0 + maj) | 0;
+
+        h = g;
+        g = f;
+        f = e;
+        e = (d + temp1) | 0;
+        d = c;
+        c = b;
+        b = a;
+        a = (temp1 + temp2) | 0;
+      }
+
+      hash[0] = (hash[0] + a) | 0;
+      hash[1] = (hash[1] + b) | 0;
+      hash[2] = (hash[2] + c) | 0;
+      hash[3] = (hash[3] + d) | 0;
+      hash[4] = (hash[4] + e) | 0;
+      hash[5] = (hash[5] + f) | 0;
+      hash[6] = (hash[6] + g) | 0;
+      hash[7] = (hash[7] + h) | 0;
+    }
+
+    let hex = '';
+    for (let i = 0; i < hash.length; i += 1) {
+      const value = hash[i];
+      hex += (value >>> 0).toString(16).padStart(8, '0');
+    }
+
+    return hex;
+  }
+
+  function sha256(value) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    const normalized = String(value);
+    const trimmed = normalized.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    const native = sha256Native(trimmed);
+    if (native) {
+      return native;
+    }
+
+    return sha256Portable(trimmed);
+  }
+
+  function splitName(value) {
+    const normalized = baseNormalize(value);
+    if (!normalized) {
+      return { firstName: null, lastName: null };
+    }
+    const parts = normalized.split(/\s+/);
+    if (parts.length === 1) {
+      return { firstName: parts[0], lastName: null };
+    }
+    return {
+      firstName: parts[0],
+      lastName: parts.slice(1).join(' ')
+    };
+  }
+
+  function buildNormalizationSnapshot(normalized) {
+    return {
+      email: normalized.email ? 'ok' : 'skip',
+      phone: normalized.phone ? 'ok' : 'skip',
+      fn: normalized.first_name ? 'ok' : 'skip',
+      ln: normalized.last_name ? 'ok' : 'skip',
+      external_id: normalized.external_id ? 'ok' : 'skip'
+    };
+  }
+
+  function buildAdvancedMatching(normalized) {
+    const result = {};
+    if (normalized.email) {
+      result.em = sha256(normalized.email);
+    }
+    if (normalized.phone) {
+      result.ph = sha256(normalized.phone);
+    }
+    if (normalized.first_name) {
+      result.fn = sha256(normalized.first_name);
+    }
+    if (normalized.last_name) {
+      result.ln = sha256(normalized.last_name);
+    }
+    if (normalized.external_id) {
+      result.external_id = sha256(normalized.external_id);
+    }
+    return result;
+  }
+
+  function normalizeUrlForEventSource(url) {
+    const normalized = baseNormalize(url);
+    if (!normalized) {
+      return null;
+    }
+    let parsed;
+    try {
+      parsed = new URL(normalized);
+    } catch (error) {
+      try {
+        parsed = new URL(`https://${normalized}`);
+      } catch (innerError) {
+        return null;
+      }
+    }
+
+    if (!BASE_URL_PROTOCOLS.has(parsed.protocol)) {
+      return null;
+    }
+
+    parsed.hash = '';
+    parsed.search = '';
+    parsed.pathname = parsed.pathname.replace(/\/{2,}/g, '/');
+
+    return parsed.toString();
+  }
+
+  function ensureArray(value) {
+    if (Array.isArray(value)) {
+      return value;
+    }
+    return value ? [value] : [];
+  }
+
+  return {
+    normalizeEmail,
+    normalizePhone,
+    normalizeName,
+    normalizeExternalId,
+    normalizeUrlForEventSource,
+    sha256,
+    splitName,
+    buildAdvancedMatching,
+    buildNormalizationSnapshot,
+    ensureArray
+  };
+});


### PR DESCRIPTION
## Summary
- introduce a shared normalization utility so browser and server build matching advanced matching hashes and normalized URLs
- update the thank-you purchase flow and CAPI service to send aligned Purchase payloads with UTMs, content metadata, and required logging
- persist purchase context with a Postgres table or SQLite fallback and log dedupe usage for the shared event_id

## Testing
- npm test *(fails: Cannot find module '/workspace/-HotBotWebV2/test-database.js')*

------
https://chatgpt.com/codex/tasks/task_e_68e574fc01e4832aaf8b367c07229f40