### PR TITLE
Remove pixel id parameter from Meta Pixel user data call

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -620,28 +620,7 @@
 
                     if (typeof fbq !== 'undefined') {
                         // 🎯 CORREÇÃO CRÍTICA: usar 'userData' (camelCase) com dados PLAINTEXT
-                        const sanitizePixelIdFn = typeof sanitizePixelId === 'function'
-                            ? sanitizePixelId
-                            : (typeof window !== 'undefined' && typeof window.__sanitizePixelId__ === 'function'
-                                ? window.__sanitizePixelId__
-                                : (value => {
-                                    if (typeof value !== 'string') return '';
-                                    const trimmed = value.trim();
-                                    if (!trimmed) return '';
-                                    return trimmed.replace(/^['"]+|['"]+$/g, '');
-                                }));
-
-                        const pixelIdForUserData = sanitizePixelIdFn(
-                            (window.__PIXEL_CONFIG && window.__PIXEL_CONFIG.FB_PIXEL_ID) ||
-                            (window.__PIXEL_CONFIG && window.__PIXEL_CONFIG.FB_PIXEL_ID_RAW) ||
-                            ''
-                        );
-
-                        if (pixelIdForUserData) {
-                            fbq('set', 'userData', userDataPlain, pixelIdForUserData);
-                        } else {
-                            fbq('set', 'userData', userDataPlain);
-                        }
+                        fbq('set', 'userData', userDataPlain);
 
                         // Log confirmando ordem correta (antes do Purchase)
                         console.log('[ADVANCED-MATCH-FRONT] set userData before Purchase | ok=true');


### PR DESCRIPTION
## Summary
- simplify the Meta Pixel userData setup by removing the pixel_id argument from fbq('set')
- keep the advanced matching logging while ensuring the call executes before Purchase

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e78749b334832a85926c192c2df98d