### PR TITLE
Harden fbq guard on obrigado purchase flow

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -43,6 +43,79 @@
                 }
             }
 
+            function sanitizeUserDataArgs(argsLike, contextLabel) {
+                const argsArray = Array.from(argsLike || []);
+
+                if (
+                    argsArray.length >= 2 &&
+                    argsArray[0] === 'set' &&
+                    (argsArray[1] === 'userData' || argsArray[1] === 'user_data')
+                ) {
+                    const originalArgs = argsArray.slice();
+                    const originInfo = captureOrigin();
+
+                    if (argsArray.length > 3) {
+                        window.__FBQ_GUARD_LOGS__.push({
+                            type: 'set-userData-fourth-argument-blocked',
+                            timestamp: Date.now(),
+                            origin: originInfo.topFrame,
+                            stack: originInfo.stack,
+                            originalArgs: originalArgs,
+                            context: contextLabel || 'fbq'
+                        });
+
+                        console.groupCollapsed('[FBQ GUARD] 🚫 4º argumento removido de fbq("set", "userData")');
+                        console.error('[FBQ GUARD] 🚫 Bloqueado: fbq("set", "userData") com 4º argumento detectado.');
+                        console.log('[FBQ GUARD] contexto:', contextLabel || 'fbq');
+                        console.log('[FBQ GUARD] argumentos originais:', originalArgs);
+                        console.log('[FBQ GUARD] origem provável:', originInfo.topFrame);
+                        if (originInfo.stack && originInfo.stack.length) {
+                            console.log('[FBQ GUARD] stack completa:', originInfo.stack);
+                        }
+                        console.groupEnd();
+
+                        argsArray.splice(3);
+                    }
+
+                    if (argsArray.length >= 3 && argsArray[2] && typeof argsArray[2] === 'object') {
+                        const sanitizedUserData = { ...argsArray[2] };
+                        let removedPixelId = false;
+
+                        for (const key of ['pixel_id', 'pixelId', 'pixelID', 'pixel-id']) {
+                            if (sanitizedUserData[key] !== undefined) {
+                                delete sanitizedUserData[key];
+                                removedPixelId = true;
+                            }
+                        }
+
+                        if (removedPixelId) {
+                            window.__FBQ_GUARD_LOGS__.push({
+                                type: 'set-userData-pixel-id-removed',
+                                timestamp: Date.now(),
+                                origin: originInfo.topFrame,
+                                stack: originInfo.stack,
+                                originalArgs: originalArgs,
+                                context: contextLabel || 'fbq'
+                            });
+
+                            console.groupCollapsed('[FBQ GUARD] 🚫 pixel_id removido de fbq("set", "userData")');
+                            console.error('[FBQ GUARD] 🚫 Bloqueado: pixel_id dentro de userData.');
+                            console.log('[FBQ GUARD] contexto:', contextLabel || 'fbq');
+                            console.log('[FBQ GUARD] argumentos originais:', originalArgs);
+                            console.log('[FBQ GUARD] origem provável:', originInfo.topFrame);
+                            if (originInfo.stack && originInfo.stack.length) {
+                                console.log('[FBQ GUARD] stack completa:', originInfo.stack);
+                            }
+                            console.groupEnd();
+                        }
+
+                        argsArray[2] = sanitizedUserData;
+                    }
+                }
+
+                return argsArray;
+            }
+
             function wrapFbqWithUserDataGuard(originalFbq) {
                 if (typeof originalFbq !== 'function') {
                     return originalFbq;
@@ -53,36 +126,8 @@
                 }
 
                 function guardedFbq() {
-                    if (
-                        arguments &&
-                        arguments.length > 3 &&
-                        arguments[0] === 'set' &&
-                        arguments[1] === 'userData'
-                    ) {
-                        const argsArray = Array.from(arguments);
-                        const originInfo = captureOrigin();
-
-                        window.__FBQ_GUARD_LOGS__.push({
-                            type: 'set-userData-fourth-argument-blocked',
-                            timestamp: Date.now(),
-                            origin: originInfo.topFrame,
-                            stack: originInfo.stack,
-                            originalArgs: argsArray
-                        });
-
-                        console.groupCollapsed('[FBQ GUARD] 🚫 4º argumento removido de fbq("set", "userData")');
-                        console.error('[FBQ GUARD] 🚫 Bloqueado: fbq("set", "userData") com 4º argumento detectado.');
-                        console.log('[FBQ GUARD] argumentos originais:', argsArray);
-                        console.log('[FBQ GUARD] origem provável:', originInfo.topFrame);
-                        if (originInfo.stack && originInfo.stack.length) {
-                            console.log('[FBQ GUARD] stack completa:', originInfo.stack);
-                        }
-                        console.groupEnd();
-
-                        return originalFbq.call(this, 'set', 'userData', argsArray[2]);
-                    }
-
-                    return originalFbq.apply(this, arguments);
+                    const sanitizedArgs = sanitizeUserDataArgs(arguments, 'fbq');
+                    return originalFbq.apply(this, sanitizedArgs);
                 }
 
                 try {
@@ -91,14 +136,37 @@
                     console.warn('[FBQ GUARD] ⚠️ Não foi possível copiar propriedades do fbq original:', assignError);
                 }
 
+                const originalCallMethod = originalFbq.callMethod;
+                if (typeof originalCallMethod === 'function') {
+                    guardedFbq.callMethod = function () {
+                        const sanitizedArgs = sanitizeUserDataArgs(arguments, 'callMethod');
+                        return originalCallMethod.apply(originalFbq, sanitizedArgs);
+                    };
+                }
+
+                const originalPush = originalFbq.push;
+                if (typeof originalPush === 'function') {
+                    guardedFbq.push = function () {
+                        const sanitizedArgs = sanitizeUserDataArgs(arguments, 'push');
+                        return originalFbq.apply(originalFbq, sanitizedArgs);
+                    };
+                }
+
                 try {
-                    guardedFbq.push = originalFbq.push;
+                    if (Array.isArray(originalFbq.queue)) {
+                        for (let i = 0; i < originalFbq.queue.length; i += 1) {
+                            originalFbq.queue[i] = sanitizeUserDataArgs(originalFbq.queue[i], 'queue');
+                        }
+                    }
+                    guardedFbq.queue = originalFbq.queue;
                     guardedFbq.loaded = originalFbq.loaded;
                     guardedFbq.version = originalFbq.version;
-                    guardedFbq.queue = originalFbq.queue;
-                    guardedFbq.callMethod = originalFbq.callMethod;
                 } catch (copyError) {
                     console.warn('[FBQ GUARD] ⚠️ Erro ao espelhar propriedades do fbq original:', copyError);
+                }
+
+                if (window._fbq === originalFbq) {
+                    window._fbq = guardedFbq;
                 }
 
                 guardedFbq.__FBQ_USERDATA_GUARDED__ = true;


### PR DESCRIPTION
## Summary
- strengthen the fbq userData guard on the obrigado purchase flow page
- sanitize queued and direct fbq calls to strip fourth arguments and pixel_id fields

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e79d03e648832a8b4b2705363170e6