### PR TITLE
feat: capture geo metadata across payload flow

### DIFF
--- a/database/sqlite.js
+++ b/database/sqlite.js
@@ -69,6 +69,13 @@ function initialize(path = './pagamentos.db') {
         fbc TEXT,
         ip TEXT,
         user_agent TEXT,
+        geo_country TEXT,
+        geo_country_code TEXT,
+        geo_region TEXT,
+        geo_region_name TEXT,
+        geo_city TEXT,
+        geo_postal_code TEXT,
+        geo_ip_query TEXT,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     `).run();
@@ -84,6 +91,13 @@ function initialize(path = './pagamentos.db') {
         fbc TEXT,
         ip TEXT,
         user_agent TEXT,
+        geo_country TEXT,
+        geo_country_code TEXT,
+        geo_region TEXT,
+        geo_region_name TEXT,
+        geo_city TEXT,
+        geo_postal_code TEXT,
+        geo_ip_query TEXT,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     `).run();
@@ -101,10 +115,12 @@ function initialize(path = './pagamentos.db') {
     `).run();
     const cols = database.prepare('PRAGMA table_info(tokens)').all();
     const payloadCols = database.prepare('PRAGMA table_info(payload_tracking)').all();
+    const payloadsCols = database.prepare('PRAGMA table_info(payloads)').all();
     const trackingCols = database.prepare('PRAGMA table_info(tracking_data)').all();
     const zapControleCols = database.prepare('PRAGMA table_info(zap_controle)').all();
     const checkCol = name => cols.some(c => c.name === name);
     const checkPayloadCol = name => payloadCols.some(c => c.name === name);
+    const checkPayloadsCol = name => payloadsCols.some(c => c.name === name);
     const checkTrackingCol = name => trackingCols.some(c => c.name === name);
     const checkZapControleCol = name => zapControleCols.some(c => c.name === name);
 
@@ -186,6 +202,27 @@ function initialize(path = './pagamentos.db') {
     if (!checkPayloadCol('telegram_id')) {
       addColumnSafely('payload_tracking', 'telegram_id', 'TEXT');
     }
+    if (!checkPayloadCol('geo_country')) {
+      addColumnSafely('payload_tracking', 'geo_country', 'TEXT');
+    }
+    if (!checkPayloadCol('geo_country_code')) {
+      addColumnSafely('payload_tracking', 'geo_country_code', 'TEXT');
+    }
+    if (!checkPayloadCol('geo_region')) {
+      addColumnSafely('payload_tracking', 'geo_region', 'TEXT');
+    }
+    if (!checkPayloadCol('geo_region_name')) {
+      addColumnSafely('payload_tracking', 'geo_region_name', 'TEXT');
+    }
+    if (!checkPayloadCol('geo_city')) {
+      addColumnSafely('payload_tracking', 'geo_city', 'TEXT');
+    }
+    if (!checkPayloadCol('geo_postal_code')) {
+      addColumnSafely('payload_tracking', 'geo_postal_code', 'TEXT');
+    }
+    if (!checkPayloadCol('geo_ip_query')) {
+      addColumnSafely('payload_tracking', 'geo_ip_query', 'TEXT');
+    }
     if (!checkTrackingCol('utm_source')) {
       addColumnSafely('tracking_data', 'utm_source', 'TEXT');
     }
@@ -206,6 +243,27 @@ function initialize(path = './pagamentos.db') {
     }
     if (!checkPayloadCol('kwai_click_id')) {
       addColumnSafely('payloads', 'kwai_click_id', 'TEXT');
+    }
+    if (!checkPayloadsCol('geo_country')) {
+      addColumnSafely('payloads', 'geo_country', 'TEXT');
+    }
+    if (!checkPayloadsCol('geo_country_code')) {
+      addColumnSafely('payloads', 'geo_country_code', 'TEXT');
+    }
+    if (!checkPayloadsCol('geo_region')) {
+      addColumnSafely('payloads', 'geo_region', 'TEXT');
+    }
+    if (!checkPayloadsCol('geo_region_name')) {
+      addColumnSafely('payloads', 'geo_region_name', 'TEXT');
+    }
+    if (!checkPayloadsCol('geo_city')) {
+      addColumnSafely('payloads', 'geo_city', 'TEXT');
+    }
+    if (!checkPayloadsCol('geo_postal_code')) {
+      addColumnSafely('payloads', 'geo_postal_code', 'TEXT');
+    }
+    if (!checkPayloadsCol('geo_ip_query')) {
+      addColumnSafely('payloads', 'geo_ip_query', 'TEXT');
     }
     if (!checkCol('qr_code_base64')) {
       addColumnSafely('tokens', 'qr_code_base64', 'TEXT');

--- a/init-postgres.js
+++ b/init-postgres.js
@@ -12,6 +12,13 @@ async function initPostgres() {
       fbc TEXT,
       ip TEXT,
       user_agent TEXT,
+      geo_country TEXT,
+      geo_country_code TEXT,
+      geo_region TEXT,
+      geo_region_name TEXT,
+      geo_city TEXT,
+      geo_postal_code TEXT,
+      geo_ip_query TEXT,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
   `);
@@ -27,12 +34,39 @@ async function initPostgres() {
       fbc TEXT,
       ip TEXT,
       user_agent TEXT,
+      geo_country TEXT,
+      geo_country_code TEXT,
+      geo_region TEXT,
+      geo_region_name TEXT,
+      geo_city TEXT,
+      geo_postal_code TEXT,
+      geo_ip_query TEXT,
       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
   `);
   await pool.query(`
     ALTER TABLE payload_tracking
     ADD COLUMN IF NOT EXISTS telegram_id BIGINT;
+  `);
+  await pool.query(`
+    ALTER TABLE payload_tracking
+      ADD COLUMN IF NOT EXISTS geo_country TEXT,
+      ADD COLUMN IF NOT EXISTS geo_country_code TEXT,
+      ADD COLUMN IF NOT EXISTS geo_region TEXT,
+      ADD COLUMN IF NOT EXISTS geo_region_name TEXT,
+      ADD COLUMN IF NOT EXISTS geo_city TEXT,
+      ADD COLUMN IF NOT EXISTS geo_postal_code TEXT,
+      ADD COLUMN IF NOT EXISTS geo_ip_query TEXT;
+  `);
+  await pool.query(`
+    ALTER TABLE payloads
+      ADD COLUMN IF NOT EXISTS geo_country TEXT,
+      ADD COLUMN IF NOT EXISTS geo_country_code TEXT,
+      ADD COLUMN IF NOT EXISTS geo_region TEXT,
+      ADD COLUMN IF NOT EXISTS geo_region_name TEXT,
+      ADD COLUMN IF NOT EXISTS geo_city TEXT,
+      ADD COLUMN IF NOT EXISTS geo_postal_code TEXT,
+      ADD COLUMN IF NOT EXISTS geo_ip_query TEXT;
   `);
   console.log('✅ Tabela payloads verificada no PostgreSQL');
   console.log('✅ Tabela payload_tracking verificada no PostgreSQL');

--- a/migrations/20251220_add_geo_columns_to_payload_tracking.sql
+++ b/migrations/20251220_add_geo_columns_to_payload_tracking.sql
@@ -1,0 +1,26 @@
+ALTER TABLE public.payload_tracking
+  ADD COLUMN IF NOT EXISTS geo_country text,
+  ADD COLUMN IF NOT EXISTS geo_country_code text,
+  ADD COLUMN IF NOT EXISTS geo_region text,
+  ADD COLUMN IF NOT EXISTS geo_region_name text,
+  ADD COLUMN IF NOT EXISTS geo_city text,
+  ADD COLUMN IF NOT EXISTS geo_postal_code text,
+  ADD COLUMN IF NOT EXISTS geo_ip_query text;
+
+ALTER TABLE IF EXISTS public.payloads
+  ADD COLUMN IF NOT EXISTS geo_country text,
+  ADD COLUMN IF NOT EXISTS geo_country_code text,
+  ADD COLUMN IF NOT EXISTS geo_region text,
+  ADD COLUMN IF NOT EXISTS geo_region_name text,
+  ADD COLUMN IF NOT EXISTS geo_city text,
+  ADD COLUMN IF NOT EXISTS geo_postal_code text,
+  ADD COLUMN IF NOT EXISTS geo_ip_query text;
+
+ALTER TABLE IF EXISTS public.telegram_users
+  ADD COLUMN IF NOT EXISTS geo_country text,
+  ADD COLUMN IF NOT EXISTS geo_country_code text,
+  ADD COLUMN IF NOT EXISTS geo_region text,
+  ADD COLUMN IF NOT EXISTS geo_region_name text,
+  ADD COLUMN IF NOT EXISTS geo_city text,
+  ADD COLUMN IF NOT EXISTS geo_postal_code text,
+  ADD COLUMN IF NOT EXISTS geo_ip_query text;

--- a/services/geo.js
+++ b/services/geo.js
@@ -1,7 +1,7 @@
 const axios = require('axios');
 
 const DEFAULT_BASE_URL = 'https://pro.ip-api.com/json/';
-const DEFAULT_FIELDS = 'status,country,countryCode,region,regionName,city,query';
+const DEFAULT_FIELDS = 'status,country,countryCode,region,regionName,city,zip,query';
 let lastKeyUrlWarningAt = 0;
 
 class GeoConfigurationError extends Error {

--- a/services/payloads.js
+++ b/services/payloads.js
@@ -31,8 +31,10 @@ async function getPayloadById(payloadId) {
   const query = `
     SELECT payload_id, utm_source, utm_medium, utm_campaign, utm_term,
            utm_content, fbp, fbc, ip, user_agent, kwai_click_id,
+           geo_country, geo_country_code, geo_region, geo_region_name,
+           geo_city, geo_postal_code, geo_ip_query,
            telegram_entry_at, telegram_entry_fbc, telegram_entry_fbp, telegram_entry_fbclid,
-           telegram_entry_user_agent, telegram_entry_event_source_url, 
+           telegram_entry_user_agent, telegram_entry_event_source_url,
            telegram_entry_referrer, telegram_entry_ip
       FROM payloads
      WHERE payload_id = $1

--- a/services/sessionTracking.js
+++ b/services/sessionTracking.js
@@ -71,6 +71,13 @@ class SessionTrackingService {
       utm_campaign: trackingData.utm_campaign || null,
       utm_term: trackingData.utm_term || null,
       utm_content: trackingData.utm_content || null,
+      geo_country: trackingData.geo_country || trackingData.geo?.country || null,
+      geo_country_code: trackingData.geo_country_code || trackingData.geo?.country_code || null,
+      geo_region: trackingData.geo_region || trackingData.geo?.region || null,
+      geo_region_name: trackingData.geo_region_name || trackingData.geo?.region_name || null,
+      geo_city: trackingData.geo_city || trackingData.geo?.city || null,
+      geo_postal_code: trackingData.geo_postal_code || trackingData.geo?.postal_code || null,
+      geo_ip_query: trackingData.geo_ip_query || trackingData.geo?.ip || null,
       created_at: timestamp,
       last_updated: timestamp,
       access_count: 1 // Para política LRU

--- a/services/telegramUsers.js
+++ b/services/telegramUsers.js
@@ -31,7 +31,14 @@ async function upsertTelegramUser(data) {
     utmCampaign = null,
     utmContent = null,
     utmTerm = null,
-    eventSourceUrl = null
+    eventSourceUrl = null,
+    geoCountry = null,
+    geoCountryCode = null,
+    geoRegion = null,
+    geoRegionName = null,
+    geoCity = null,
+    geoPostalCode = null,
+    geoIpQuery = null
   } = data;
 
   const params = [
@@ -47,7 +54,14 @@ async function upsertTelegramUser(data) {
     sanitizeString(utmCampaign),
     sanitizeString(utmContent),
     sanitizeString(utmTerm),
-    sanitizeString(eventSourceUrl)
+    sanitizeString(eventSourceUrl),
+    sanitizeString(geoCountry),
+    sanitizeString(geoCountryCode),
+    sanitizeString(geoRegion),
+    sanitizeString(geoRegionName),
+    sanitizeString(geoCity),
+    sanitizeString(geoPostalCode),
+    sanitizeString(geoIpQuery)
   ];
 
   const query = `
@@ -64,9 +78,16 @@ async function upsertTelegramUser(data) {
       utm_campaign,
       utm_content,
       utm_term,
-      event_source_url
+      event_source_url,
+      geo_country,
+      geo_country_code,
+      geo_region,
+      geo_region_name,
+      geo_city,
+      geo_postal_code,
+      geo_ip_query
     ) VALUES (
-      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13
+      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20
     )
     ON CONFLICT (telegram_id) DO UPDATE SET
       external_id_hash = COALESCE(EXCLUDED.external_id_hash, telegram_users.external_id_hash),
@@ -81,9 +102,18 @@ async function upsertTelegramUser(data) {
       utm_content = COALESCE(EXCLUDED.utm_content, telegram_users.utm_content),
       utm_term = COALESCE(EXCLUDED.utm_term, telegram_users.utm_term),
       event_source_url = COALESCE(EXCLUDED.event_source_url, telegram_users.event_source_url),
+      geo_country = COALESCE(EXCLUDED.geo_country, telegram_users.geo_country),
+      geo_country_code = COALESCE(EXCLUDED.geo_country_code, telegram_users.geo_country_code),
+      geo_region = COALESCE(EXCLUDED.geo_region, telegram_users.geo_region),
+      geo_region_name = COALESCE(EXCLUDED.geo_region_name, telegram_users.geo_region_name),
+      geo_city = COALESCE(EXCLUDED.geo_city, telegram_users.geo_city),
+      geo_postal_code = COALESCE(EXCLUDED.geo_postal_code, telegram_users.geo_postal_code),
+      geo_ip_query = COALESCE(EXCLUDED.geo_ip_query, telegram_users.geo_ip_query),
       criado_em = telegram_users.criado_em
     RETURNING telegram_id, external_id_hash, fbp, fbc, zip_hash, ip_capturado, ua_capturado,
-      utm_source, utm_medium, utm_campaign, utm_content, utm_term, event_source_url, criado_em;
+      utm_source, utm_medium, utm_campaign, utm_content, utm_term, event_source_url,
+      geo_country, geo_country_code, geo_region, geo_region_name, geo_city, geo_postal_code, geo_ip_query,
+      criado_em;
   `;
 
   const result = await executeQuery(pool, query, params);
@@ -94,7 +124,9 @@ async function getTelegramUserById(telegramId) {
   const pool = ensurePool();
   const query = `
     SELECT telegram_id, external_id_hash, fbp, fbc, zip_hash, ip_capturado, ua_capturado,
-           utm_source, utm_medium, utm_campaign, utm_content, utm_term, event_source_url, criado_em
+           utm_source, utm_medium, utm_campaign, utm_content, utm_term, event_source_url,
+           geo_country, geo_country_code, geo_region, geo_region_name, geo_city, geo_postal_code, geo_ip_query,
+           criado_em
       FROM telegram_users
      WHERE telegram_id = $1
   `;


### PR DESCRIPTION
## Summary
- enrich the geo lookup configuration to request postal codes
- persist geo metadata on payload creation and expose it back to clients
- propagate stored geo fields to Telegram start handling and user persistence
- add database migration and bootstrap changes for the new geo columns across stores

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8d7b36a28832a8984c893a695f85f