### PR TITLE
Implement facebook capi lead event userdata

### DIFF
--- a/MODELO1/core/TelegramBotService.js
+++ b/MODELO1/core/TelegramBotService.js
@@ -888,6 +888,14 @@ class TelegramBotService {
       }
     });
 
+    // 🔥 NOVO: Extrair dados de geolocalização do tracking
+    const geoCity = tracking.geo_city || null;
+    const geoRegion = tracking.geo_region || null;
+    const geoRegionName = tracking.geo_region_name || null;
+    const geoPostalCode = tracking.geo_postal_code || null;
+    const geoCountry = tracking.geo_country || null;
+    const geoCountryCode = tracking.geo_country_code || null;
+
     const leadOptions = {
       telegramId: cleanTelegramId,
       eventTime,
@@ -897,7 +905,14 @@ class TelegramBotService {
       client_ip_address: clientIp,
       client_user_agent: clientUserAgent,
       eventSourceUrl: eventSourceUrl || this.frontendUrl || null,
-      utms
+      utms,
+      // 🔥 NOVO: Passar dados de geolocalização
+      geo_city: geoCity,
+      geo_region: geoRegion,
+      geo_region_name: geoRegionName,
+      geo_postal_code: geoPostalCode,
+      geo_country: geoCountry,
+      geo_country_code: geoCountryCode
     };
 
     const result = await sendLeadCapi(leadOptions);

--- a/capi/metaCapi.js
+++ b/capi/metaCapi.js
@@ -364,6 +364,50 @@ function buildUserData(raw = {}) {
     }
   }
 
+  // 🔥 NOVO: Adicionar campos de geolocalização (city, state, zip)
+  if (raw.ct || raw.city) {
+    const cityValue = raw.ct || raw.city;
+    const normalizedCity = normalizeString(cityValue);
+    if (normalizedCity) {
+      const hashedCity = looksLikeSha256(cityValue) 
+        ? cityValue.toLowerCase() 
+        : hashSha256(normalizedCity.toLowerCase());
+      if (hashedCity) {
+        userData.ct = [hashedCity];
+      }
+    }
+  }
+
+  if (raw.st || raw.state) {
+    const stateValue = raw.st || raw.state;
+    const normalizedState = normalizeString(stateValue);
+    if (normalizedState) {
+      const hashedState = looksLikeSha256(stateValue)
+        ? stateValue.toLowerCase()
+        : hashSha256(normalizedState.toLowerCase());
+      if (hashedState) {
+        userData.st = [hashedState];
+      }
+    }
+  }
+
+  if (raw.zp || raw.zip_code || raw.postal_code) {
+    const zipValue = raw.zp || raw.zip_code || raw.postal_code;
+    // ZIP code deve ser apenas dígitos antes de hashear
+    const normalizedZip = normalizeString(zipValue);
+    if (normalizedZip) {
+      const digitsOnly = normalizedZip.replace(/\D+/g, '');
+      if (digitsOnly) {
+        const hashedZip = looksLikeSha256(zipValue)
+          ? zipValue.toLowerCase()
+          : hashSha256(digitsOnly);
+        if (hashedZip) {
+          userData.zp = [hashedZip];
+        }
+      }
+    }
+  }
+
   return sanitize(userData) || {};
 }
 

--- a/services/facebook.js
+++ b/services/facebook.js
@@ -1206,7 +1206,14 @@ async function sendLeadCapi(options = {}) {
     client_user_agent = null,
     utms = {},
     eventSourceUrl = null,
-    test_event_code = null
+    test_event_code = null,
+    // 🔥 NOVO: Campos de geolocalização
+    geo_city = null,
+    geo_region = null,
+    geo_region_name = null,
+    geo_postal_code = null,
+    geo_country = null,
+    geo_country_code = null
   } = options;
 
   const leadEventId = uuidv4();
@@ -1260,6 +1267,39 @@ async function sendLeadCapi(options = {}) {
     available.push('client_user_agent');
   }
 
+  // 🔥 NOVO: Adicionar campos de geolocalização ao userData
+  const geoFields = [];
+  if (geo_city) {
+    userData.ct = geo_city;
+    available.push('ct');
+    geoFields.push('city');
+  }
+  if (geo_region_name || geo_region) {
+    userData.st = geo_region_name || geo_region;
+    available.push('st');
+    geoFields.push('state');
+  }
+  if (geo_postal_code) {
+    // Limpar postal code para apenas dígitos
+    const cleanPostalCode = String(geo_postal_code).replace(/\D+/g, '');
+    if (cleanPostalCode) {
+      userData.zp = cleanPostalCode;
+      available.push('zp');
+      geoFields.push('postal_code');
+    }
+  }
+
+  // Log dos dados de geolocalização se disponíveis
+  if (geoFields.length > 0) {
+    logWithContext('log', '🌍 [LeadCAPI] Dados de geolocalização incluídos', {
+      telegram_id: telegramId,
+      geo_fields: geoFields,
+      geo_city: geo_city || null,
+      geo_region: geo_region_name || geo_region || null,
+      geo_postal_code: geo_postal_code || null
+    });
+  }
+
   if (available.length < 2) {
     return { skipped: true, reason: 'missing_user_data', availableFields: available };
   }
@@ -1307,7 +1347,10 @@ async function sendLeadCapi(options = {}) {
     has_fbp: Boolean(fbp),
     has_fbc: Boolean(fbc),
     has_client_ip: Boolean(client_ip_address),
-    has_client_ua: Boolean(client_user_agent)
+    has_client_ua: Boolean(client_user_agent),
+    has_geo_city: Boolean(geo_city),
+    has_geo_region: Boolean(geo_region_name || geo_region),
+    has_geo_postal: Boolean(geo_postal_code)
   });
 
   try {


### PR DESCRIPTION
Implement sending of captured geographical data (postal code, city, state) to Facebook CAPI Lead events.

This data was already being successfully captured and stored, but was not being included in the `user_data` payload sent to Facebook CAPI, limiting the completeness of lead event tracking.

---
<a href="https://cursor.com/background-agent?bcId=bc-49bc0c3c-caf3-4ad1-a29b-52ed0826f876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-49bc0c3c-caf3-4ad1-a29b-52ed0826f876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

