### PR TITLE
fix(meta-capi): restore sendLeadEvent and guard startup

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,21 @@ process.on('unhandledRejection', (reason, promise) => {
 
 console.log('Iniciando servidor...');
 
+try {
+  const meta = require('./services/metaCapi');
+  const required = ['sendLeadEvent', 'sendInitiateCheckoutEvent'];
+  for (const fn of required) {
+    if (typeof meta[fn] !== 'function') {
+      console.error('[BOOT][FATAL] MetaCAPI export inválido:', fn, 'não é função');
+      process.exit(1);
+    }
+  }
+  console.log('[BOOT] MetaCAPI OK');
+} catch (e) {
+  console.error('[BOOT][FATAL] Falha ao carregar services/metaCapi:', e?.message);
+  process.exit(1);
+}
+
 const { getWhatsAppTrackingEnv } = require('./config/env');
 const whatsappTrackingEnv = getWhatsAppTrackingEnv();
 const whatsappPixelIdStatus = whatsappTrackingEnv.pixelId ? 'OK' : 'ausente';


### PR DESCRIPTION
## Summary
- restore the Meta CAPI sendLeadEvent implementation and its dependencies
- ensure metaCapi exports stay consistent with defined functions
- add a defensive startup check that validates Meta CAPI exports before booting

## Testing
- node -e "require('./services/metaCapi'); console.log('meta ok')"
- PORT=10000 timeout 5 node server.js > /tmp/server.log 2>&1
- curl -i http://localhost:10000/health-basic

------
https://chatgpt.com/codex/tasks/task_e_68e8f58dc100832aae902ee7f80d05e6