### PR TITLE
Sanitize pixel data and disable audit scripts

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -78,8 +78,9 @@
             .catch(err => console.error('[PIXEL] ❌ Erro ao carregar config:', err));
     </script>
     <script src="shared/purchaseNormalization.js"></script>
-    <!-- [AUDIT-ONLY] Meta Pixel conflict diagnostic -->
+    <!-- [AUDIT-ONLY - DESATIVADO EM PRODUÇÃO]
     <script src="/diagnostic-pixel-audit.js"></script>
+    -->
     <noscript><img height="1" width="1" style="display:none"
     src="https://www.facebook.com/tr?id=YOUR_PIXEL_ID&ev=PageView&noscript=1"
     /></noscript>

--- a/MODELO1/WEB/shared/fbq-safe-proxy.js
+++ b/MODELO1/WEB/shared/fbq-safe-proxy.js
@@ -18,9 +18,20 @@
   }
 
   // Garantia: NUNCA mandar pixel_id para userData e NUNCA usar 4º argumento
-  function sanitizeUserData(input) {
-    var o = cloneShallow(input) || {};
-    if (o && typeof o === 'object' && 'pixel_id' in o) delete o.pixel_id;
+  function sanitizeUserData(input, originalArgs) {
+    // Garante objeto plano; ignora arrays/strings/null/etc.
+    var o = (input && typeof input === 'object' && !Array.isArray(input)) ? cloneShallow(input) : {};
+    // Remove pixel_id no clone
+    if ('pixel_id' in o) { try { delete o.pixel_id; } catch (_) { o.pixel_id = undefined; } }
+    // Defesa extra: tenta remover pixel_id também do objeto original passado à call
+    try {
+      if (originalArgs && originalArgs.length >= 3) {
+        var ref = originalArgs[2];
+        if (ref && typeof ref === 'object' && !Array.isArray(ref) && 'pixel_id' in ref) {
+          delete ref.pixel_id;
+        }
+      }
+    } catch (_) {}
     return o;
   }
 
@@ -34,11 +45,18 @@
           if (Array.isArray(maybe)) a = maybe;
         } catch (_) { /* ignore enricher errors */ }
       }
-      // Sanitização específica do userData
+      // Sanitização: set('userData', userData[, pixelId])
       if (a[0] === 'set' && a[1] === 'userData') {
-        a[2] = sanitizeUserData(a[2]);
-        // garantir máximo de 3 argumentos (evita erro do 4º arg)
+        a[2] = sanitizeUserData(a[2], args);
+        // Nunca permitir 4º argumento
         a = a.slice(0, 3);
+      }
+      // Sanitização: init(pixelId, advancedMatching, options)
+      // Assinatura comum: init, pixelId, advancedMatching, options
+      if (a[0] === 'init' && a.length >= 3) {
+        if (a[2] && typeof a[2] === 'object' && !Array.isArray(a[2])) {
+          if ('pixel_id' in a[2]) { try { delete a[2].pixel_id; } catch (_) { a[2].pixel_id = undefined; } }
+        }
       }
       return Reflect.apply(target, thisArg, a);
     } catch (_) {
@@ -69,8 +87,11 @@
   function installOnce() {
     if (typeof window.fbq !== 'function') return false;
     if (window.fbq.__FBQ_SAFE_PROXY__) return true;
-    // Importante: não perder shape; usamos get trap para refletir props dinâmicas (version/loaded/etc.)
-    window.fbq = proxifyFunction(window.fbq);
+    // Importante: não perder shape; get trap reflete props dinâmicas (version/loaded/etc.)
+    var proxied = proxifyFunction(window.fbq);
+    window.fbq = proxied;
+    // Garante que o alias _fbq use o mesmo proxy (evita bypass)
+    try { window._fbq = proxied; } catch (_) {}
     return true;
   }
 

--- a/MODELO1/WEB/telegram/index.html
+++ b/MODELO1/WEB/telegram/index.html
@@ -207,8 +207,9 @@
     <script src="/telegram/utmify-pixel-interceptor.js" defer></script>
     <script src="/telegram/geolocation.js" defer></script>
     <script src="/telegram/app.js" defer></script>
-    <!-- [AUDIT-ONLY] Meta Pixel conflict diagnostic -->
+    <!-- [AUDIT-ONLY - DESATIVADO EM PRODUÇÃO]
     <script src="/diagnostic-pixel-audit.js" defer></script>
+    -->
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         const infoElement = document.querySelector('.info');


### PR DESCRIPTION
Enhance Meta Pixel data sanitization to prevent `pixel_id` leakage and disable audit scripts in production.

---
<a href="https://cursor.com/background-agent?bcId=bc-5bf76934-9c3f-4ecf-9e2f-3976fbaa1b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5bf76934-9c3f-4ecf-9e2f-3976fbaa1b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

