### PR TITLE
feat: instrument fbq enrichers for debug

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Pagamento Confirmado!</title>
-    
+
+    <script>
+        if (/[?&]fbq_debug=1\b/.test(window.location.search)) {
+            window.DEBUG_FB_ENRICHERS = true;
+            console.log('[FBQ-DEBUG] modo detetive ON');
+        }
+    </script>
     <!-- Meta Pixel Code -->
     <script>
         !function(f,b,e,v,n,t,s)
@@ -547,7 +553,19 @@
 
                     // 🎯 CORREÇÃO: Montar userData em plaintext (sem hash no front)
                     // O Pixel faz hashing automático
-                    const userDataPlain = {};
+                    const userDataTarget = {};
+                    const DEBUG_FB_ENRICHERS = Boolean(window.DEBUG_FB_ENRICHERS);
+                    const userDataPlain = DEBUG_FB_ENRICHERS ? new Proxy(userDataTarget, {
+                        set(target, prop, value) {
+                            if (prop === 'pixel_id') {
+                                console.group('[FBQ-DEBUG] tentativa de definir pixel_id em userDataPlain');
+                                console.log('value:', value);
+                                console.log('stack:', (new Error('userDataPlain.set')).stack);
+                                console.groupEnd();
+                            }
+                            return Reflect.set(target, prop, value);
+                        }
+                    }) : userDataTarget;
                     
                     if (normalizedData.email) userDataPlain.em = normalizedData.email;
                     if (normalizedData.phone) userDataPlain.ph = normalizedData.phone;
@@ -649,12 +667,28 @@
                     console.log(`data[0].event_time = ${eventTimeUnix}`);
                     console.log(`data[0].event_id = "${eventId}"`);
                     console.log(`data[0].action_source = "website"`);
-                    console.log(`data[0].user_data =`, JSON.stringify(userDataPlain, null, 2));
+                    console.log(`data[0].user_data =`, JSON.stringify(userDataTarget, null, 2));
                     console.log(`data[0].custom_data =`, JSON.stringify(customDataForLog, null, 2));
                     console.log(`data[0].event_source_url = "${eventSourceUrl}"`);
 
                     if (window.__fbqReady && window.__fbqReady()) {
                         // 🎯 CORREÇÃO CRÍTICA: usar 'userData' (camelCase) com dados PLAINTEXT
+                        if (DEBUG_FB_ENRICHERS) {
+                            let snapshot;
+                            try {
+                                if (typeof structuredClone === 'function') {
+                                    snapshot = structuredClone(userDataTarget);
+                                } else {
+                                    snapshot = JSON.parse(JSON.stringify(userDataTarget));
+                                }
+                            } catch (err) {
+                                snapshot = Object.assign({}, userDataTarget);
+                            }
+                            console.group('[FBQ-DEBUG] userDataPlain antes de fbq("set","userData")');
+                            console.log(snapshot);
+                            console.groupEnd();
+                        }
+
                         fbq('set', 'userData', userDataPlain);
 
                         // Log confirmando ordem correta (antes do Purchase)

--- a/MODELO1/WEB/shared/fbq-safe-proxy.js
+++ b/MODELO1/WEB/shared/fbq-safe-proxy.js
@@ -4,15 +4,186 @@
   if (window.__FBQ_SAFE_PROXY_INSTALLED__) return;
   window.__FBQ_SAFE_PROXY_INSTALLED__ = true;
 
+  const DEBUG = Boolean(window.DEBUG_FB_ENRICHERS || /[?&]fbq_debug=1\b/.test(location.search));
+
+  function captureStack(label) {
+    try { throw new Error(label); } catch (err) { return err.stack; }
+  }
+
+  function safeClone(value, seen) {
+    if (typeof structuredClone === 'function') {
+      try { return structuredClone(value); } catch (_) {}
+    }
+    if (value === null || typeof value !== 'object') return value;
+    if (value instanceof Date) return new Date(value.getTime());
+    if (value instanceof RegExp) return new RegExp(value.source, value.flags);
+    seen = seen || new WeakMap();
+    if (seen.has(value)) return seen.get(value);
+    if (Array.isArray(value)) {
+      var arr = [];
+      seen.set(value, arr);
+      for (var i = 0; i < value.length; i++) {
+        arr[i] = safeClone(value[i], seen);
+      }
+      return arr;
+    }
+    var out = {};
+    seen.set(value, out);
+    for (var key in value) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
+        out[key] = safeClone(value[key], seen);
+      }
+    }
+    return out;
+  }
+
+  function containsPixelIdInSetUserData(args) {
+    if (!Array.isArray(args)) return false;
+    if (args[0] !== 'set' || args[1] !== 'userData') return false;
+    if (args.length < 3) return false;
+    var userData = args[2];
+    return !!(userData && typeof userData === 'object' && !Array.isArray(userData) && Object.prototype.hasOwnProperty.call(userData, 'pixel_id'));
+  }
+
+  function containsPixelIdInInit(args) {
+    if (!Array.isArray(args)) return false;
+    if (args[0] !== 'init') return false;
+    if (args.length < 3) return false;
+    var advancedMatching = args[2];
+    return !!(advancedMatching && typeof advancedMatching === 'object' && !Array.isArray(advancedMatching) && Object.prototype.hasOwnProperty.call(advancedMatching, 'pixel_id'));
+  }
+
+  function stripPixelIdEverywhere(args) {
+    if (!Array.isArray(args)) return args;
+    if (args[0] === 'set' && args[1] === 'userData' && args.length >= 3) {
+      var userData = args[2];
+      if (userData && typeof userData === 'object' && !Array.isArray(userData) && Object.prototype.hasOwnProperty.call(userData, 'pixel_id')) {
+        try { delete userData.pixel_id; } catch (_) { userData.pixel_id = undefined; }
+      }
+    }
+    if (args[0] === 'init' && args.length >= 3) {
+      var advancedMatching = args[2];
+      if (advancedMatching && typeof advancedMatching === 'object' && !Array.isArray(advancedMatching) && Object.prototype.hasOwnProperty.call(advancedMatching, 'pixel_id')) {
+        try { delete advancedMatching.pixel_id; } catch (_) { advancedMatching.pixel_id = undefined; }
+      }
+    }
+    return args;
+  }
+
+  function computeDiff(before, after) {
+    var changes = [];
+
+    function joinPath(path, key, isIndex) {
+      if (!path) return isIndex ? '[' + key + ']' : key;
+      return isIndex ? path + '[' + key + ']' : path + '.' + key;
+    }
+
+    function diffRec(b, a, path) {
+      if (b === a) return;
+      var bIsObj = b && typeof b === 'object';
+      var aIsObj = a && typeof a === 'object';
+      if (!bIsObj || !aIsObj) {
+        if (b !== a) {
+          changes.push({ path: path || '(root)', before: b, after: a });
+        }
+        return;
+      }
+      if (Array.isArray(b) || Array.isArray(a)) {
+        var bArr = Array.isArray(b) ? b : [];
+        var aArr = Array.isArray(a) ? a : [];
+        var max = Math.max(bArr.length, aArr.length);
+        for (var i = 0; i < max; i++) {
+          diffRec(bArr[i], aArr[i], joinPath(path, i, true));
+        }
+        return;
+      }
+      var seenKeys = {};
+      if (bIsObj) {
+        for (var key in b) {
+          if (Object.prototype.hasOwnProperty.call(b, key)) {
+            seenKeys[key] = true;
+          }
+        }
+      }
+      if (aIsObj) {
+        for (var key2 in a) {
+          if (Object.prototype.hasOwnProperty.call(a, key2)) {
+            seenKeys[key2] = true;
+          }
+        }
+      }
+      for (var prop in seenKeys) {
+        diffRec(b ? b[prop] : undefined, a ? a[prop] : undefined, joinPath(path, prop, false));
+      }
+    }
+
+    diffRec(before, after, '');
+    return changes;
+  }
+
   // Helper global: fbq pronto de verdade (lib real carregada)
   window.__fbqReady = function () {
     return typeof window.fbq === 'function' && typeof window.fbq.callMethod === 'function';
   };
 
   var enrichers = [];
-  // Outras partes do código (ex.: UTMify) podem registrar transformadores de chamadas do fbq
-  window.__FBQ_SAFE_PROXY_REGISTER = function (fn) {
-    if (typeof fn === 'function') enrichers.push(fn);
+  var ENRICHER_REGISTRY = window.__ENRICHER_REGISTRY__ = window.__ENRICHER_REGISTRY__ || [];
+  var enricherIdCounter = ENRICHER_REGISTRY.length;
+
+  window.__FBQ_SAFE_PROXY_REGISTER = function (fn, label) {
+    if (typeof fn !== 'function') return;
+    var script = (document && document.currentScript && document.currentScript.src) || null;
+    var registeredAtStack = captureStack('register');
+    var id = 'enricher#' + (++enricherIdCounter);
+    var meta = { id: id, label: label || fn.name || 'anonymous', script: script, registeredAtStack: registeredAtStack };
+
+    function fnWrapped(args) {
+      var before = DEBUG ? safeClone(args) : null;
+      var result;
+      try {
+        result = fn(args);
+      } catch (err) {
+        if (DEBUG) {
+          console.error('[FBQ-ENRICHER] erro durante execução', { meta: meta, error: err });
+        }
+      }
+      var outputArgs = Array.isArray(result) ? result : args;
+      var after = DEBUG ? safeClone(outputArgs) : null;
+
+      if (DEBUG && before && after) {
+        var hadBefore = containsPixelIdInSetUserData(before) || containsPixelIdInInit(before);
+        var hasAfter = containsPixelIdInSetUserData(after) || containsPixelIdInInit(after);
+        if (!hadBefore && hasAfter) {
+          console.group('[FBQ-ENRICHER] pixel_id ADICIONADO');
+          console.log('meta:', meta);
+          console.log('before:', before);
+          console.log('after:', after);
+          console.log('stack (chamada):', captureStack('call'));
+          console.groupEnd();
+        }
+      }
+
+      return result;
+    }
+
+    var registryEntry = {
+      id: meta.id,
+      label: meta.label,
+      script: meta.script,
+      registeredAtStack: meta.registeredAtStack,
+      fnWrapped: fnWrapped
+    };
+
+    if (DEBUG) {
+      console.group('[FBQ-ENRICHER] registered');
+      console.log('meta:', meta);
+      console.log('stack (registro):', registeredAtStack);
+      console.groupEnd();
+    }
+
+    fnWrapped.__ENRICHER_ENTRY__ = registryEntry;
+    enrichers.push(fnWrapped);
+    ENRICHER_REGISTRY.push(registryEntry);
   };
 
   function cloneShallow(obj) {
@@ -43,26 +214,62 @@
   function applyWithSanitize(target, thisArg, args) {
     try {
       var a = Array.prototype.slice.call(args);
-      // Aplicar enrichers registrados (transformam args; devem retornar o array novo ou falsy p/ manter)
-      for (var i = 0; i < enrichers.length; i++) {
-        try {
-          var maybe = enrichers[i](a);
-          if (Array.isArray(maybe)) a = maybe;
-        } catch (_) { /* ignore enricher errors */ }
+      if (DEBUG) {
+        console.groupCollapsed('[FBQ-SAFE] args (pre-enrichers)');
+        console.log(safeClone(a));
+        console.groupEnd();
       }
-      // Sanitização: set('userData', userData[, pixelId])
+      for (var i = 0; i < enrichers.length; i++) {
+        var enricherFn = enrichers[i];
+        var beforeEnricher = DEBUG ? safeClone(a) : null;
+        var maybe;
+        try {
+          maybe = enricherFn(a);
+        } catch (err) {
+          if (DEBUG) {
+            console.error('[FBQ-ENRICHER] exceção não capturada', { error: err });
+          }
+        }
+        if (Array.isArray(maybe)) a = maybe;
+        if (DEBUG) {
+          var afterEnricher = safeClone(a);
+          var diff = computeDiff(beforeEnricher, afterEnricher);
+          var entry = enricherFn.__ENRICHER_ENTRY__;
+          if (diff.length) {
+            console.group('[FBQ-ENRICHER] run ' + (entry ? entry.id + ' (' + entry.label + ')' : '[desconhecido]'));
+            if (entry) {
+              console.log('meta:', { id: entry.id, label: entry.label, script: entry.script });
+            }
+            console.log('diff:', diff);
+            console.log('before:', beforeEnricher);
+            console.log('after:', afterEnricher);
+            console.groupEnd();
+          } else if (entry) {
+            console.log('[FBQ-ENRICHER] run ' + entry.id + ' (' + entry.label + ') sem mudanças detectadas');
+          }
+        }
+      }
       if (a[0] === 'set' && a[1] === 'userData') {
         a[2] = sanitizeUserData(a[2], args);
-        // Nunca permitir 4º argumento
         a = a.slice(0, 3);
       }
-      // Sanitização: init(pixelId, advancedMatching, options)
-      // Assinatura comum: init, pixelId, advancedMatching, options
       if (a[0] === 'init' && a.length >= 3) {
         if (a[2] && typeof a[2] === 'object' && !Array.isArray(a[2])) {
           if ('pixel_id' in a[2]) { try { delete a[2].pixel_id; } catch (_) { a[2].pixel_id = undefined; } }
         }
       }
+
+      stripPixelIdEverywhere(a);
+
+      if (DEBUG && (containsPixelIdInSetUserData(a) || containsPixelIdInInit(a))) {
+        console.group('[FBQ-SAFE] pixel_id ainda presente após sanitize-final');
+        console.log('args:', safeClone(a));
+        console.log('__ENRICHER_REGISTRY__:', safeClone(ENRICHER_REGISTRY));
+        console.log('stack:', captureStack('post-sanitize'));
+        console.groupEnd();
+        throw new Error('[FBQ-SAFE] pixel_id presente após sanitize-final (debug)');
+      }
+
       return Reflect.apply(target, thisArg, a);
     } catch (_) {
       return Reflect.apply(target, thisArg, args);
@@ -98,11 +305,23 @@
     try {
       var q = window.fbq && window.fbq.queue;
       if (Array.isArray(q) && q.length) {
+        if (DEBUG) {
+          console.group('[FBQ-SAFE] queue snapshot (antes da limpeza)');
+          console.log({ length: q.length, entries: safeClone(q) });
+          console.groupEnd();
+        }
         for (var i = 0; i < q.length; i++) {
-          var item = Array.prototype.slice.call(q[i] || []);
+          var originalItem = q[i] || [];
+          var item = Array.prototype.slice.call(originalItem);
+          if (DEBUG && (containsPixelIdInSetUserData(item) || containsPixelIdInInit(item))) {
+            console.group('[FBQ-SAFE] queue item com pixel_id detectado');
+            console.log('index:', i);
+            console.log('raw:', safeClone(originalItem));
+            console.groupEnd();
+          }
           if (item[0] === 'set' && item[1] === 'userData') {
             item[2] = sanitizeUserData(item[2], item);
-            q[i] = item.slice(0, 3);
+            item = item.slice(0, 3);
           } else if (item[0] === 'init' && item.length >= 3) {
             if (item[2] && typeof item[2] === 'object' && !Array.isArray(item[2]) && 'pixel_id' in item[2]) {
               try {
@@ -111,8 +330,14 @@
                 item[2].pixel_id = undefined;
               }
             }
-            q[i] = item;
           }
+          stripPixelIdEverywhere(item);
+          q[i] = item;
+        }
+        if (DEBUG) {
+          console.group('[FBQ-SAFE] queue snapshot (após limpeza)');
+          console.log({ length: q.length, entries: safeClone(q) });
+          console.groupEnd();
         }
       }
     } catch (_) {}


### PR DESCRIPTION
## Summary
- add debug-aware registry, diff logging, and final sanitization to the fbq safe proxy to identify enrichers that inject `pixel_id`
- enable the obrigado purchase flow to activate the debug flag via `?fbq_debug=1`, proxy `userData`, and log attempts to set `pixel_id`

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7fb8d5138832ab2b114f94e2294e5