### PR TITLE
Allow CAPI-first purchase flow with delayed pixel dispatch

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -566,6 +566,7 @@
                     }
 
                     console.log(`[PURCHASE-BROWSER] event_id=${eventId}`);
+                    console.log('[CAPI-FIRST][HARD] Preparando Purchase', { eventID: eventId });
 
                     // 🎯 LOG AUDITORIA: Estrutura espelhada ao CAPI (plaintext)
                     const eventTimeUnix = Math.floor(Date.now() / 1000);
@@ -601,48 +602,52 @@
                     console.log(`data[0].custom_data =`, JSON.stringify(customDataForLog, null, 2));
                     console.log(`data[0].event_source_url = "${eventSourceUrl}"`);
 
-                    if (typeof fbq !== 'undefined') {
-                        // 🎯 CORREÇÃO CRÍTICA: usar 'userData' (camelCase) com dados PLAINTEXT
-                        fbq('set', 'userData', userDataPlain);
-                        
-                        // Log confirmando ordem correta (antes do Purchase)
-                        console.log('[ADVANCED-MATCH-FRONT] set userData before Purchase | ok=true');
-                        
-                        // Enviar evento Purchase com eventID para deduplicação
-                        fbq('track', 'Purchase', pixelCustomData, { eventID: eventId });
-                        
-                        console.log('[PURCHASE-BROWSER] ✅ Purchase enviado ao Pixel (plaintext AM):', {
-                            event_id: eventId,
-                            custom_data_fields: Object.keys(pixelCustomData).length,
-                            user_data_fields: Object.keys(userDataPlain).length,
-                            value: pixelCustomData.value,
-                            currency: pixelCustomData.currency
-                        });
-                    } else {
-                        console.warn('[PURCHASE-BROWSER] ⚠️ fbq não disponível');
-                    }
-
-                    const markPixelResponse = await fetch('/api/mark-pixel-sent', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ token })
-                    });
-
-                    const markPixelText = await markPixelResponse.text();
-                    let markPixelBody = markPixelText;
-                    try {
-                        markPixelBody = JSON.parse(markPixelText);
-                    } catch (err) {
-                        // manter texto bruto
-                    }
-
-                    console.log(
-                        `[PURCHASE-BROWSER] mark-pixel-sent -> ${markPixelResponse.ok ? 'OK' : 'ERR'}`,
-                        markPixelBody
-                    );
+                    // [PIXEL-OLD][DESATIVADO EM CAPI-FIRST]
+                    // if (typeof fbq !== 'undefined') {
+                    //     // 🎯 CORREÇÃO CRÍTICA: usar 'userData' (camelCase) com dados PLAINTEXT
+                    //     fbq('set', 'userData', userDataPlain);
+                    //
+                    //     // Log confirmando ordem correta (antes do Purchase)
+                    //     console.log('[ADVANCED-MATCH-FRONT] set userData before Purchase | ok=true');
+                    //
+                    //     // Enviar evento Purchase com eventID para deduplicação
+                    //     fbq('track', 'Purchase', pixelCustomData, { eventID: eventId });
+                    //
+                    //     console.log('[PURCHASE-BROWSER] ✅ Purchase enviado ao Pixel (plaintext AM):', {
+                    //         event_id: eventId,
+                    //         custom_data_fields: Object.keys(pixelCustomData).length,
+                    //         user_data_fields: Object.keys(userDataPlain).length,
+                    //         value: pixelCustomData.value,
+                    //         currency: pixelCustomData.currency
+                    //     });
+                    // } else {
+                    //     console.warn('[PURCHASE-BROWSER] ⚠️ fbq não disponível');
+                    // }
+                    //
+                    // const markPixelResponse = await fetch('/api/mark-pixel-sent', {
+                    //     method: 'POST',
+                    //     headers: { 'Content-Type': 'application/json' },
+                    //     body: JSON.stringify({ token })
+                    // });
+                    //
+                    // const markPixelText = await markPixelResponse.text();
+                    // let markPixelBody = markPixelText;
+                    // try {
+                    //     markPixelBody = JSON.parse(markPixelText);
+                    // } catch (err) {
+                    //     // manter texto bruto
+                    // }
+                    //
+                    // console.log(
+                    //     `[PURCHASE-BROWSER] mark-pixel-sent -> ${markPixelResponse.ok ? 'OK' : 'ERR'}`,
+                    //     markPixelBody
+                    // );
 
                     // 🎯 CORREÇÃO: Enviar dados NORMALIZADOS (plaintext) ao CAPI
                     // O backend fará o hashing antes de enviar à Meta
+                    const PIXEL_PURCHASE_DELAY_MS = 10000;
+                    console.log('[CAPI-FIRST][HARD] Atraso Pixel (ms)=10000', { eventID: eventId });
+
                     const capiPayload = {
                         token,
                         event_id: eventId,
@@ -661,6 +666,8 @@
                         body: JSON.stringify(capiPayload)
                     });
 
+                    console.log('[CAPI-FIRST][HARD] CAPI enviado', { status: capiResponse.status, eventID: eventId });
+
                     const capiText = await capiResponse.text();
                     let capiData = null;
                     try {
@@ -678,6 +685,52 @@
                     if (!capiResponse.ok || !(capiData && capiData.success)) {
                         console.warn('[PURCHASE-BROWSER] ⚠️ Erro ao enviar Purchase CAPI', capiRawOutput);
                     }
+
+                    setTimeout(async () => {
+                        try {
+                            if (typeof fbq !== 'undefined') {
+                                fbq('set', 'userData', userDataPlain);
+                                console.log('[ADVANCED-MATCH-FRONT] set userData before Purchase | ok=true');
+                                fbq('track', 'Purchase', pixelCustomData, { eventID: eventId });
+                                console.log('[PURCHASE-BROWSER] ✅ Purchase enviado ao Pixel (plaintext AM):', {
+                                    event_id: eventId,
+                                    custom_data_fields: Object.keys(pixelCustomData).length,
+                                    user_data_fields: Object.keys(userDataPlain).length,
+                                    value: pixelCustomData.value,
+                                    currency: pixelCustomData.currency
+                                });
+                            } else {
+                                console.warn('[PURCHASE-BROWSER] ⚠️ fbq não disponível');
+                            }
+
+                            try {
+                                const markPixelResponse = await fetch('/api/mark-pixel-sent', {
+                                    method: 'POST',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({ token })
+                                });
+
+                                const markPixelText = await markPixelResponse.text();
+                                let markPixelBody = markPixelText;
+                                try {
+                                    markPixelBody = JSON.parse(markPixelText);
+                                } catch (err) {
+                                    // manter texto bruto
+                                }
+
+                                console.log(
+                                    `[PURCHASE-BROWSER] mark-pixel-sent -> ${markPixelResponse.ok ? 'OK' : 'ERR'}`,
+                                    markPixelBody
+                                );
+                            } catch (markPixelError) {
+                                console.error('[PURCHASE-BROWSER] ❌ Erro mark-pixel-sent após Pixel', markPixelError);
+                            }
+
+                            console.log('[CAPI-FIRST][HARD] Pixel disparado após 10s', { eventID: eventId });
+                        } catch (err) {
+                            console.error('[CAPI-FIRST][HARD][ERROR] Falha ao disparar Pixel após 10s', err);
+                        }
+                    }, PIXEL_PURCHASE_DELAY_MS);
 
                     loadingEl.style.display = 'none';
                     successMessage.style.display = 'block';

--- a/server.js
+++ b/server.js
@@ -2133,8 +2133,27 @@ app.post('/api/capi/purchase', async (req, res) => {
       )} email=${readinessValue(tokenData.email)} phone=${readinessValue(tokenData.phone)}`
     );
 
-    if (!tokenData.pixel_sent || !tokenData.capi_ready) {
-      console.warn('[PURCHASE-CAPI] ⚠️ Token ainda não está pronto para envio', {
+    // [CAPI-FIRST][HARD][DESATIVADO] Bloqueio que exigia pixel_sent=true antes do CAPI
+    // if (!tokenData.pixel_sent || !tokenData.capi_ready) {
+    //   console.warn('[PURCHASE-CAPI] ⚠️ Token ainda não está pronto para envio', {
+    //     request_id: requestId,
+    //     token,
+    //     pixel_sent: tokenData.pixel_sent,
+    //     capi_ready: tokenData.capi_ready
+    //   });
+
+    //   return res.status(400).json({
+    //     success: false,
+    //     reason: 'not_ready',
+    //     details: {
+    //       pixel_sent: !!tokenData.pixel_sent,
+    //       capi_ready: !!tokenData.capi_ready
+    //     }
+    //   });
+    // }
+
+    if (!tokenData.capi_ready) {
+      console.warn('[PURCHASE-CAPI] ⚠️ Token ainda não está pronto para envio (capi_ready=false)', {
         request_id: requestId,
         token,
         pixel_sent: tokenData.pixel_sent,
@@ -2148,6 +2167,15 @@ app.post('/api/capi/purchase', async (req, res) => {
           pixel_sent: !!tokenData.pixel_sent,
           capi_ready: !!tokenData.capi_ready
         }
+      });
+    }
+
+    if (!tokenData.pixel_sent) {
+      console.log('[CAPI-FIRST][HARD] Aceitando CAPI antes do Pixel', {
+        request_id: requestId,
+        token,
+        event_id: eventIdFromBody || tokenData.event_id_purchase || null,
+        pixel_sent: tokenData.pixel_sent
       });
     }
 

--- a/services/purchaseCapi.js
+++ b/services/purchaseCapi.js
@@ -603,9 +603,15 @@ function validatePurchaseReadiness(tokenData) {
     return { valid: false, reason: 'token_not_found', already_sent: false };
   }
 
-  // Verificar se pixel já foi enviado
+  // [CAPI-FIRST][HARD][DESATIVADO] Bloqueio que exigia pixel_sent=true antes do CAPI
+  // if (!tokenData.pixel_sent) {
+  //   return { valid: false, reason: 'pixel_not_sent', already_sent: false };
+  // }
+
   if (!tokenData.pixel_sent) {
-    return { valid: false, reason: 'pixel_not_sent', already_sent: false };
+    console.log('[CAPI-FIRST][HARD] Aceitando CAPI antes do Pixel', {
+      token: tokenData.token || null
+    });
   }
 
   // Verificar se webhook já marcou como pronto


### PR DESCRIPTION
## Summary
- remove the hard requirement for pixel_sent before processing purchase CAPI calls and log when the backend accepts CAPI-first requests
- dispatch the browser pixel purchase event exactly 10 seconds after the CAPI call while keeping existing payloads intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9431bf84c832ab4ada18e03cdf8ef