### PR TITLE
Sanitize queued fbq calls and guard pixel usage

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -653,7 +653,7 @@
                     console.log(`data[0].custom_data =`, JSON.stringify(customDataForLog, null, 2));
                     console.log(`data[0].event_source_url = "${eventSourceUrl}"`);
 
-                    if (typeof fbq !== 'undefined') {
+                    if (window.__fbqReady && window.__fbqReady()) {
                         // 🎯 CORREÇÃO CRÍTICA: usar 'userData' (camelCase) com dados PLAINTEXT
                         fbq('set', 'userData', userDataPlain);
 
@@ -671,7 +671,7 @@
                             currency: pixelCustomData.currency
                         });
                     } else {
-                        console.warn('[PURCHASE-BROWSER] ⚠️ fbq não disponível');
+                        console.warn('[PURCHASE-BROWSER] ⚠️ Pixel indisponível/aguardando — seguir apenas com CAPI');
                     }
 
                     const markPixelResponse = await fetch('/api/mark-pixel-sent', {


### PR DESCRIPTION
## Summary
- add a global helper to detect when the real fbq library is ready
- sanitize any queued fbq calls before installing the proxy to strip sensitive fields
- require the purchase flow to wait for fbq readiness before calling Pixel APIs and clarify logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7efd7b1b4832ab6f906b5b6a80a12