### PR TITLE
Remover qr code e usar copia e cola

### DIFF
--- a/CHANGELOG_REMOCAO_QR_CODE.md
+++ b/CHANGELOG_REMOCAO_QR_CODE.md
@@ -1,0 +1,178 @@
+# Changelog - Remoção de QR Code (Apenas PIX Copia e Cola)
+
+**Data:** 2025-10-08  
+**Objetivo:** Eliminar completamente a funcionalidade de QR Code no fluxo do bot, mantendo apenas o código PIX "copia e cola" em texto.
+
+---
+
+## Arquivos Modificados
+
+### 1. `/workspace/MODELO1/core/TelegramBotService.js`
+
+#### Handler de Callback `qr_code_` (Linhas 4636-4672)
+- **COMENTADO** - Handler completo que enviava imagem do QR Code quando usuário clicava no botão "Qr code"
+- Não é mais necessário, pois o botão foi removido
+
+#### Envio de Imagem PIX (Linhas 4803-4815)
+- **COMENTADO** - Envio da imagem `./midia/pix_image.png` via `sendPhoto`
+- O fluxo agora envia apenas mensagens de texto com o código PIX
+
+#### Botão "Qr code" (Linha 4836-4839)
+- **COMENTADO** - Botão inline que disparava o callback `qr_code_${transacao_id}`
+- **ADICIONADO** - Log `[PIX-SHOW]` demonstrando envio do texto com código
+
+#### Botão de Verificação (Linha 4837)
+- **ALTERADO** - Texto do botão de "EFETUEI O PAGAMENTO" para "✅ Já paguei (verificar)"
+- Mantém a mesma funcionalidade de verificação
+
+### 2. `/workspace/MODELO1/BOT/config.js`
+
+#### Mensagem de Expiração (Linha 383)
+- **ANTES:** `'❌ Este QR Code expirou. Por favor, gere uma nova cobrança.'`
+- **DEPOIS:** `'❌ Este código PIX expirou. Por favor, gere uma nova cobrança.'`
+
+### 3. `/workspace/MODELO1/BOT/config.default.js`
+
+#### Mensagem de Expiração (Linha 334)
+- **ANTES:** `'❌ Este QR Code expirou. Por favor, gere uma nova cobrança.'`
+- **DEPOIS:** `'❌ Este código PIX expirou. Por favor, gere uma nova cobrança.'`
+
+### 4. `/workspace/MODELO1/WEB/obrigado_especial.html`
+
+#### Exibição do QR Code (Linhas 312-315)
+- **COMENTADO** - Div que exibia a imagem do QR Code (`<img id="qr-image">`)
+
+#### Mensagens de Loading/Erro (Linhas 308-326)
+- **ALTERADO** - Textos de "Gerando QR code PIX..." para "Gerando código PIX..."
+- **ALTERADO** - "Erro ao gerar QR code" para "Erro ao gerar código PIX"
+
+#### Função JavaScript `gerarQRCodePIX()` (Linhas 503-555)
+- **COMENTADO** - Referências a `qrContainer` e `qrImage`
+- **COMENTADO** - Código que exibia a imagem: `qrImage.src = data.qr_code_base64`
+- **ALTERADO** - Validação não mais requer `data.qr_code_base64`, apenas `data.pix_copia_cola`
+- Mantém apenas a exibição do código PIX em texto
+
+### 5. `/workspace/checkout/index.html`
+
+#### Validação de Resposta (Linha 1205)
+- **ANTES:** `if (data.success && data.qr_code_base64 && data.pix_copia_cola)`
+- **DEPOIS:** `if (data.success && data.pix_copia_cola)` (com comentário explicativo)
+
+#### Exibição do QR Code (Linhas 1562-1567)
+- **COMENTADO** - Div que exibia a imagem do QR Code
+
+### 6. `/workspace/checkout/funil_completo/assinatura_premiada.html`
+
+#### Exibição do QR Code (Linhas 658-663)
+- **COMENTADO** - Div que exibia a imagem do QR Code
+
+### 7. `/workspace/checkout/funil_completo/chamada_premiada.html`
+
+#### Exibição do QR Code (Linhas 1221-1226)
+- **COMENTADO** - Div que exibia a imagem do QR Code
+
+---
+
+## Fluxo Atual (Após Mudanças)
+
+### Quando usuário seleciona um plano:
+
+1. **Mensagem de aguarde** - "⏳ Aguarde um instante, estou gerando seu PIX..."
+
+2. **Instruções de pagamento** - Passo a passo de como pagar:
+   ```
+   ✅ Como realizar o pagamento:
+   1. Abra o aplicativo do seu banco.
+   2. Selecione a opção "Pagar" ou "PIX".
+   3. Escolha "PIX Copia e Cola".
+   4. Cole a chave que está abaixo e finalize o pagamento com segurança.
+   ```
+
+3. **Aviso para copiar** - "Copie o código abaixo:"
+
+4. **Código PIX** - Em formato `<pre>` para facilitar cópia:
+   ```
+   <pre>00020126580014br.gov.bcb.pix...</pre>
+   ```
+
+5. **Botão de verificação** - Apenas 1 botão:
+   - **"✅ Já paguei (verificar)"** → Callback `verificar_pagamento_${transacao_id}`
+
+### Handler de Verificação (Sem mudanças)
+
+- Continua funcionando normalmente
+- Chama endpoint `/api/payment-status/${transacao_id}`
+- Se `paid`:
+  - Atualiza DB com `status='valido'`
+  - Persiste `payer_name` e `payer_cpf`
+  - Envia CTA de acesso via `URL_ENVIO_X`
+- Se `pending`: "Ainda pendente..."
+- Se `expired`: Oferece "🔄 Gerar novo código"
+
+---
+
+## Dados Mantidos (Não Apagados)
+
+### Banco de Dados
+- Campo `qr_code_base64` em `tokens` table - **MANTIDO** (não usado)
+- Campo `pix_copia_cola` em `tokens` table - **USADO ATIVAMENTE**
+
+### Arquivos
+- `./midia/pix_image.png` - **MANTIDO** (não usado)
+- `qr_debug.png` - **MANTIDO** (não usado)
+
+### Código Backend
+- Rotas `/api/gerar-qr-pix` - **MANTIDAS** (ainda retornam `qr_code_base64`, mas não é mais usado)
+- Gateway PIX (`services/pushinpay.js`, `services/oasyfy.js`) - **SEM ALTERAÇÕES**
+- Webhook handlers - **SEM ALTERAÇÕES**
+
+---
+
+## Logs Implementados
+
+### `[PIX-SHOW]` - Quando enviado código PIX
+```javascript
+console.log(`[${this.botId}] [PIX-SHOW] Texto enviado para ${chatId}:`, {
+  telegram_id: chatId,
+  provider_id: transacao_id,
+  has_qr_code_string: !!pix_copia_cola
+});
+```
+
+### Logs Existentes Mantidos
+- `[PIX-VERIFY]` - Verificação de status
+- `[PIX-WEBHOOK]` - Update via webhook
+- Logs de criação de cobrança
+
+---
+
+## Testes Sugeridos
+
+1. ✅ Selecionar plano → Receber apenas código PIX (sem imagem)
+2. ✅ Clicar em "Já paguei" → Verificar status
+3. ✅ Pagamento confirmado via webhook → Receber CTA de acesso
+4. ✅ Código expirado → Receber mensagem correta ("código PIX" não "QR Code")
+5. ✅ Páginas web (checkout/obrigado) → Exibir apenas código PIX (sem imagem)
+
+---
+
+## Compatibilidade
+
+- ✅ Gateway PIX continua funcionando normalmente
+- ✅ Webhook continua recebendo notificações
+- ✅ Persistência de dados continua igual
+- ✅ Verificação de pagamento continua funcional
+- ✅ Tracking e CAPI não afetados
+
+---
+
+## Próximos Passos (Opcional)
+
+1. Remover dependência `qrcode` do `package.json` (se existir)
+2. Remover coluna `qr_code_base64` do banco (após backup)
+3. Remover arquivos de imagem não usados
+4. Atualizar documentação do projeto
+
+---
+
+**Nota:** Todas as mudanças foram feitas **comentando** o código antigo, não apagando. Isso facilita rollback se necessário.

--- a/MODELO1/BOT/config.default.js
+++ b/MODELO1/BOT/config.default.js
@@ -331,7 +331,7 @@ const pagamento = {
   pendente: '⏳ O pagamento ainda não foi identificado. Aguarde alguns instantes e clique novamente.',
   aprovado: '✅ Pagamento confirmado com sucesso!\n\n🔓 Aqui está seu acesso ao conteúdo:',
   link: '👉 https://t.me/+UEmVhhccVMw3ODcx',
-  expirado: '❌ Este QR Code expirou. Por favor, gere uma nova cobrança.',
+  expirado: '❌ Este código PIX expirou. Por favor, gere uma nova cobrança.',
   erro: '❌ Erro ao verificar status do pagamento. Tente novamente em alguns instantes.'
 };
 

--- a/MODELO1/BOT/config.js
+++ b/MODELO1/BOT/config.js
@@ -380,7 +380,7 @@ const pagamento = {
   pendente: '⏳ O pagamento ainda não foi identificado. Aguarde alguns instantes e clique novamente.',
   aprovado: '✅ Pagamento confirmado com sucesso!\n\n🔓 Aqui está seu acesso ao conteúdo:',
   link: '👉 https://t.me/+UEmVhhccVMw3ODcx',
-  expirado: '❌ Este QR Code expirou. Por favor, gere uma nova cobrança.',
+  expirado: '❌ Este código PIX expirou. Por favor, gere uma nova cobrança.',
   erro: '❌ Erro ao verificar status do pagamento. Tente novamente em alguns instantes.'
 };
 

--- a/MODELO1/WEB/obrigado_especial.html
+++ b/MODELO1/WEB/obrigado_especial.html
@@ -306,23 +306,24 @@
       <div class="qr-title">PIX DE RESGATE - R$ 100,00</div>
       
       <div id="qr-loading" class="loading-qr">
-        Gerando QR code PIX...
+        Gerando código PIX...
       </div>
       
-      <div id="qr-container" class="qr-code-container" style="display: none;">
+      <!-- ❌ [REMOVIDO - QR CODE] Imagem do QR Code - não é mais usada -->
+      <!-- <div id="qr-container" class="qr-code-container" style="display: none;">
         <img id="qr-image" class="qr-code-image" alt="QR Code PIX" />
-      </div>
+      </div> -->
       
       <div id="pix-code-container" class="pix-code-section" style="display: none;">
         <div class="pix-code-label">Código PIX (Copia e Cola):</div>
         <div id="pix-code" class="pix-code"></div>
         <div style="font-size: 12px; color: #cccccc; margin-top: 10px;">
-          Copie o código acima ou escaneie o QR code
+          Copie o código acima e cole no seu aplicativo do banco
         </div>
       </div>
       
       <div id="qr-error" class="error-qr" style="display: none;">
-        Erro ao gerar QR code. Tente recarregar a página.
+        Erro ao gerar código PIX. Tente recarregar a página.
       </div>
     </div>
   </div>
@@ -499,17 +500,18 @@
         });
     }
     
-    // Função para gerar QR code PIX
+    // Função para gerar código PIX (copia e cola)
     async function gerarQRCodePIX() {
       const loadingElement = document.getElementById('qr-loading');
-      const qrContainer = document.getElementById('qr-container');
+      // ❌ [REMOVIDO - QR CODE] Não usamos mais a imagem do QR Code
+      // const qrContainer = document.getElementById('qr-container');
       const pixCodeContainer = document.getElementById('pix-code-container');
       const errorElement = document.getElementById('qr-error');
-      const qrImage = document.getElementById('qr-image');
+      // const qrImage = document.getElementById('qr-image');
       const pixCode = document.getElementById('pix-code');
       
       try {
-        console.log('Gerando QR code PIX...');
+        console.log('Gerando código PIX copia e cola...');
         
         const response = await fetch('/api/gerar-qr-pix', {
           method: 'POST',
@@ -521,32 +523,34 @@
         
         const data = await response.json();
         
-        if (data.success && data.qr_code_base64 && data.pix_copia_cola) {
+        // ❌ [REMOVIDO - QR CODE] Apenas validamos o pix_copia_cola, não mais o qr_code_base64
+        if (data.success && data.pix_copia_cola) {
           // Esconder loading
           loadingElement.style.display = 'none';
           
-          // Mostrar QR code
-          qrImage.src = data.qr_code_base64;
-          qrContainer.style.display = 'flex';
+          // ❌ [REMOVIDO - QR CODE] Não exibimos mais a imagem
+          // // Mostrar QR code
+          // qrImage.src = data.qr_code_base64;
+          // qrContainer.style.display = 'flex';
           
           // Mostrar código PIX
           pixCode.textContent = data.pix_copia_cola;
           pixCodeContainer.style.display = 'block';
           
-          console.log('QR code PIX gerado com sucesso:', data.transacao_id);
+          console.log('Código PIX gerado com sucesso:', data.transacao_id);
         } else {
           throw new Error(data.error || 'Erro desconhecido');
         }
         
       } catch (error) {
-        console.error('Erro ao gerar QR code PIX:', error);
+        console.error('Erro ao gerar código PIX:', error);
         
         // Esconder loading
         loadingElement.style.display = 'none';
         
         // Mostrar erro
         errorElement.style.display = 'block';
-        errorElement.textContent = 'Erro ao gerar QR code PIX. Tente recarregar a página.';
+        errorElement.textContent = 'Erro ao gerar código PIX. Tente recarregar a página.';
       }
     }
     

--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -4633,41 +4633,43 @@ async _executarGerarCobranca(req, res) {
         return;
       }
       
-      if (data.startsWith('qr_code_')) {
-        const transacaoId = data.replace('qr_code_', '');
-        const tokenRow = this.db ? this.db.prepare('SELECT pix_copia_cola, qr_code_base64 FROM tokens WHERE id_transacao = ? LIMIT 1').get(transacaoId) : null;
-        if (!tokenRow || !tokenRow.pix_copia_cola) {
-          return this.bot.sendMessage(chatId, '❌ Código PIX não encontrado.');
-        }
-        
-        // Se existe QR code base64, enviar a imagem
-        if (tokenRow.qr_code_base64) {
-          try {
-            const base64Image = tokenRow.qr_code_base64.replace(/^data:image\/png;base64,/, '');
-            const imageBuffer = Buffer.from(base64Image, 'base64');
-            const buffer = await this.processarImagem(imageBuffer);
-            
-            return this.bot.sendPhoto(chatId, buffer, {
-              caption: `<pre>${tokenRow.pix_copia_cola}</pre>`,
-              parse_mode: 'HTML',
-              reply_markup: { 
-                inline_keyboard: [[{ text: 'EFETUEI O PAGAMENTO', callback_data: `verificar_pagamento_${transacaoId}` }]] 
-              }
-            });
-          } catch (error) {
-            console.error('Erro ao processar QR code:', error.message);
-            // Fallback para texto se houver erro na imagem
-          }
-        }
-        
-        // Fallback: enviar apenas o código PIX copia e cola
-        return this.bot.sendMessage(chatId, `<pre>${tokenRow.pix_copia_cola}</pre>`, { 
-          parse_mode: 'HTML',
-          reply_markup: { 
-            inline_keyboard: [[{ text: 'EFETUEI O PAGAMENTO', callback_data: `verificar_pagamento_${transacaoId}` }]] 
-          }
-        });
-      }
+      // ❌ [REMOVIDO - QR CODE] Handler do botão "Qr code" - não é mais usado
+      // Mantemos apenas o fluxo de "copia e cola" com texto
+      // if (data.startsWith('qr_code_')) {
+      //   const transacaoId = data.replace('qr_code_', '');
+      //   const tokenRow = this.db ? this.db.prepare('SELECT pix_copia_cola, qr_code_base64 FROM tokens WHERE id_transacao = ? LIMIT 1').get(transacaoId) : null;
+      //   if (!tokenRow || !tokenRow.pix_copia_cola) {
+      //     return this.bot.sendMessage(chatId, '❌ Código PIX não encontrado.');
+      //   }
+      //   
+      //   // Se existe QR code base64, enviar a imagem
+      //   if (tokenRow.qr_code_base64) {
+      //     try {
+      //       const base64Image = tokenRow.qr_code_base64.replace(/^data:image\/png;base64,/, '');
+      //       const imageBuffer = Buffer.from(base64Image, 'base64');
+      //       const buffer = await this.processarImagem(imageBuffer);
+      //       
+      //       return this.bot.sendPhoto(chatId, buffer, {
+      //         caption: `<pre>${tokenRow.pix_copia_cola}</pre>`,
+      //         parse_mode: 'HTML',
+      //         reply_markup: { 
+      //           inline_keyboard: [[{ text: 'EFETUEI O PAGAMENTO', callback_data: `verificar_pagamento_${transacaoId}` }]] 
+      //         }
+      //       });
+      //     } catch (error) {
+      //       console.error('Erro ao processar QR code:', error.message);
+      //       // Fallback para texto se houver erro na imagem
+      //     }
+      //   }
+      //   
+      //   // Fallback: enviar apenas o código PIX copia e cola
+      //   return this.bot.sendMessage(chatId, `<pre>${tokenRow.pix_copia_cola}</pre>`, { 
+      //     parse_mode: 'HTML',
+      //     reply_markup: { 
+      //       inline_keyboard: [[{ text: 'EFETUEI O PAGAMENTO', callback_data: `verificar_pagamento_${transacaoId}` }]] 
+      //     }
+      //   });
+      // }
       console.log(`[${this.botId}] 🔍 BUSCANDO PLANO para callback: ${data}`);
       console.log(`[${this.botId}] 📋 PLANOS DISPONÍVEIS:`, this.config.planos.map(p => ({ id: p.id, nome: p.nome, valor: p.valor })));
       
@@ -4798,17 +4800,19 @@ async _executarGerarCobranca(req, res) {
         
         console.log(`[${this.botId}] ✅ DADOS VALIDADOS - Prosseguindo com envio da mensagem`);
         
-        // 1. Primeiro enviar a imagem PIX (sem texto)
-        try {
-          const sucessoImagem = await this.enviarMidiaComFallback(chatId, 'photo', './midia/pix_image.png');
-          
-          if (!sucessoImagem) {
-            console.log(`[${this.botId}] ⚠️ Falha ao enviar imagem PIX via sistema otimizado, tentando upload direto`);
-            await this.bot.sendPhoto(chatId, './midia/pix_image.png');
-          }
-        } catch (error) {
-          console.log(`[${this.botId}] ⚠️ Erro ao enviar imagem PIX, continuando sem imagem:`, error.message);
-        }
+        // ❌ [REMOVIDO - QR CODE] Envio de imagem PIX - não é mais usado
+        // Mantemos apenas o fluxo de texto "copia e cola"
+        // // 1. Primeiro enviar a imagem PIX (sem texto)
+        // try {
+        //   const sucessoImagem = await this.enviarMidiaComFallback(chatId, 'photo', './midia/pix_image.png');
+        //   
+        //   if (!sucessoImagem) {
+        //     console.log(`[${this.botId}] ⚠️ Falha ao enviar imagem PIX via sistema otimizado, tentando upload direto`);
+        //     await this.bot.sendPhoto(chatId, './midia/pix_image.png');
+        //   }
+        // } catch (error) {
+        //   console.log(`[${this.botId}] ⚠️ Erro ao enviar imagem PIX, continuando sem imagem:`, error.message);
+        // }
         
         // 2. Enviar instruções passo a passo
         const instrucoes = `✅ <b>Como realizar o pagamento:</b>
@@ -4830,12 +4834,19 @@ async _executarGerarCobranca(req, res) {
         await this.bot.sendMessage(chatId, `<pre>${pix_copia_cola}</pre>`, { parse_mode: 'HTML' });
         
         // 5. Enviar mensagem final com botões
-        const botaoPagar = { text: 'EFETUEI O PAGAMENTO', callback_data: `verificar_pagamento_${transacao_id}` };
-        const botaoQr = { text: 'Qr code', callback_data: `qr_code_${transacao_id}` };
+        const botaoPagar = { text: '✅ Já paguei (verificar)', callback_data: `verificar_pagamento_${transacao_id}` };
+        // ❌ [REMOVIDO - QR CODE] Botão "Qr code" - não é mais necessário
+        // const botaoQr = { text: 'Qr code', callback_data: `qr_code_${transacao_id}` };
+        
+        console.log(`[${this.botId}] [PIX-SHOW] Texto enviado para ${chatId}:`, {
+          telegram_id: chatId,
+          provider_id: transacao_id,
+          has_qr_code_string: !!pix_copia_cola
+        });
         
         await this.bot.sendMessage(chatId, 'Após efetuar o pagamento, clique no botão abaixo ⬇️', {
           parse_mode: 'HTML',
-          reply_markup: { inline_keyboard: [[botaoPagar], [botaoQr]] }
+          reply_markup: { inline_keyboard: [[botaoPagar]] }
         });
         
       } catch (error) {

--- a/checkout/funil_completo/assinatura_premiada.html
+++ b/checkout/funil_completo/assinatura_premiada.html
@@ -655,11 +655,12 @@
                                 </div>
                             </div>
 
-                            <div style="padding: 18px 50px 0 50px;">
+                            <!-- ❌ [REMOVIDO - QR CODE] Imagem do QR Code - mantemos apenas copia e cola -->
+                            <!-- <div style="padding: 18px 50px 0 50px;">
                                 <div style="background:#F3F4F6; border-radius:16px; box-shadow: 0 6px 16px rgba(0,0,0,.06); padding:24px; display:flex; align-items:center; justify-content:center;">
                                     <img src="${data.qr_code_base64}" alt="QR Code PIX" style="width: 256px; height: 256px; max-width: 100%; object-fit: contain;">
                                 </div>
-                            </div>
+                            </div> -->
 
                             <div style="padding: 18px 50px 0 50px;">
                                 <div style="font-weight:700; color:#6B7280; font-size:12px; letter-spacing:.24px;">CHAVE PIX</div>

--- a/checkout/funil_completo/chamada_premiada.html
+++ b/checkout/funil_completo/chamada_premiada.html
@@ -1218,11 +1218,12 @@
                                     </div>
                                 </div>
 
-                                <div style="padding: 18px 50px 0 50px;">
+                                <!-- ❌ [REMOVIDO - QR CODE] Imagem do QR Code - mantemos apenas copia e cola -->
+                                <!-- <div style="padding: 18px 50px 0 50px;">
                                     <div style="background:#F3F4F6; border-radius:16px; box-shadow: 0 6px 16px rgba(0,0,0,.06); padding:24px; display:flex; align-items:center; justify-content:center;">
                                         <img src="${data.qr_code_base64}" alt="QR Code PIX" style="width: 256px; height: 256px; max-width: 100%; object-fit: contain;">
                                     </div>
-                                </div>
+                                </div> -->
 
                                 <div style="padding: 18px 50px 0 50px;">
                                     <div style="font-weight:700; color:#6B7280; font-size:12px; letter-spacing:.24px;">CHAVE PIX</div>

--- a/checkout/index.html
+++ b/checkout/index.html
@@ -1202,7 +1202,8 @@ $(document).ready(function() {
 
             const data = await response.json();
 
-            if (data.success && data.qr_code_base64 && data.pix_copia_cola) {
+            // ❌ [REMOVIDO - QR CODE] Validação ajustada: não mais necessário qr_code_base64
+            if (data.success && data.pix_copia_cola) {
                 // Fechar loading
                 Swal.close();
 
@@ -1558,11 +1559,12 @@ $(document).ready(function() {
                                 </div>
                             </div>
 
-                            <div style="padding: 18px 50px 0 50px;">
+                            <!-- ❌ [REMOVIDO - QR CODE] Imagem do QR Code - mantemos apenas copia e cola -->
+                            <!-- <div style="padding: 18px 50px 0 50px;">
                                 <div style="background:#F3F4F6; border-radius:16px; box-shadow: 0 6px 16px rgba(0,0,0,.06); padding:24px; display:flex; align-items:center; justify-content:center;">
                                     <img src="${data.qr_code_base64}" alt="QR Code PIX" style="width: 256px; height: 256px; max-width: 100%; object-fit: contain;">
                                 </div>
-                            </div>
+                            </div> -->
 
                             <div style="padding: 18px 50px 0 50px;">
                                 <div style="font-weight:700; color:#6B7280; font-size:12px; letter-spacing:.24px;">CHAVE PIX</div>


### PR DESCRIPTION
Remove QR Code generation and display, streamlining the PIX payment flow to use only the "copia e cola" text.

All QR Code related functionalities, buttons, and image displays have been commented out instead of being deleted, as per the task instructions, to allow for easier rollback if needed.

---
<a href="https://cursor.com/background-agent?bcId=bc-16567136-ce78-40e7-b824-84093d399cb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16567136-ce78-40e7-b824-84093d399cb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

