### PR TITLE
Allow CAPI purchase without pixel flag

### DIFF
--- a/server.js
+++ b/server.js
@@ -2672,12 +2672,6 @@ app.post('/api/capi/purchase', async (req, res) => {
       });
     }
 
-    console.log('[SERVER-FIRST][CAPI] prosseguindo sem pixel_sent (capi_ready=true)', {
-      request_id: requestId,
-      token,
-      event_id: eventIdFromBody || tokenData.event_id_purchase
-    });
-
     // 🎯 VALIDAÇÃO CRÍTICA: Bloquear se price_cents ausente ou 0
     const priceCents = toIntOrNull(tokenData.price_cents);
     if (!priceCents || priceCents === 0) {
@@ -2715,6 +2709,14 @@ app.post('/api/capi/purchase', async (req, res) => {
     }
 
     const validation = validatePurchaseReadiness(tokenData);
+
+    if (!tokenData.pixel_sent && validation.valid) {
+      console.log('[SERVER-FIRST][CAPI] prosseguindo sem pixel_sent (capi_ready=true)', {
+        request_id: requestId,
+        token,
+        event_id: eventIdFromBody || tokenData.event_id_purchase
+      });
+    }
 
     // 🎯 LOG DE DEDUPLICAÇÃO: Mostrar política de envio cross-channel
     console.log('[CAPI-DEDUPE] policy=cross-channel-allowed', {

--- a/services/purchaseCapi.js
+++ b/services/purchaseCapi.js
@@ -669,11 +669,6 @@ function validatePurchaseReadiness(tokenData) {
     return { valid: false, reason: 'token_not_found', already_sent: false };
   }
 
-  // Verificar se pixel já foi enviado
-  if (!tokenData.pixel_sent) {
-    return { valid: false, reason: 'pixel_not_sent', already_sent: false };
-  }
-
   // Verificar se webhook já marcou como pronto
   if (!tokenData.capi_ready) {
     return { valid: false, reason: 'capi_not_ready', already_sent: false };


### PR DESCRIPTION
## Summary
- allow the CAPI purchase endpoint to proceed when capi_ready is true even if pixel_sent is false
- emit a dedicated log entry only when the request continues without the pixel flag

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e96188eff8832a834f5d8bec5b9a18