### PR TITLE
Add persistent FBC/FBP logging for presell and start

### DIFF
--- a/MODELO1/WEB/index.html
+++ b/MODELO1/WEB/index.html
@@ -382,9 +382,26 @@
 
   // Função removida - Pixel não mais usado na Rota 1
 
+  // function getCookie(name) {
+  //   const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
+  //   return match ? decodeURIComponent(match[1]) : null;
+  // }
+
+  function getQueryParam(name) {
+    const url = new URL(window.location.href);
+    return url.searchParams.get(name);
+  }
   function getCookie(name) {
-    const match = document.cookie.match(new RegExp('(?:^|; )' + name + '=([^;]*)'));
-    return match ? decodeURIComponent(match[1]) : null;
+    const m = document.cookie.match(new RegExp('(?:^|; )' + name.replace(/([.$?*|{}()[\]\/+^])/g, '\\$1') + '=([^;]*)')));
+    return m ? decodeURIComponent(m[1]) : '';
+  }
+  function setCookie(name, value, days = 30) {
+    const expires = new Date(Date.now() + days*24*60*60*1000).toUTCString();
+    document.cookie = `${name}=${value}; expires=${expires}; path=/; SameSite=Lax`;
+    console.log('[PRESELL-FBC] 🍪 Cookie set', { name, value });
+  }
+  function buildFbcFromFbclid(fbclid, ts = Date.now()) {
+    return `fb.1.${ts}.${fbclid}`;
   }
 
   function normalizePixelValue(value, storageKey = null) {
@@ -431,10 +448,36 @@
   async function gatherTracking() {
     const fresh = {};
 
+    const fbclid = getQueryParam('fbclid');
+    const cookieFbc = getCookie('_fbc');
+    const cookieFbp = getCookie('_fbp');
+
+    console.log('[PRESELL-FBC] 🔗 URL params', { fbclid });
+    console.log('[PRESELL-FBC] 🍪 Cookies lidos', { _fbc: cookieFbc || '(vazio)', _fbp: cookieFbp || '(vazio)' });
+
+    let fbcFromCookies = cookieFbc;
+    if (!fbcFromCookies && fbclid) {
+      fbcFromCookies = buildFbcFromFbclid(fbclid);
+      setCookie('_fbc', fbcFromCookies, 30);
+      console.log('[PRESELL-FBC] 🔧 _fbc reconstruído a partir de fbclid', fbcFromCookies);
+    }
+    if (!fbclid && !cookieFbc) {
+      console.warn('[PRESELL-FBC] ⚠️ Sem fbclid e sem _fbc — não é possível construir fbc aqui');
+    }
+
+    const fbpFromCookies = cookieFbp || '';
+
     const [fbp, fbc] = await Promise.all([
       getPixelValue('fbp', '_fbp'),
       getPixelValue('fbc', '_fbc')
     ]);
+
+    const resolvedFbp = fbp || fbpFromCookies || null;
+    const resolvedFbc = fbc || fbcFromCookies || null;
+
+    fresh.fbclid = fbclid || '';
+    fresh.event_source_url = window.location.href;
+    fresh.referrer = document.referrer || '';
 
     let ip = localStorage.getItem('client_ip_address');
     if (!ip) {
@@ -465,8 +508,8 @@
       }
     });
 
-    if (fbp) fresh.fbp = fbp;
-    if (fbc) fresh.fbc = fbc;
+    if (resolvedFbp) fresh.fbp = resolvedFbp;
+    if (resolvedFbc) fresh.fbc = resolvedFbc;
     if (ip) fresh.ip = ip;
     if (ua) fresh.user_agent = ua;
 
@@ -486,28 +529,59 @@
   async function gerarPayload() {
     try {
       await gatherTracking();
-      const { fbp, fbc, ip, user_agent, utm_source, utm_medium, utm_campaign, utm_term, utm_content, kwai_click_id } = trackData;
+      const {
+        fbp,
+        fbc,
+        ip,
+        user_agent,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        utm_term,
+        utm_content,
+        kwai_click_id,
+        fbclid,
+        event_source_url,
+        referrer
+      } = trackData;
+
+      const existingBody = {
+        fbp,
+        fbc,
+        ip,
+        user_agent,
+        utm_source,
+        utm_medium,
+        utm_campaign,
+        utm_term,
+        utm_content,
+        kwai_click_id
+      };
+
+      const body = {
+        ...existingBody,
+        fbc: (fbc || '').toString(),
+        fbp: (fbp || '').toString(),
+        fbclid: fbclid || '',
+        user_agent: user_agent || navigator.userAgent,
+        event_source_url: event_source_url || window.location.href,
+        referrer: typeof referrer === 'string' ? referrer : (document.referrer || '')
+      };
+
+      console.log('[PRESELL-FBC] 📬 POST /api/gerar-payload (request)', body);
+
       const resp = await fetch('/api/gerar-payload', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          fbp,
-          fbc,
-          ip,
-          user_agent,
-          utm_source,
-          utm_medium,
-          utm_campaign,
-          utm_term,
-          utm_content,
-          kwai_click_id
-        })
+        body: JSON.stringify(body)
       });
 
       const data = await resp.json().catch(() => ({}));
       if (resp.ok && data.payload_id) {
         const clickParam = kwai_click_id ? `&click_id=${encodeURIComponent(kwai_click_id)}` : '';
         cta.href = `${baseUrl}?start=${data.payload_id}${clickParam}`;
+        console.log('[PRESELL-FBC] ✅ payload criado', { payload_id: data.payload_id });
+        console.log('[PRESELL-FBC] 🔗 CTA Telegram atualizado', { href: cta.href });
         trackWelcomeEvent();
       } else {
         cta.href = kwai_click_id ? `${baseUrl}?click_id=${encodeURIComponent(kwai_click_id)}` : baseUrl;


### PR DESCRIPTION
## Summary
- add permanent presell logging for fbclid, _fbc/_fbp cookies, reconstructed tokens, and the payload posted to `/api/gerar-payload`
- instrument the Telegram `/start` flow to log payload sources, chosen FBC/FBP values, and the user_data sent to the Lead CAPI request

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e86a2c4144832ab7d1c516b7518b11