### PR TITLE
Corrigir erro de preço em evento de compra

### DIFF
--- a/services/purchaseCapi.js
+++ b/services/purchaseCapi.js
@@ -142,7 +142,7 @@ async function sendPurchaseEvent(purchaseData, options = {}) {
   });
 
   console.log(
-    `[DEBUG] price_cents(type)=${typeof price_cents} value(type)=${typeof value} price_cents=${priceCents} value=${value}`
+    `[DEBUG] price_cents(type)=${typeof price_cents} value(type)=${typeof value} price_cents=${price_cents} value=${value}`
   );
 
   // 🎯 CORREÇÃO: Se advanced_matching já vem no payload (do browser), usar direto


### PR DESCRIPTION
Corrected a debug log variable name from `priceCents` to `price_cents` to resolve a 'priceCents is not defined' error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1b151cd-1b40-40fa-88cc-2c75aa701853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1b151cd-1b40-40fa-88cc-2c75aa701853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

