### PR TITLE
feat(capi-lead): incluir ct/st/zp/country em user_data + fix de hidratação do payload no /start

### DIFF
--- a/services/funnelMetrics.js
+++ b/services/funnelMetrics.js
@@ -98,7 +98,7 @@ async function recordEvent(eventName, options = {}) {
         reason: error.message
       });
     }
-    if (error.code === '42703' || /column\s+"?telegram_id"?/i.test(error.message)) {
+    if (error.code === '42703' || /column\s+"?telegram_id"?/i.test(error.message) || /column\s+"?token"?/i.test(error.message)) {
       console.warn('[funnel-metrics] desativando gravação até ajuste do schema (coluna ausente)');
     }
     tablesReady = false;

--- a/services/metaCapi.js
+++ b/services/metaCapi.js
@@ -4,7 +4,7 @@ const { v4: uuidv4 } = require('uuid');
 
 const FACEBOOK_API_VERSION = 'v17.0';
 const { FB_PIXEL_ID, FB_PIXEL_TOKEN } = process.env;
-const { mapGeoToUserData } = require('../utils/geoNormalization');
+const { norm, onlyDigits } = require('../utils/geoNormalization');
 
 const ALLOWED_ACTION_SOURCES = new Set([
   'website',
@@ -244,190 +244,6 @@ async function sendInitiateCheckoutEvent(eventPayload) {
   } = eventPayload;
 
   const { resolved: resolvedTestEventCode, source: testEventSource } = resolveTestEventCode(incomingTestEventCode);
-  if (resolvedTestEventCode) {
-    console.info('[CAPI] test_event_code aplicado', {
-      source: testEventSource
-    });
-  }
-
-  const userData = buildUserData({ 
-    externalIdHash, 
-    emailHash, 
-    phoneHash, 
-    firstNameHash, 
-    lastNameHash,
-    fbp, 
-    fbc, 
-    zipHash, 
-    clientIpAddress, 
-    clientUserAgent 
-  });
-  const customData = buildCustomData(utmData);
-
-  // Log de IP/UA para rastreamento
-  const uaTruncated = clientUserAgent ? 
-    (clientUserAgent.length > 80 ? `${clientUserAgent.substring(0, 80)}... (${clientUserAgent.length} chars)` : clientUserAgent) 
-    : 'vazio';
-  console.log(`[CAPI-IPUA] origem=website ip=${clientIpAddress || 'vazio'} ua_present=${!!clientUserAgent}`);
-  console.log(`[CAPI-IPUA] user_data aplicado { client_ip_address: "${clientIpAddress || 'vazio'}", client_user_agent_present: ${!!clientUserAgent} }`);
-
-  const data = {
-    event_name: 'InitiateCheckout',
-    event_time: eventTime,
-    action_source: 'website',
-    event_id: eventId,
-    user_data: userData,
-    custom_data: customData
-  };
-
-  if (eventSourceUrl) {
-    data.event_source_url = eventSourceUrl;
-  }
-  if (clientIpAddress) {
-    data.client_ip_address = clientIpAddress;
-  }
-  if (clientUserAgent) {
-    data.client_user_agent = clientUserAgent;
-  }
-
-  const payload = {
-    data: [data],
-    access_token: FB_PIXEL_TOKEN
-  };
-
-  const urlBase = `https://graph.facebook.com/${FACEBOOK_API_VERSION}/${FB_PIXEL_ID}/events`;
-  const url = resolvedTestEventCode
-    ? `${urlBase}?test_event_code=${encodeURIComponent(resolvedTestEventCode)}`
-    : urlBase;
-  const maxAttempts = 3;
-  const baseDelay = 300;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      const response = await axios.post(url, payload, { timeout: 10000 });
-      logWithContext('log', '[Meta CAPI] InitiateCheckout enviado com sucesso', {
-        request_id: requestId,
-        event_name: 'InitiateCheckout',
-        event_id: eventId,
-        status: response.status,
-        attempt,
-        telegram_id: telegramId
-      });
-      return { success: true, response: response.data, status: response.status, attempt };
-    } catch (error) {
-      const status = error.response?.status;
-      const responseData = error.response?.data;
-      logWithContext('error', '[Meta CAPI] Falha ao enviar InitiateCheckout', {
-        request_id: requestId,
-        event_name: 'InitiateCheckout',
-        event_id: eventId,
-        status: status || 'network_error',
-        attempt,
-        telegram_id: telegramId,
-        has_response: Boolean(responseData),
-        error: error.message
-      });
-
-      const isRetryable = status && status >= 500 && status < 600;
-      if (!isRetryable || attempt === maxAttempts) {
-        return { success: false, error: error.message, status, response: responseData };
-      }
-
-      const delay = baseDelay * Math.pow(2, attempt - 1);
-      await new Promise(resolve => setTimeout(resolve, delay));
-    }
-  }
-
-  return { success: false, error: 'Unknown error sending InitiateCheckout' };
-}
-
-async function sendLeadEvent(eventPayload = {}) {
-  if (!FB_PIXEL_ID || !FB_PIXEL_TOKEN) {
-    logWithContext('error', '[Meta CAPI] Pixel ID/Token não configurados. Lead não enviado.', {});
-    return { success: false, error: 'pixel_not_configured', hasMinUserData: false };
-  }
-
-  const {
-    telegramId = null,
-    eventTime = Math.floor(Date.now() / 1000),
-    eventSourceUrl = null,
-    eventId: incomingEventId = null,
-    // Advanced Matching - hashes SHA-256
-    externalIdHash = null,
-    emailHash = null,
-    phoneHash = null,
-    firstNameHash = null,
-    lastNameHash = null,
-    // Facebook cookies
-    fbp = null,
-    fbc = null,
-    zipHash = null,
-    // IP e UA (não hashear)
-    clientIpAddress = null,
-    clientUserAgent = null,
-    geoCity = null,
-    geoRegion = null,
-    geoRegionName = null,
-    geoCountry = null,
-    geoCountryCode = null,
-    geoPostalCode = null,
-    actionSource = null,
-    utmData = {},
-    requestId = null,
-    test_event_code: incomingTestEventCode = null
-  } = eventPayload;
-
-  const geoUserData = mapGeoToUserData({
-    geo_city: geoCity,
-    geo_region: geoRegion,
-    geo_region_name: geoRegionName,
-    geo_country: geoCountry,
-    geo_country_code: geoCountryCode,
-    geo_postal_code: geoPostalCode
-  });
-
-  const providedFields = [];
-  if (emailHash) {
-    providedFields.push('em');
-  }
-  if (phoneHash) {
-    providedFields.push('ph');
-  }
-  if (firstNameHash) {
-    providedFields.push('fn');
-  }
-  if (lastNameHash) {
-    providedFields.push('ln');
-  }
-  if (externalIdHash) {
-    providedFields.push('external_id');
-  }
-  if (fbp) {
-    providedFields.push('fbp');
-  }
-  if (fbc) {
-    providedFields.push('fbc');
-  }
-  if (clientIpAddress) {
-    providedFields.push('client_ip_address');
-  }
-  if (clientUserAgent) {
-    providedFields.push('client_user_agent');
-  }
-  if (geoUserData.ct) {
-    providedFields.push('ct');
-  }
-  if (geoUserData.st) {
-    providedFields.push('st');
-  }
-  if (geoUserData.zp) {
-    providedFields.push('zp');
-  }
-  if (geoUserData.country) {
-    providedFields.push('country');
-  }
-
-  const { resolved: resolvedTestEventCode, source: testEventSource } = resolveTestEventCode(incomingTestEventCode);
   const hasMinUserData = providedFields.length >= 2;
 
   if (!hasMinUserData) {
@@ -453,30 +269,85 @@ async function sendLeadEvent(eventPayload = {}) {
     });
   }
 
-  const userData = buildUserData({
-    externalIdHash,
-    emailHash,
-    phoneHash,
-    firstNameHash,
-    lastNameHash,
-    fbp,
-    fbc,
-    zipHash,
-    clientIpAddress,
-    clientUserAgent
+  console.log('[CAPI-DEDUPE] user_data_fields:', providedFields);
+
+  const userData = {};
+  const appendHashedArray = (field, value) => {
+    if (!value) {
+      return;
+    }
+
+    const values = Array.isArray(value) ? value : [value];
+    const sanitizedValues = values
+      .map(item => (typeof item === 'string' ? item.trim() : item))
+      .filter(item => Boolean(item));
+
+    if (sanitizedValues.length) {
+      userData[field] = sanitizedValues;
+    }
+  };
+
+  appendHashedArray('em', emailHash);
+  appendHashedArray('ph', phoneHash);
+  appendHashedArray('fn', firstNameHash);
+  appendHashedArray('ln', lastNameHash);
+  if (!normalizedExternalId) {
+    appendHashedArray('external_id', externalIdHash);
+  }
+  appendHashedArray('zip', zipHash);
+
+  if (normalizedExternalId) {
+    userData.external_id = normalizedExternalId;
+  }
+  if (sanitizedFbp) {
+    userData.fbp = sanitizedFbp;
+  }
+  if (sanitizedFbc) {
+    userData.fbc = sanitizedFbc;
+  }
+  if (sanitizedClientIp) {
+    userData.client_ip_address = sanitizedClientIp;
+  }
+  if (sanitizedClientUserAgent) {
+    userData.client_user_agent = sanitizedClientUserAgent;
+  }
+  if (normalizedCity) {
+    userData.ct = normalizedCity;
+  }
+  if (normalizedState) {
+    userData.st = normalizedState;
+  }
+  if (normalizedPostal) {
+    userData.zp = normalizedPostal;
+  }
+  if (normalizedCountry) {
+    userData.country = normalizedCountry;
+  }
+
+  console.log('[LEAD-CAPI] user_data', {
+    ct: normalizedCity || null,
+    st: normalizedState || null,
+    zp: normalizedPostal || null,
+    country: normalizedCountry || null,
+    fbc_present: Boolean(sanitizedFbc),
+    fbp_present: Boolean(sanitizedFbp),
+    ip_v6: sanitizedClientIp ? sanitizedClientIp.includes(':') : false
   });
-  Object.assign(userData, geoUserData);
+
   const customData = buildCustomData(utmData);
 
   // Log de IP/UA para rastreamento
-  const uaTruncated = clientUserAgent ? 
-    (clientUserAgent.length > 80 ? `${clientUserAgent.substring(0, 80)}... (${clientUserAgent.length} chars)` : clientUserAgent) 
+  const uaTruncated = sanitizedClientUserAgent ?
+    (sanitizedClientUserAgent.length > 80
+      ? `${sanitizedClientUserAgent.substring(0, 80)}... (${sanitizedClientUserAgent.length} chars)`
+      : sanitizedClientUserAgent)
+
     : 'vazio';
-  console.log(`[CAPI-IPUA] origem=chat ip=${clientIpAddress || 'vazio'} ua_present=${!!clientUserAgent}`);
-  console.log(`[CAPI-IPUA] user_data aplicado { client_ip_address: "${clientIpAddress || 'vazio'}", client_user_agent_present: ${!!clientUserAgent} }`);
-  
-  if (clientIpAddress && clientUserAgent) {
-    console.log('[CAPI-IPUA] Fallback aplicado (tracking) ip=' + clientIpAddress + ' ua_present=true');
+  console.log(`[CAPI-IPUA] origem=chat ip=${sanitizedClientIp || 'vazio'} ua_present=${!!sanitizedClientUserAgent}`);
+  console.log(`[CAPI-IPUA] user_data aplicado { client_ip_address: "${sanitizedClientIp || 'vazio'}", client_user_agent_present: ${!!sanitizedClientUserAgent} }`);
+
+  if (sanitizedClientIp && sanitizedClientUserAgent) {
+    console.log('[CAPI-IPUA] Fallback aplicado (tracking) ip=' + sanitizedClientIp + ' ua_present=true');
   }
 
   if (incomingEventId) {
@@ -516,11 +387,11 @@ async function sendLeadEvent(eventPayload = {}) {
   if (eventSourceUrl) {
     baseEventPayloadData.event_source_url = eventSourceUrl;
   }
-  if (clientIpAddress) {
-    baseEventPayloadData.client_ip_address = clientIpAddress;
+  if (sanitizedClientIp) {
+    baseEventPayloadData.client_ip_address = sanitizedClientIp;
   }
-  if (clientUserAgent) {
-    baseEventPayloadData.client_user_agent = clientUserAgent;
+  if (sanitizedClientUserAgent) {
+    baseEventPayloadData.client_user_agent = sanitizedClientUserAgent;
   }
 
   const urlBase = `https://graph.facebook.com/${FACEBOOK_API_VERSION}/${FB_PIXEL_ID}/events`;
@@ -545,12 +416,13 @@ async function sendLeadEvent(eventPayload = {}) {
       event_id: attemptEventId,
       action_source: leadActionSource,
       user_data: {
-        ct: geoUserData.ct || null,
-        st: geoUserData.st || null,
-        zp: geoUserData.zp || null,
-        country: geoUserData.country || null,
-        fbc_present: Boolean(fbc),
-        fbp_present: Boolean(fbp)
+        ct: normalizedCity || null,
+        st: normalizedState || null,
+        zp: normalizedPostal || null,
+        country: normalizedCountry || null,
+        fbc_present: Boolean(sanitizedFbc),
+        fbp_present: Boolean(sanitizedFbp),
+        ip_v6: sanitizedClientIp ? sanitizedClientIp.includes(':') : false
       },
       request_id: requestId
     });
@@ -561,7 +433,7 @@ async function sendLeadEvent(eventPayload = {}) {
     };
 
     // [TELEGRAM-ENTRY] Log obrigatório para Lead CAPI
-    console.log(`[LEAD-CAPI] user_data.fbc=${fbc || 'vazio'} fbp=${fbp || 'vazio'} event_id=${attemptEventId}`);
+    console.log(`[LEAD-CAPI] user_data.fbc=${sanitizedFbc || 'vazio'} fbp=${sanitizedFbp || 'vazio'} event_id=${attemptEventId}`);
 
     logWithContext('log', '[Meta CAPI] Lead preparado para envio', {
       request_id: requestId,
@@ -571,10 +443,10 @@ async function sendLeadEvent(eventPayload = {}) {
       test_event_code: resolvedTestEventCode,
       url,
       attempt,
-      has_fbp: Boolean(fbp),
-      has_fbc: Boolean(fbc),
-      has_client_ip: Boolean(clientIpAddress),
-      has_client_ua: Boolean(clientUserAgent)
+      has_fbp: Boolean(sanitizedFbp),
+      has_fbc: Boolean(sanitizedFbc),
+      has_client_ip: Boolean(sanitizedClientIp),
+      has_client_ua: Boolean(sanitizedClientUserAgent)
     });
 
     try {

--- a/services/payloads.js
+++ b/services/payloads.js
@@ -46,6 +46,182 @@ async function getPayloadById(payloadId) {
   return result.rows[0] || null;
 }
 
+async function getPayloadTrackingById(payloadId) {
+  const sanitized = sanitizePayloadId(payloadId);
+
+  if (!sanitized) {
+    return null;
+  }
+
+  const pool = ensurePool();
+
+  const result = await executeQuery(
+    pool,
+    `SELECT payload_id, telegram_id, fbp, fbc, ip, user_agent,
+            geo_country, geo_country_code, geo_region, geo_region_name,
+            geo_city, geo_postal_code, geo_ip_query, created_at
+       FROM payload_tracking
+      WHERE payload_id = $1
+      LIMIT 1`,
+    [sanitized]
+  );
+
+  return result.rows[0] || null;
+}
+
+function sanitizeMinutes(value, fallback = 15) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallback;
+  }
+  return Math.min(parsed, 120);
+}
+
+function sanitizeTelegramId(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  const trimmed = String(value).trim();
+  return trimmed || null;
+}
+
+async function findRecentPayloadTrackingByTelegramId(telegramId, { windowMinutes = 15 } = {}) {
+  const sanitizedTelegramId = sanitizeTelegramId(telegramId);
+  if (!sanitizedTelegramId) {
+    return null;
+  }
+
+  const minutes = sanitizeMinutes(windowMinutes);
+  const pool = ensurePool();
+
+  const result = await executeQuery(
+    pool,
+    `SELECT payload_id, telegram_id, fbp, fbc, ip, user_agent,
+            geo_country, geo_country_code, geo_region, geo_region_name,
+            geo_city, geo_postal_code, geo_ip_query, created_at
+       FROM payload_tracking
+      WHERE telegram_id = $1::bigint
+        AND created_at >= NOW() - ($2::int * INTERVAL '1 minute')
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [sanitizedTelegramId, minutes]
+  );
+
+  return result.rows[0] || null;
+}
+
+async function findRecentPayloadTrackingByIp(ip, { windowMinutes = 15 } = {}) {
+  if (!ip || typeof ip !== 'string') {
+    return null;
+  }
+
+  const trimmedIp = ip.trim();
+  if (!trimmedIp) {
+    return null;
+  }
+
+  const minutes = sanitizeMinutes(windowMinutes);
+  const pool = ensurePool();
+
+  const result = await executeQuery(
+    pool,
+    `SELECT payload_id, telegram_id, fbp, fbc, ip, user_agent,
+            geo_country, geo_country_code, geo_region, geo_region_name,
+            geo_city, geo_postal_code, geo_ip_query, created_at
+       FROM payload_tracking
+      WHERE ip = $1
+        AND created_at >= NOW() - ($2::int * INTERVAL '1 minute')
+      ORDER BY created_at DESC
+      LIMIT 1`,
+    [trimmedIp, minutes]
+  );
+
+  return result.rows[0] || null;
+}
+
+async function ensurePayloadTelegramLink(payloadId, telegramId) {
+  const sanitizedPayloadId = sanitizePayloadId(payloadId);
+  const sanitizedTelegramId = sanitizeTelegramId(telegramId);
+
+  if (!sanitizedPayloadId || !sanitizedTelegramId) {
+    return { updated: false };
+  }
+
+  const pool = ensurePool();
+
+  const result = await executeQuery(
+    pool,
+    `UPDATE payload_tracking
+        SET telegram_id = $2::bigint
+      WHERE payload_id = $1
+        AND (telegram_id IS DISTINCT FROM $2::bigint)` ,
+    [sanitizedPayloadId, sanitizedTelegramId]
+  );
+
+  return { updated: (result?.rowCount || 0) > 0 };
+}
+
+async function getHydratedPayloadById(payloadId) {
+  const sanitized = sanitizePayloadId(payloadId);
+
+  if (!sanitized) {
+    return null;
+  }
+
+  const [payloadRow, trackingRow] = await Promise.all([
+    getPayloadById(sanitized),
+    getPayloadTrackingById(sanitized)
+  ]);
+
+  if (!payloadRow && !trackingRow) {
+    return null;
+  }
+
+  const merged = {
+    ...(payloadRow || {}),
+    payload_tracking: trackingRow || null
+  };
+
+  if (!merged.payload_id) {
+    merged.payload_id = sanitized;
+  }
+
+  const fallbackFields = [
+    'fbp',
+    'fbc',
+    'ip',
+    'user_agent',
+    'kwai_click_id',
+    'geo_country',
+    'geo_country_code',
+    'geo_region',
+    'geo_region_name',
+    'geo_city',
+    'geo_postal_code',
+    'geo_ip_query'
+  ];
+
+  if (trackingRow) {
+    for (const field of fallbackFields) {
+      const current = merged[field];
+      if ((current === null || current === undefined || current === '') && trackingRow[field] !== undefined && trackingRow[field] !== null && trackingRow[field] !== '') {
+        merged[field] = trackingRow[field];
+      }
+    }
+
+    if (!merged.created_at && trackingRow.created_at) {
+      merged.created_at = trackingRow.created_at;
+    }
+  }
+
+  return merged;
+}
+
 async function cleanupExpiredPayloads({ olderThanHours = 72 } = {}) {
   const pool = ensurePool();
   const hours = Number.parseInt(olderThanHours, 10);
@@ -74,6 +250,11 @@ async function ensurePayloadIndexes() {
 
 module.exports = {
   getPayloadById,
+  getPayloadTrackingById,
+  findRecentPayloadTrackingByTelegramId,
+  findRecentPayloadTrackingByIp,
+  ensurePayloadTelegramLink,
+  getHydratedPayloadById,
   cleanupExpiredPayloads,
   ensurePayloadIndexes
 };


### PR DESCRIPTION
## Summary
- hidrata o payload do /start com fallback por telegram_id e IP, vinculando o payload_tracking ao telegram_id quando possível
- envia os campos de GEO, cookies e identificadores normalizados em user_data, com logs sanitizados e action_source forçado para website
- endurece o registro de métricas ignorando erros por ausência da coluna token em funnel_events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e8e75f04e8832ab37edd26ec829ad4