### PR TITLE
Fix missing closing braces in obrigado purchase flow

### DIFF
--- a/MODELO1/WEB/obrigado_purchase_flow.html
+++ b/MODELO1/WEB/obrigado_purchase_flow.html
@@ -1043,6 +1043,11 @@
                                 errorMessage.textContent = `❌ ${pixelError.message}`;
                             }
                         }, 10000);
+
+                        // FECHA o if (window.__fbqReady && window.__fbqReady())
+                    }
+
+                    // FECHA o try iniciado no início do handler
                 } catch (error) {
                     console.error('[PURCHASE-BROWSER] ❌ Erro no fluxo', error);
                     loadingEl.style.display = 'none';


### PR DESCRIPTION
## Summary
- close the server-first pixel flow's `if` block after the delayed handler
- restore the surrounding try/catch structure to prevent syntax errors on the thank-you page

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e95e804688832abc59d111ef8d8bc1