### PR TITLE
Ensure Meta Pixel external_id is sent in plaintext

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -572,7 +572,11 @@
                     if (normalizedData.phone) userDataPlain.ph = normalizedData.phone;
                     if (normalizedData.first_name) userDataPlain.fn = normalizedData.first_name;
                     if (normalizedData.last_name) userDataPlain.ln = normalizedData.last_name;
-                    if (normalizedData.external_id) userDataPlain.external_id = normalizedData.external_id;
+                    const externalIdPlain = normalizedData && normalizedData.external_id
+                        ? String(normalizedData.external_id).trim()
+                        : undefined;
+
+                    if (externalIdPlain) userDataPlain.external_id = externalIdPlain;
                     if (finalFbp) userDataPlain.fbp = finalFbp;
                     if (finalFbc) userDataPlain.fbc = finalFbc;
 


### PR DESCRIPTION
## Summary
- ensure the Meta Pixel userData payload sets external_id using the plaintext value from normalizedData
- avoid assigning hashed external_id values before invoking fbq

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e82d9577d8832ab943f4098be582cc