### PR TITLE
Fix TypeError in portable SHA-256 normalization

### DIFF
--- a/shared/purchaseNormalization.js
+++ b/shared/purchaseNormalization.js
@@ -91,7 +91,7 @@
 
   function sha256Portable(input) {
     const bytes = toUtf8Bytes(input);
-    const ascii = bytesToBinaryString(bytes);
+    let ascii = bytesToBinaryString(bytes);
     const rightRotate = (value, amount) => (value >>> amount) | (value << (32 - amount));
 
     const mathPow = Math.pow;


### PR DESCRIPTION
## Summary
- fix the portable SHA-256 implementation by allowing the ascii buffer to be mutated during padding

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e57e61d7f8832aac61925e3a2328c9