### PR TITLE
Harden fbq sanitization and disable diagnostic scripts

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -79,7 +79,9 @@
     </script>
     <script src="shared/purchaseNormalization.js"></script>
     <!-- [AUDIT-ONLY] Meta Pixel conflict diagnostic -->
+    <!-- [AUDIT-ONLY - DESATIVADO EM PRODUÇÃO]
     <script src="/diagnostic-pixel-audit.js"></script>
+    -->
     <noscript><img height="1" width="1" style="display:none"
     src="https://www.facebook.com/tr?id=YOUR_PIXEL_ID&ev=PageView&noscript=1"
     /></noscript>

--- a/MODELO1/WEB/shared/fbq-safe-proxy.js
+++ b/MODELO1/WEB/shared/fbq-safe-proxy.js
@@ -18,9 +18,28 @@
   }
 
   // Garantia: NUNCA mandar pixel_id para userData e NUNCA usar 4º argumento
-  function sanitizeUserData(input) {
-    var o = cloneShallow(input) || {};
-    if (o && typeof o === 'object' && 'pixel_id' in o) delete o.pixel_id;
+  function sanitizeUserData(input, originalArgs) {
+    // Garante objeto plano; ignora arrays/strings/null/etc.
+    var o = (input && typeof input === 'object' && !Array.isArray(input))
+      ? cloneShallow(input)
+      : {};
+    // Remove pixel_id no clone
+    if ('pixel_id' in o) {
+      try {
+        delete o.pixel_id;
+      } catch (_) {
+        o.pixel_id = undefined;
+      }
+    }
+    // Defesa extra: tenta remover pixel_id também do objeto original passado à call
+    try {
+      if (originalArgs && originalArgs.length >= 3) {
+        var ref = originalArgs[2];
+        if (ref && typeof ref === 'object' && !Array.isArray(ref) && 'pixel_id' in ref) {
+          delete ref.pixel_id;
+        }
+      }
+    } catch (_) {}
     return o;
   }
 
@@ -34,11 +53,23 @@
           if (Array.isArray(maybe)) a = maybe;
         } catch (_) { /* ignore enricher errors */ }
       }
-      // Sanitização específica do userData
+      // Sanitização: set('userData', userData[, pixelId])
       if (a[0] === 'set' && a[1] === 'userData') {
-        a[2] = sanitizeUserData(a[2]);
-        // garantir máximo de 3 argumentos (evita erro do 4º arg)
+        a[2] = sanitizeUserData(a[2], args);
+        // Nunca permitir 4º argumento
         a = a.slice(0, 3);
+      }
+      // Sanitização: init(pixelId, advancedMatching, options)
+      if (a[0] === 'init' && a.length >= 3) {
+        if (a[2] && typeof a[2] === 'object' && !Array.isArray(a[2])) {
+          if ('pixel_id' in a[2]) {
+            try {
+              delete a[2].pixel_id;
+            } catch (_) {
+              a[2].pixel_id = undefined;
+            }
+          }
+        }
       }
       return Reflect.apply(target, thisArg, a);
     } catch (_) {
@@ -69,8 +100,12 @@
   function installOnce() {
     if (typeof window.fbq !== 'function') return false;
     if (window.fbq.__FBQ_SAFE_PROXY__) return true;
-    // Importante: não perder shape; usamos get trap para refletir props dinâmicas (version/loaded/etc.)
-    window.fbq = proxifyFunction(window.fbq);
+    // Importante: não perder shape; get trap reflete props dinâmicas (version/loaded/etc.)
+    var proxied = proxifyFunction(window.fbq);
+    window.fbq = proxied;
+    try {
+      window._fbq = proxied;
+    } catch (_) {}
     return true;
   }
 

--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -207,8 +207,9 @@
     <script src="/telegram/utmify-pixel-interceptor.js" defer></script>
     <script src="/telegram/geolocation.js" defer></script>
     <script src="/telegram/app.js" defer></script>
-    <!-- [AUDIT-ONLY] Meta Pixel conflict diagnostic -->
+    <!-- [AUDIT-ONLY - DESATIVADO EM PRODUÇÃO]
     <script src="/diagnostic-pixel-audit.js" defer></script>
+    -->
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         const infoElement = document.querySelector('.info');


### PR DESCRIPTION
## Summary
- harden the fbq safe proxy to defensively strip pixel_id data during set and init calls and mirror the proxy to _fbq
- comment out the diagnostic pixel audit script includes on the Telegram and Obrigado pages for production

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7c7dc8c44832a9efa055f37cb31ab