### PR TITLE
Remove pixel_sent requirement from purchase CAPI readiness

### DIFF
--- a/services/purchaseCapi.js
+++ b/services/purchaseCapi.js
@@ -669,11 +669,6 @@ function validatePurchaseReadiness(tokenData) {
     return { valid: false, reason: 'token_not_found', already_sent: false };
   }
 
-  // Verificar se pixel já foi enviado
-  if (!tokenData.pixel_sent) {
-    return { valid: false, reason: 'pixel_not_sent', already_sent: false };
-  }
-
   // Verificar se webhook já marcou como pronto
   if (!tokenData.capi_ready) {
     return { valid: false, reason: 'capi_not_ready', already_sent: false };


### PR DESCRIPTION
## Summary
- remove the pixel_sent validation gate in `validatePurchaseReadiness` to match the server-first behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e98b6513a4832aac8072d4705de00e