### PR TITLE
Add persistent FBC/FBP logging on presell and start

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -382,9 +382,26 @@
 
   // Função removida - Pixel não mais usado na Rota 1
 
+  // function getCookie(name) {
+  //   const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  //   return match ? decodeURIComponent(match[1]) : null;
+  // }
+
+  function getQueryParam(name) {
+    const url = new URL(window.location.href);
+    return url.searchParams.get(name);
+  }
   function getCookie(name) {
-    const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
-    return match ? decodeURIComponent(match[1]) : null;
+    const m = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/([.$?*|{}()\[\]\/\\+^])/g, '\\$1') + '=([^;]*)'));
+    return m ? decodeURIComponent(m[1]) : '';
+  }
+  function setCookie(name, value, days = 30) {
+    const expires = new Date(Date.now() + days*24*60*60*1000).toUTCString();
+    document.cookie = `${name}=${value}; expires=${expires}; path=/; SameSite=Lax`;
+    console.log('[PRESELL-FBC] 🍪 Cookie set', { name, value });
+  }
+  function buildFbcFromFbclid(fbclid, ts = Date.now()) {
+    return `fb.1.${ts}.${fbclid}`;
   }
 
   function normalizePixelValue(value, storageKey = null) {
@@ -485,23 +502,54 @@
 
   async function gerarPayload() {
     try {
+      const fbclid = getQueryParam('fbclid');
+      const cookieFbc = getCookie('_fbc');
+      const cookieFbp = getCookie('_fbp');
+
+      console.log('[PRESELL-FBC] 🔗 URL params', { fbclid });
+      console.log('[PRESELL-FBC] 🍪 Cookies lidos', { _fbc: cookieFbc || '(vazio)', _fbp: cookieFbp || '(vazio)' });
+
+      let fbcFinal = cookieFbc;
+      if (!fbcFinal && fbclid) {
+        fbcFinal = buildFbcFromFbclid(fbclid);
+        setCookie('_fbc', fbcFinal, 30);
+        console.log('[PRESELL-FBC] 🔧 _fbc reconstruído a partir de fbclid', fbcFinal);
+      }
+      if (!fbclid && !cookieFbc) {
+        console.warn('[PRESELL-FBC] ⚠️ Sem fbclid e sem _fbc — não é possível construir fbc aqui');
+      }
+
+      const fbpFinal = cookieFbp || '';
+
       await gatherTracking();
-      const { fbp, fbc, ip, user_agent, utm_source, utm_medium, utm_campaign, utm_term, utm_content, kwai_click_id } = trackData;
+      const { ip, user_agent, utm_source, utm_medium, utm_campaign, utm_term, utm_content, kwai_click_id } = trackData;
+      const finalFbc = fbcFinal || trackData.fbc || '';
+      const finalFbp = fbpFinal || trackData.fbp || '';
+      trackData.fbc = finalFbc;
+      trackData.fbp = finalFbp;
+
+      const body = {
+        fbp: finalFbp,
+        fbc: finalFbc,
+        ip,
+        user_agent: user_agent || navigator.userAgent,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        utm_term,
+        utm_content,
+        kwai_click_id,
+        fbclid: fbclid || '',
+        event_source_url: window.location.href,
+        referrer: document.referrer || ''
+      };
+
+      console.log('[PRESELL-FBC] 📬 POST /api/gerar-payload (request)', body);
+
       const resp = await fetch('/api/gerar-payload', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          fbp,
-          fbc,
-          ip,
-          user_agent,
-          utm_source,
-          utm_medium,
-          utm_campaign,
-          utm_term,
-          utm_content,
-          kwai_click_id
-        })
+        body: JSON.stringify(body)
       });
 
       const data = await resp.json().catch(() => ({}));
@@ -509,14 +557,19 @@
         const clickParam = kwai_click_id ? `&click_id=${encodeURIComponent(kwai_click_id)}` : '';
         cta.href = `${baseUrl}?start=${data.payload_id}${clickParam}`;
         trackWelcomeEvent();
+        console.log('[PRESELL-FBC] ✅ payload criado', { payload_id: data.payload_id });
+        console.log('[PRESELL-FBC] 🔗 CTA Telegram atualizado', { href: cta.href });
       } else {
         cta.href = kwai_click_id ? `${baseUrl}?click_id=${encodeURIComponent(kwai_click_id)}` : baseUrl;
         trackWelcomeEvent();
+        console.warn('[PRESELL-FBC] ⚠️ Falha ao criar payload — usando fallback direto no CTA', { status: resp.status, ok: resp.ok });
+        console.log('[PRESELL-FBC] 🔗 CTA Telegram atualizado', { href: cta.href });
       }
     } catch (e) {
       console.error('Erro ao gerar payload', e);
       cta.href = baseUrl;
       trackWelcomeEvent();
+      console.log('[PRESELL-FBC] 🔗 CTA Telegram atualizado', { href: cta.href, motivo: 'erro_fetch_payload' });
     }
   }
 

--- a/routes/telegram.js
+++ b/routes/telegram.js
@@ -301,6 +301,12 @@ router.post('/telegram/webhook', async (req, res) => {
       return res.status(200).json({ ok: true, ignored: true });
     }
 
+    const telegramId = String(message.from.id);
+    const telegramUsername = message.from.username || null;
+    const telegramFirstName = message.from.first_name || null;
+    const telegramLastName = message.from.last_name || null;
+    const trackingContext = { fbc: null, fbp: null };
+
     const payloadSize = Buffer.byteLength(payloadBase64, 'utf8');
     if (payloadSize > MAX_START_PAYLOAD_BYTES) {
       console.warn('[Telegram Webhook] start payload muito grande', {
@@ -316,10 +322,17 @@ router.post('/telegram/webhook', async (req, res) => {
 
     const trimmedPayload = typeof payloadBase64 === 'string' ? payloadBase64.trim() : '';
     const candidatePayloadId = extractPayloadIdCandidate(payloadBase64);
+    console.log('[BOT-START]', {
+      payload_id: candidatePayloadId || null,
+      telegram_id: telegramId,
+      username: telegramUsername,
+      first_name: telegramFirstName,
+      last_name: telegramLastName
+    });
     if (candidatePayloadId) {
       resolvedPayloadId = candidatePayloadId;
       payloadSource = 'payload_id';
-      
+
       // [TELEGRAM-ENTRY] Log do payload_id recebido
       console.log('[BOT-START] payload_id=', candidatePayloadId, 'telegram_id=', message.from.id);
 
@@ -336,15 +349,50 @@ router.post('/telegram/webhook', async (req, res) => {
 
         const storedUtmData = extractUtmData(storedPayload);
 
-        // [TELEGRAM-ENTRY] Merge inteligente: priorizar dados da presell, fallback para telegram_entry
-        const mergedFbp = storedPayload.fbp || storedPayload.telegram_entry_fbp || null;
-        const mergedFbc = storedPayload.fbc || storedPayload.telegram_entry_fbc || null;
+        // const mergedFbp = storedPayload.fbp || storedPayload.telegram_entry_fbp || null;
+        // const mergedFbc = storedPayload.fbc || storedPayload.telegram_entry_fbc || null;
+        const presellFbp = storedPayload.fbp || null;
+        const presellFbc = storedPayload.fbc || null;
+        const telegramEntryFbp = storedPayload.telegram_entry_fbp || null;
+        const telegramEntryFbc = storedPayload.telegram_entry_fbc || null;
+        const mergedFbp = presellFbp || telegramEntryFbp || null;
+        const mergedFbc = presellFbc || telegramEntryFbc || null;
         const mergedFbclid = storedPayload.telegram_entry_fbclid || null;
         const mergedIp = storedPayload.ip || storedPayload.telegram_entry_ip || null;
         const mergedUserAgent = storedPayload.user_agent || storedPayload.telegram_entry_user_agent || null;
-        const mergedEventSourceUrl = storedPayload.event_source_url || 
-                                     storedPayload.telegram_entry_event_source_url || 
+        const mergedEventSourceUrl = storedPayload.event_source_url ||
+                                     storedPayload.telegram_entry_event_source_url ||
                                      storedPayload.landing_url || null;
+
+        console.log('[MERGE-FBC] 🔎 fontes', {
+          presell: {
+            fbc: presellFbc || '(vazio)',
+            fbp: presellFbp || '(vazio)',
+            fbclid: storedPayload.fbclid || '(vazio)'
+          },
+          telegram_entry: {
+            fbc: telegramEntryFbc || '(vazio)',
+            fbp: telegramEntryFbp || '(vazio)',
+            fbclid: storedPayload.telegram_entry_fbclid || '(vazio)'
+          }
+        });
+
+        const fbcChosen = mergedFbc;
+        const fbpChosen = mergedFbp;
+        const fbcSourceChosen = presellFbc ? 'presell' : (telegramEntryFbc ? 'telegram' : 'nenhum');
+        const fbpSourceChosen = presellFbp ? 'presell' : (telegramEntryFbp ? 'telegram' : 'nenhum');
+
+        console.log('[MERGE-FBC] ✅ escolhidos', {
+          fbc: fbcChosen || '(vazio)', fbc_source: fbcSourceChosen,
+          fbp: fbpChosen || '(vazio)', fbp_source: fbpSourceChosen
+        });
+
+        trackingContext.fbc = trackingContext.fbc ?? fbcChosen ?? null;
+        trackingContext.fbp = trackingContext.fbp ?? fbpChosen ?? null;
+
+        if (!trackingContext.fbc && !trackingContext.fbp) {
+          console.warn('[MERGE-FBC] ⚠️ FBC e FBP ausentes após merge — verificar captura na presell e no /telegram');
+        }
 
         // Log de merge
         const fbpSource = storedPayload.fbp ? 'presell' : (storedPayload.telegram_entry_fbp ? 'telegram-entry' : 'vazio');
@@ -400,7 +448,7 @@ router.post('/telegram/webhook', async (req, res) => {
       payloadSource = 'base64';
     }
 
-    const telegramId = String(message.from.id);
+    // const telegramId = String(message.from.id);
     const utmData = extractUtmData(parsedPayload.utm_data);
     const zipHash = normalizeZipHash(parsedPayload.zip);
     const clientIpAddress = resolveClientIp(req, parsedPayload.client_ip_address || parsedPayload.client_ip);
@@ -410,6 +458,13 @@ router.post('/telegram/webhook', async (req, res) => {
     const sanitizedFbp = sanitizeTrackingToken(parsedPayload.fbp, FBP_REGEX);
     const sanitizedFbc = sanitizeTrackingToken(parsedPayload.fbc, FBC_REGEX);
     const sanitizedUtmData = sanitizeUtmPayload(utmData);
+
+    if (trackingContext.fbp === null) {
+      trackingContext.fbp = sanitizedFbp || null;
+    }
+    if (trackingContext.fbc === null) {
+      trackingContext.fbc = sanitizedFbc || null;
+    }
 
     const normalizedExternalIdHash = normalizeExternalIdHash(
       parsedPayload.external_id || parsedPayload.external_id_hash
@@ -437,6 +492,12 @@ router.post('/telegram/webhook', async (req, res) => {
     const finalExternalIdHash = normalizeExternalIdHash(
       upserted?.external_id_hash || normalizedExternalIdHash
     );
+
+    console.log('[LEAD-CAPI] user_data.fbc/fbp', {
+      fbc: trackingContext.fbc || '(vazio)',
+      fbp: trackingContext.fbp || '(vazio)',
+      event_id: resolvedPayloadId || '(gerado_no_sendLeadEvent)'
+    });
 
     const sendResult = await sendLeadEvent({
       telegramId,


### PR DESCRIPTION
## Summary
- add persistent fbclid/cookie logging and request payload instrumentation on the presell page
- log payload source decisions and lead user data before sending the Lead CAPI event in the Telegram /start flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e868a99f2c832ab48ddd5064575af9