### PR TITLE
Refactor fbq integration with safe proxy and enrichers

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -15,7 +15,13 @@
         t.src=v;s=b.getElementsByTagName(e)[0];
         s.parentNode.insertBefore(t,s)}(window, document,'script',
         'https://connect.facebook.net/en_US/fbevents.js');
-
+    </script>
+    <!-- [FIX-PIXEL-CONFLICT] Proxy seguro do fbq (idempotente, sem reatribuir) -->
+    <script src="shared/fbq-safe-proxy.js"></script>
+    <script>
+        // [FIX-PIXEL-CONFLICT] Comentado: este guard redefinia window.fbq e removia metadados (.version/.callMethod).
+        // Mantido apenas como referência; NÃO executar para evitar "Multiple pixels with conflicting versions".
+        /*
         (function () {
             if (typeof window.fbq === 'function' && !window.__FBQ_SET_GUARD__) {
                 window.__FBQ_SET_GUARD__ = true;
@@ -37,6 +43,10 @@
                 };
             }
         })();
+        */
+    </script>
+    <!-- [FIX-PIXEL-CONFLICT] Guard antigo desativado (comentado acima). O fbq-safe-proxy cobre sanitização do userData. -->
+    <script>
 
         // Carregar Pixel ID do backend
         const sanitizePixelId = (value) => {
@@ -67,7 +77,7 @@
             })
             .catch(err => console.error('[PIXEL] ❌ Erro ao carregar config:', err));
     </script>
-    <script src="/shared/purchaseNormalization.js"></script>
+    <script src="shared/purchaseNormalization.js"></script>
     <!-- [AUDIT-ONLY] Meta Pixel conflict diagnostic -->
     <script src="/diagnostic-pixel-audit.js"></script>
     <noscript><img height="1" width="1" style="display:none"

--- a/MODELO1/WEB/shared/fbq-safe-proxy.js
+++ b/MODELO1/WEB/shared/fbq-safe-proxy.js
@@ -1,0 +1,81 @@
+// [FIX-PIXEL-CONFLICT] fbq Safe Proxy + Enricher Registry (idempotente)
+;(function () {
+  'use strict';
+  if (window.__FBQ_SAFE_PROXY_INSTALLED__) return;
+  window.__FBQ_SAFE_PROXY_INSTALLED__ = true;
+
+  var enrichers = [];
+  // Outras partes do código (ex.: UTMify) podem registrar transformadores de chamadas do fbq
+  window.__FBQ_SAFE_PROXY_REGISTER = function (fn) {
+    if (typeof fn === 'function') enrichers.push(fn);
+  };
+
+  function cloneShallow(obj) {
+    if (!obj || typeof obj !== 'object') return obj;
+    var out = {};
+    for (var k in obj) if (Object.prototype.hasOwnProperty.call(obj, k)) out[k] = obj[k];
+    return out;
+  }
+
+  // Garantia: NUNCA mandar pixel_id para userData e NUNCA usar 4º argumento
+  function sanitizeUserData(input) {
+    var o = cloneShallow(input) || {};
+    if (o && typeof o === 'object' && 'pixel_id' in o) delete o.pixel_id;
+    return o;
+  }
+
+  function applyWithSanitize(target, thisArg, args) {
+    try {
+      var a = Array.prototype.slice.call(args);
+      // Aplicar enrichers registrados (transformam args; devem retornar o array novo ou falsy p/ manter)
+      for (var i = 0; i < enrichers.length; i++) {
+        try {
+          var maybe = enrichers[i](a);
+          if (Array.isArray(maybe)) a = maybe;
+        } catch (_) { /* ignore enricher errors */ }
+      }
+      // Sanitização específica do userData
+      if (a[0] === 'set' && a[1] === 'userData') {
+        a[2] = sanitizeUserData(a[2]);
+        // garantir máximo de 3 argumentos (evita erro do 4º arg)
+        a = a.slice(0, 3);
+      }
+      return Reflect.apply(target, thisArg, a);
+    } catch (_) {
+      return Reflect.apply(target, thisArg, args);
+    }
+  }
+
+  function proxifyFunction(fn) {
+    if (typeof fn !== 'function') return fn;
+    if (fn.__FBQ_SAFE_PROXY__) return fn;
+    var proxy = new Proxy(fn, {
+      apply: function (target, thisArg, argumentsList) {
+        return applyWithSanitize(target, thisArg, argumentsList);
+      },
+      get: function (target, prop, receiver) {
+        var val = Reflect.get(target, prop, receiver);
+        // Encadear proxy em callMethod/push (fila/execução interna do fbq)
+        if (prop === 'callMethod' || prop === 'push') {
+          return proxifyFunction(val);
+        }
+        return val;
+      }
+    });
+    try { Object.defineProperty(proxy, '__FBQ_SAFE_PROXY__', { value: true }); } catch (_) {}
+    return proxy;
+  }
+
+  function installOnce() {
+    if (typeof window.fbq !== 'function') return false;
+    if (window.fbq.__FBQ_SAFE_PROXY__) return true;
+    // Importante: não perder shape; usamos get trap para refletir props dinâmicas (version/loaded/etc.)
+    window.fbq = proxifyFunction(window.fbq);
+    return true;
+  }
+
+  // Instalar quando a lib real estiver pronta; evitar redefinir várias vezes
+  var tries = 0, timer = setInterval(function () {
+    if (installOnce() || ++tries > 120) clearInterval(timer);
+  }, 50);
+})();

--- a/MODELO1/WEB/shared/purchaseNormalization.js
+++ b/MODELO1/WEB/shared/purchaseNormalization.js
@@ -1,0 +1,98 @@
+/**
+ * Purchase Normalization Library
+ * Funções de normalização de dados para eventos de Purchase
+ */
+(function(window) {
+  'use strict';
+
+  /**
+   * Normaliza URL para event_source_url
+   * Remove fragmentos e parâmetros sensíveis
+   */
+  function normalizeUrlForEventSource(url) {
+    if (!url || typeof url !== 'string') return null;
+    
+    try {
+      var urlObj = new URL(url);
+      // Remove fragmento (#)
+      urlObj.hash = '';
+      // Remove parâmetros sensíveis comuns
+      var sensitiveParams = ['token', 'password', 'secret', 'key', 'auth'];
+      sensitiveParams.forEach(function(param) {
+        urlObj.searchParams.delete(param);
+      });
+      return urlObj.toString();
+    } catch (e) {
+      return url;
+    }
+  }
+
+  /**
+   * Normaliza telefone
+   * Remove caracteres não numéricos
+   */
+  function normalizePhone(phone) {
+    if (!phone || typeof phone !== 'string') return null;
+    
+    // Remove todos os caracteres não numéricos
+    var cleaned = phone.replace(/\D/g, '');
+    
+    if (!cleaned) return null;
+    
+    return cleaned;
+  }
+
+  /**
+   * Normaliza email
+   * Converte para lowercase e remove espaços
+   */
+  function normalizeEmail(email) {
+    if (!email || typeof email !== 'string') return null;
+    
+    var cleaned = email.trim().toLowerCase();
+    
+    // Validação básica de email
+    if (!cleaned.includes('@')) return null;
+    
+    return cleaned;
+  }
+
+  /**
+   * Normaliza nome (firstName ou lastName)
+   * Remove espaços extras e converte para lowercase
+   */
+  function normalizeName(name) {
+    if (!name || typeof name !== 'string') return null;
+    
+    var cleaned = name.trim().toLowerCase();
+    
+    if (!cleaned) return null;
+    
+    return cleaned;
+  }
+
+  /**
+   * Normaliza external_id (CPF)
+   * Remove caracteres não numéricos
+   */
+  function normalizeExternalId(externalId) {
+    if (!externalId || typeof externalId !== 'string') return null;
+    
+    // Remove todos os caracteres não numéricos
+    var cleaned = externalId.replace(/\D/g, '');
+    
+    if (!cleaned) return null;
+    
+    return cleaned;
+  }
+
+  // Exportar a biblioteca
+  window.PurchaseNormalization = {
+    normalizeUrlForEventSource: normalizeUrlForEventSource,
+    normalizePhone: normalizePhone,
+    normalizeEmail: normalizeEmail,
+    normalizeName: normalizeName,
+    normalizeExternalId: normalizeExternalId
+  };
+
+})(window);

--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -143,6 +143,8 @@
         });
       })(window, document);
     </script>
+    <!-- [FIX-PIXEL-CONFLICT] Proxy seguro do fbq -->
+    <script src="../shared/fbq-safe-proxy.js"></script>
     <!-- End Meta Pixel Code -->
   </head>
   <body>

--- a/MODELO1/WEB/telegram/utmify-pixel-interceptor.js
+++ b/MODELO1/WEB/telegram/utmify-pixel-interceptor.js
@@ -1,3 +1,6 @@
+// [FIX-PIXEL-CONFLICT] Interceptor antigo que redefinia window.fbq várias vezes (polling até 40x)
+// (comentado para evitar "Multiple pixels with conflicting versions")
+/*
 (function (window) {
   'use strict';
 
@@ -26,7 +29,7 @@
           ' fbc=' + flags.fbc
       );
     } catch (error) {
-      /* noop */
+      // noop
     }
   }
 
@@ -298,7 +301,7 @@
         }
       }
     } catch (error) {
-      /* noop */
+      // noop
     }
 
     window.fbq = interceptedFbq;
@@ -318,3 +321,268 @@
     }, 50);
   }
 })(window);
+*/
+
+// [FIX-PIXEL-CONFLICT] Registrar apenas um "enricher" no Proxy seguro (sem redefinir window.fbq)
+(function registerUtmifyFbqEnricher() {
+  'use strict';
+
+  var UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'];
+  var HEX64_REGEX = /^[a-f0-9]{64}$/i;
+  var DEV_HOST_REGEX = /(localhost|127\.0\.0\.1|\.local|\.test|dev)/i;
+  var isDev = false;
+
+  try {
+    isDev = DEV_HOST_REGEX.test(window.location && window.location.hostname);
+  } catch (error) {
+    isDev = false;
+  }
+
+  function ensureObj(v) { 
+    return (v && typeof v === 'object') ? v : {}; 
+  }
+
+  function safeStorages() {
+    var storages = [];
+
+    try {
+      if (window.localStorage) {
+        storages.push(window.localStorage);
+      }
+    } catch (error) {
+      /* noop */
+    }
+
+    try {
+      if (window.sessionStorage) {
+        storages.push(window.sessionStorage);
+      }
+    } catch (error) {
+      /* noop */
+    }
+
+    return storages;
+  }
+
+  function readFromStorages(keys) {
+    var storages = safeStorages();
+
+    for (var i = 0; i < storages.length; i++) {
+      var storage = storages[i];
+
+      for (var j = 0; j < keys.length; j++) {
+        var key = keys[j];
+
+        try {
+          var value = storage.getItem(key);
+          if (typeof value === 'string' && value) {
+            return value;
+          }
+        } catch (error) {
+          /* noop */
+        }
+      }
+    }
+
+    return null;
+  }
+
+  function getCookie(name) {
+    try {
+      var match = document.cookie.match(
+        new RegExp('(?:^|; )' + name.replace(/[.$?*|{}()\[\]\\\/\+^]/g, '\\$&') + '=([^;]*)')
+      );
+      return match ? decodeURIComponent(match[1]) : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function getExternalId() {
+    try {
+      var value = window.__EXTERNAL_ID__;
+      return HEX64_REGEX.test(value) ? value : null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function getFbp() {
+    var cookieValue = getCookie('_fbp');
+    if (cookieValue) {
+      return cookieValue;
+    }
+
+    return readFromStorages(['captured_fbp', 'fbp']);
+  }
+
+  function getFbc() {
+    var cookieValue = getCookie('_fbc');
+    if (cookieValue) {
+      return cookieValue;
+    }
+
+    var storedValue = readFromStorages(['captured_fbc', 'fbc']);
+    if (storedValue) {
+      return storedValue;
+    }
+
+    try {
+      if (window.fbclidHandler && typeof window.fbclidHandler.obterFbc === 'function') {
+        return window.fbclidHandler.obterFbc();
+      }
+    } catch (error) {
+      /* noop */
+    }
+
+    return null;
+  }
+
+  function getUtms() {
+    var utms = {};
+
+    try {
+      if (window.UTMTracking && typeof window.UTMTracking.get === 'function') {
+        var trackerValues = window.UTMTracking.get() || {};
+
+        for (var i = 0; i < UTM_KEYS.length; i++) {
+          var key = UTM_KEYS[i];
+          var value = trackerValues[key];
+
+          if (typeof value === 'string' && value) {
+            utms[key] = value;
+          }
+        }
+      }
+    } catch (error) {
+      /* noop */
+    }
+
+    for (var j = 0; j < UTM_KEYS.length; j++) {
+      var utmKey = UTM_KEYS[j];
+
+      if (!utms[utmKey]) {
+        var storedValue = readFromStorages([utmKey]);
+        if (storedValue) {
+          utms[utmKey] = storedValue;
+        }
+      }
+    }
+
+    return utms;
+  }
+
+  function enrichTrackArgs(a) {
+    try {
+      // a = ['track', 'EventName', {...payload...}, { eventID: '...' }]
+      if (!Array.isArray(a) || a[0] !== 'track') return a;
+      
+      var eventName = a.length > 1 ? a[1] : null;
+      if (!eventName || typeof eventName !== 'string') return a;
+
+      // Payload pode estar em a[2] ou precisar ser criado
+      var originalPayload = a.length > 2 ? a[2] : undefined;
+      var hadOriginalPayload = !!originalPayload && typeof originalPayload === 'object';
+      var payload = hadOriginalPayload ? originalPayload : {};
+
+      if (!hadOriginalPayload) {
+        if (a.length > 2) {
+          a[2] = payload;
+        } else {
+          a.push(payload);
+        }
+      }
+
+      // Enriquecer custom_data com UTMs
+      var utms = getUtms();
+      var utmAdded = false;
+      var hadCustomData = !!payload.custom_data && typeof payload.custom_data === 'object';
+      var customData = hadCustomData ? payload.custom_data : {};
+
+      for (var i = 0; i < UTM_KEYS.length; i++) {
+        var key = UTM_KEYS[i];
+        var value = utms[key];
+
+        if (!value) continue;
+        if (Object.prototype.hasOwnProperty.call(customData, key)) continue;
+
+        customData[key] = value;
+        utmAdded = true;
+      }
+
+      if (utmAdded || hadCustomData) {
+        payload.custom_data = customData;
+      }
+
+      // Enriquecer user_data com external_id, fbp, fbc
+      var hadUserData = !!payload.user_data && typeof payload.user_data === 'object';
+      var userData = hadUserData ? payload.user_data : {};
+      var externalAdded = false;
+      var fbpAdded = false;
+      var fbcAdded = false;
+
+      var externalId = getExternalId();
+      if (externalId && !Object.prototype.hasOwnProperty.call(userData, 'external_id')) {
+        userData.external_id = externalId;
+        externalAdded = true;
+      }
+
+      var fbp = getFbp();
+      if (fbp && !Object.prototype.hasOwnProperty.call(userData, 'fbp')) {
+        userData.fbp = fbp;
+        fbpAdded = true;
+      }
+
+      var fbc = getFbc();
+      if (fbc && !Object.prototype.hasOwnProperty.call(userData, 'fbc')) {
+        userData.fbc = fbc;
+        fbcAdded = true;
+      }
+
+      if (externalAdded || fbpAdded || fbcAdded || hadUserData) {
+        payload.user_data = userData;
+      }
+
+      // Se não adicionamos nada e não havia payload original, remover payload vazio
+      var somethingAdded = utmAdded || externalAdded || fbpAdded || fbcAdded;
+      if (!hadOriginalPayload && !somethingAdded && Object.keys(payload).length === 0) {
+        a.splice(2, 1);
+      }
+
+      // Log de desenvolvimento
+      if (isDev && somethingAdded) {
+        try {
+          console.info(
+            '[PIXEL-INT] enrich ' + eventName +
+              ' utms=' + utmAdded +
+              ' user_data.ext=' + externalAdded +
+              ' fbp=' + fbpAdded +
+              ' fbc=' + fbcAdded
+          );
+        } catch (error) {
+          /* noop */
+        }
+      }
+
+      return a;
+    } catch (_) { 
+      return a; 
+    }
+  }
+
+  if (typeof window.__FBQ_SAFE_PROXY_REGISTER === 'function') {
+    window.__FBQ_SAFE_PROXY_REGISTER(enrichTrackArgs);
+  } else {
+    // Fallback suave: aguarda o proxy estar disponível e registra uma vez
+    var tries = 0, t = setInterval(function(){
+      if (typeof window.__FBQ_SAFE_PROXY_REGISTER === 'function') {
+        try { 
+          window.__FBQ_SAFE_PROXY_REGISTER(enrichTrackArgs); 
+        } catch (_) {}
+        clearInterval(t);
+      } else if (++tries > 120) {
+        clearInterval(t);
+      }
+    }, 50);
+  }
+})();


### PR DESCRIPTION
Implement a safe, idempotent Proxy for `window.fbq` and replace direct reassignments with an enricher registry to fix Meta Pixel warnings and ensure data sanitization.

Previously, `window.fbq` was directly reassigned in multiple locations, causing "Multiple pixels with conflicting versions" warnings and potentially breaking `fbq`'s internal properties. This PR centralizes `fbq` interception into a single, idempotent Proxy. This Proxy allows argument modification via a new "enricher" registry, preventing re-assignment conflicts. It also automatically sanitizes `fbq('set', 'userData')` calls by removing `pixel_id` and limiting arguments to three, addressing specific Meta Pixel warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b1a1ae7-5708-4aee-8f4f-c20739e7ce0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b1a1ae7-5708-4aee-8f4f-c20739e7ce0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

