### PR TITLE
Switch purchase external ID to telegram identifier

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -322,6 +322,7 @@
             let eventSourceUrl = null;
             let payerName = null;
             let payerCpf = null;
+            let telegramIdFromContext = null;
             let fbpFromContext = null;
             let fbcFromContext = null;
             let contextValueForLog = null;
@@ -381,6 +382,11 @@
                             title: contextData.plan_title || contextData.nome_oferta || 'Plano'
                         }];
                     }
+
+                    telegramIdFromContext =
+                        contextData && contextData.telegram_id !== null && contextData.telegram_id !== undefined
+                            ? String(contextData.telegram_id)
+                            : null;
 
                     contextValueForLog =
                         typeof valor === 'number' && !Number.isNaN(valor)
@@ -535,7 +541,17 @@
                     }
 
                     const { firstName, lastName } = splitName(payerName || '');
-                    const cpfDigits = payerCpf ? payerCpf.replace(/\D/g, '') : null;
+                    // const cpfDigits = payerCpf ? payerCpf.replace(/\D/g, '') : null;
+
+                    const externalIdSource = (() => {
+                        if (contextData && contextData.external_id !== null && contextData.external_id !== undefined) {
+                            return String(contextData.external_id);
+                        }
+                        if (telegramIdFromContext) {
+                            return telegramIdFromContext;
+                        }
+                        return null;
+                    })();
 
                     // Normalizar telefone com DDI
                     let phoneNormalized = normalizationLib.normalizePhone(phoneDigits);
@@ -549,7 +565,8 @@
                         phone: phoneNormalized,
                         first_name: normalizationLib.normalizeName(firstName || ''),
                         last_name: normalizationLib.normalizeName(lastName || ''),
-                        external_id: normalizationLib.normalizeExternalId(cpfDigits || '')
+                        // external_id: normalizationLib.normalizeExternalId(cpfDigits || '')
+                        external_id: normalizationLib.normalizeExternalId(externalIdSource || '')
                     };
 
                     // 🎯 CORREÇÃO: Montar userData em plaintext (sem hash no front)
@@ -576,7 +593,9 @@
                         ? String(normalizedData.external_id).trim()
                         : undefined;
 
-                    if (externalIdPlain) userDataPlain.external_id = externalIdPlain;
+                    if (externalIdPlain) {
+                        userDataPlain.external_id = externalIdPlain;
+                    }
                     if (finalFbp) userDataPlain.fbp = finalFbp;
                     if (finalFbc) userDataPlain.fbc = finalFbc;
 
@@ -590,7 +609,10 @@
                         fbp: !!finalFbp,
                         fbc: !!finalFbc
                     };
-                    console.log('[ADVANCED-MATCH-FRONT] normalized_presence', normalizationSnapshot);
+                    if (!normalizationSnapshot.external_id) {
+                        console.warn('[AM-WARN] telegram_id ausente — external_id não enviado.');
+                    }
+                    console.log('[ADVANCED-MATCH-FRONT] presence', normalizationSnapshot);
 
                     const pixelUtms = {};
                     for (const field of TRACKING_UTM_FIELDS) {
@@ -698,6 +720,10 @@
                         const pid = window.__PIXEL_CONFIG?.FB_PIXEL_ID_SANITIZED || window.__PIXEL_CONFIG?.FB_PIXEL_ID;
 
                         fbq('init', pid, userDataPlain);
+                        const externalIdForPixelLog = externalIdPlain ?? null;
+                        console.log(
+                            `[PIXEL-AM] init ready external_id(from=telegram_id)=${externalIdForPixelLog !== null ? externalIdForPixelLog : 'null'}`
+                        );
                         console.log('[PIXEL] ✅ Meta Pixel inicializado com AM:', pid);
 
                         fbq('track', 'Purchase', pixelCustomData, { eventID: eventIdPurchase });

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -621,10 +621,11 @@ async function sendFacebookEvent(eventName, payload) {
     if (finalUserAgent) finalUserData.client_user_agent = finalUserAgent;
 
     // Para eventos Purchase, adicionar external_id apenas se necessário
-    if (event_name === 'Purchase' && (telegram_id || finalFbp)) {
-      const extId = generateExternalId(telegram_id, finalFbp, finalIpAddress);
+    if (event_name === 'Purchase' && telegram_id !== null && telegram_id !== undefined) {
+      // const extId = generateExternalId(telegram_id, finalFbp, finalIpAddress);
+      const extId = String(telegram_id);
       finalUserData.external_id = extId;
-      console.log('🔐 external_id gerado para Purchase (fallback)');
+      console.log('🔐 external_id definido a partir do telegram_id para Purchase (fallback)');
     }
 
   } else {

--- a/services/purchaseCapi.js
+++ b/services/purchaseCapi.js
@@ -72,6 +72,8 @@ async function sendPurchaseEvent(purchaseData, options = {}) {
     origin = 'unknown'
   } = purchaseData;
 
+  const telegramIdString = telegram_id !== null && telegram_id !== undefined ? String(telegram_id) : null;
+
   const { config: providedConfig = null } = options || {};
 
   const price_cents = toIntOrNull(priceCentsInput);
@@ -243,7 +245,8 @@ async function sendPurchaseEvent(purchaseData, options = {}) {
       phone: normalizedUserSource.phone ?? normalizePhone(phone),
       first_name: normalizedUserSource.first_name ?? normalizeName(first_name),
       last_name: normalizedUserSource.last_name ?? normalizeName(last_name),
-      external_id: normalizedUserSource.external_id ?? normalizeExternalId(external_id || payer_cpf)
+      // external_id: normalizedUserSource.external_id ?? normalizeExternalId(external_id || payer_cpf)
+      external_id: normalizedUserSource.external_id ?? (telegramIdString ? normalizeExternalId(telegramIdString) : null)
     };
 
     const normalizationSnapshot = {


### PR DESCRIPTION
## Summary
- ensure the purchase context API exposes telegram_id and external_id as the same string value and logs the new advanced matching context marker
- update the purchase CAPI pipeline (route and service) plus the facebook service fallback to rely on telegram_id for external_id and warn if it is missing
- adjust the obrigado purchase flow advanced matching setup to consume the telegram-based external_id, emit the requested logs, and keep plaintext data aligned with CAPI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e833632374832a8cc91b43b83625ef