### PR TITLE
Add guard preventing invalid fbq userData arguments

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -45,6 +45,28 @@
             })
             .catch(err => console.error('[PIXEL] ❌ Erro ao carregar config:', err));
     </script>
+    <script>
+        (function() {
+            if (typeof window.fbq === 'function' && !window.__FBQ_SET_GUARD__) {
+                window.__FBQ_SET_GUARD__ = true;
+                const _fbq = window.fbq;
+                window.fbq = function() {
+                    try {
+                        if (arguments && arguments[0] === 'set' && arguments[1] === 'userData') {
+                            console.log('[FBQ GUARD] set userData args:', arguments);
+                            if (arguments.length > 3) {
+                                console.error('[FBQ GUARD] Bloqueado: não use 4º argumento em set userData');
+                                return _fbq('set', 'userData', arguments[2]);
+                            }
+                        }
+                    } catch (e) {
+                        console.warn('[FBQ GUARD] intercept error:', e);
+                    }
+                    return _fbq.apply(this, arguments);
+                };
+            }
+        })();
+    </script>
     <script src="/shared/purchaseNormalization.js"></script>
     <noscript><img height="1" width="1" style="display:none"
     src="https://www.facebook.com/tr?id=YOUR_PIXEL_ID&ev=PageView&noscript=1"

--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -16,6 +16,28 @@
         s.parentNode.insertBefore(t,s)}(window, document,'script',
         'https://connect.facebook.net/en_US/fbevents.js');
 
+        (function () {
+            if (typeof window.fbq === 'function' && !window.__FBQ_SET_GUARD__) {
+                window.__FBQ_SET_GUARD__ = true;
+                const _fbq = window.fbq;
+                window.fbq = function () {
+                    try {
+                        if (arguments && arguments[0] === 'set' && arguments[1] === 'userData') {
+                            console.log('[FBQ GUARD] set userData args:', arguments);
+                            if (arguments.length > 3) {
+                                console.error('[FBQ GUARD] 🚫 Bloqueado: 4º argumento detectado em set userData');
+                                console.trace('[FBQ GUARD TRACE]');
+                                return _fbq('set', 'userData', arguments[2]);
+                            }
+                        }
+                    } catch (e) {
+                        console.warn('[FBQ GUARD] intercept error:', e);
+                    }
+                    return _fbq.apply(this, arguments);
+                };
+            }
+        })();
+
         // Carregar Pixel ID do backend
         const sanitizePixelId = (value) => {
             if (typeof value !== 'string') return '';
@@ -44,28 +66,6 @@
                 }
             })
             .catch(err => console.error('[PIXEL] ❌ Erro ao carregar config:', err));
-    </script>
-    <script>
-        (function() {
-            if (typeof window.fbq === 'function' && !window.__FBQ_SET_GUARD__) {
-                window.__FBQ_SET_GUARD__ = true;
-                const _fbq = window.fbq;
-                window.fbq = function() {
-                    try {
-                        if (arguments && arguments[0] === 'set' && arguments[1] === 'userData') {
-                            console.log('[FBQ GUARD] set userData args:', arguments);
-                            if (arguments.length > 3) {
-                                console.error('[FBQ GUARD] Bloqueado: não use 4º argumento em set userData');
-                                return _fbq('set', 'userData', arguments[2]);
-                            }
-                        }
-                    } catch (e) {
-                        console.warn('[FBQ GUARD] intercept error:', e);
-                    }
-                    return _fbq.apply(this, arguments);
-                };
-            }
-        })();
     </script>
     <script src="/shared/purchaseNormalization.js"></script>
     <noscript><img height="1" width="1" style="display:none"


### PR DESCRIPTION
## Summary
- wrap the Meta Pixel fbq function on the thank-you page to block `userData` calls with more than three arguments
- ensure the existing purchase flow keeps using the three-argument `fbq('set', 'userData', userDataPlain)` call

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e78b6a6e70832ab21b8a142855569c