### PR TITLE
feat: persist geo postal code from ip-api

### DIFF
--- a/migrations/20251228_ensure_payload_tracking_postal_code.sql
+++ b/migrations/20251228_ensure_payload_tracking_postal_code.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.payload_tracking
+  ADD COLUMN IF NOT EXISTS geo_postal_code text;

--- a/routes/telegram.js
+++ b/routes/telegram.js
@@ -456,7 +456,8 @@ router.post('/telegram/webhook', async (req, res) => {
           payload_id: resolvedPayloadId,
           geo_city: storedGeo?.city || null,
           geo_region_name: storedGeo?.region_name || null,
-          geo_country: storedGeo?.country || null
+          geo_country: storedGeo?.country || null,
+          geo_postal_code: storedGeo?.postal_code || null
         });
       } catch (error) {
         console.error('[Telegram Webhook] Falha ao buscar payload_id', {


### PR DESCRIPTION
## Summary
- ensure ip-api lookups always request the zip field and normalize responses with the postal code
- store and expose geo_postal_code during payload creation and Telegram start handling
- add an idempotent migration to guarantee geo_postal_code exists on payload_tracking

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e8dc7259b0832a81d5716ab1548109